### PR TITLE
fix: add pull-requests write permission to CI workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,7 +5,10 @@ on:
   push:
     branches: [ "feat/react-migration" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
+
+permissions:
+  pull-requests: write
 
 jobs:
   # Frontend tests - React with vitest


### PR DESCRIPTION
## Summary
- Adds `permissions: pull-requests: write` so `dotnet-test-reporter` can post coverage comments on PRs
- Also adds `dev` to the `pull_request` trigger (was only running on PRs to `main`)

## Test plan
- CI backend job should pass without "Resource not accessible by integration" error