### PR TITLE
fix: use secondary color for loading spinner in dark mode

### DIFF
--- a/Client.React/src/app/theme.ts
+++ b/Client.React/src/app/theme.ts
@@ -190,6 +190,11 @@ export function createAppTheme(mode: 'light' | 'dark') {
         },
       },
     },
+    MuiCircularProgress: {
+      defaultProps: {
+        color: isDark ? 'secondary' : 'primary',
+      },
+    },
     MuiTableCell: {
       styleOverrides: {
         head: {


### PR DESCRIPTION
## Summary
- `CircularProgress` defaulted to `color="primary"` (#1a2847 dark navy) which was invisible against the dark mode background (#0f1729)
- Added `MuiCircularProgress` theme override to use `secondary` (orange #ff6b35) in dark mode, `primary` in light mode

## Test plan
- [ ] Toggle to dark mode — loading spinners should be visible (orange)
- [ ] Toggle to light mode — loading spinners should remain navy (unchanged)