### PR TITLE
fix: dark mode spinner visibility

### DIFF
--- a/Client.React/src/app/theme.ts
+++ b/Client.React/src/app/theme.ts
@@ -190,6 +190,11 @@ export function createAppTheme(mode: 'light' | 'dark') {
         },
       },
     },
+    MuiCircularProgress: {
+      defaultProps: {
+        color: isDark ? 'secondary' : 'primary',
+      },
+    },
     MuiTableCell: {
       styleOverrides: {
         head: {


### PR DESCRIPTION
## Summary
- Loading spinner was invisible in dark mode (navy on navy)
- Spinner now uses orange (secondary) in dark mode via theme override

## Test plan
- No structural changes — visual fix only