### PR TITLE
feat(257): add public Rules page

### DIFF
--- a/Client.React/src/App.tsx
+++ b/Client.React/src/App.tsx
@@ -34,6 +34,7 @@ import AdminUserManagementPage from './pages/admin/UserManagementPage';
 import AdminInvitationsPage from './pages/admin/InvitationsPage';
 import LogoutPage from './pages/LogoutPage';
 import AuthPage from './pages/AuthPage';
+import RulesPage from './pages/RulesPage';
 
 export default function App() {
   return (
@@ -114,6 +115,7 @@ export default function App() {
         <Route path="/account/manage/changepassword" caseSensitive={false} element={<ChangePasswordPage />} />
       </Route>
 
+      <Route path="/rules" caseSensitive={false} element={<RulesPage />} />
       <Route path="/account" element={<Navigate to="/account/login" replace />} />
       <Route path="*" element={<NotFoundPage />} />
     </Routes>

--- a/Client.React/src/__tests__/RulesPage.test.tsx
+++ b/Client.React/src/__tests__/RulesPage.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import RulesPage from '../pages/RulesPage';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <RulesPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('RulesPage', () => {
+  it('renders all major section headings', () => {
+    renderPage();
+    expect(screen.getByText(/how picks work/i)).toBeInTheDocument();
+    expect(screen.getByText(/when games lock/i)).toBeInTheDocument();
+    expect(screen.getByText(/playoff rounds/i)).toBeInTheDocument();
+    expect(screen.getByText(/scoring/i)).toBeInTheDocument();
+  });
+
+  it('shows correct regular-season required pick count (4)', () => {
+    renderPage();
+    expect(screen.getByText(/4 picks/i)).toBeInTheDocument();
+  });
+
+  it('shows correct Wild Card required picks (3)', () => {
+    renderPage();
+    expect(screen.getByText(/wild card/i)).toBeInTheDocument();
+    expect(screen.getByText(/3 picks/i)).toBeInTheDocument();
+  });
+
+  it('shows correct Divisional required picks (2)', () => {
+    renderPage();
+    expect(screen.getByText(/divisional/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 picks/i)).toBeInTheDocument();
+  });
+
+  it('references individual kickoff time, not noon CST', () => {
+    renderPage();
+    expect(screen.getByText(/kickoff/i)).toBeInTheDocument();
+    expect(screen.queryByText(/noon cst/i)).not.toBeInTheDocument();
+  });
+});

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -26,6 +26,7 @@ import HomeIcon from '@mui/icons-material/Home';
 import AddToPhotosIcon from '@mui/icons-material/AddToPhotos';
 import ScoreboardIcon from '@mui/icons-material/Scoreboard';
 import LeaderboardIcon from '@mui/icons-material/Leaderboard';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
 import SettingsIcon from '@mui/icons-material/Settings';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
@@ -206,6 +207,17 @@ export default function AppLayout() {
                 <LeaderboardIcon />
               </ListItemIcon>
               <ListItemText primary="Leaderboard" />
+            </ListItemButton>
+            <ListItemButton
+              component={NavLink}
+              to="/rules"
+              sx={navItemSx}
+              onClick={() => handleNavClick('/rules')}
+            >
+              <ListItemIcon>
+                <MenuBookIcon />
+              </ListItemIcon>
+              <ListItemText primary="Rules" />
             </ListItemButton>
           </List>
           {showAdmin && (

--- a/Client.React/src/pages/RulesPage.tsx
+++ b/Client.React/src/pages/RulesPage.tsx
@@ -1,0 +1,115 @@
+import { Box, Container, Divider, Paper, Stack, Typography } from '@mui/material';
+import { getEspnRequiredPicks } from '../utils/gameHelpers';
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
+      <Typography variant="h6" fontWeight={700} gutterBottom>
+        {title}
+      </Typography>
+      <Divider sx={{ mb: 2 }} />
+      {children}
+    </Paper>
+  );
+}
+
+function Rule({ children }: { children: React.ReactNode }) {
+  return (
+    <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+      {children}
+    </Typography>
+  );
+}
+
+export default function RulesPage() {
+  const regularPicks = getEspnRequiredPicks(1, false);
+  const wildCardPicks = getEspnRequiredPicks(1, true);
+  const divisionalPicks = getEspnRequiredPicks(3, true);
+  const championshipPicks = getEspnRequiredPicks(4, true);
+  const superBowlPicks = getEspnRequiredPicks(5, true);
+
+  return (
+    <Container maxWidth="sm" sx={{ py: 4 }}>
+      <Stack spacing={3}>
+        <Box>
+          <Typography variant="h4" fontWeight={700}>
+            How FourPlay Works
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+            Everything you need to know before making your picks.
+          </Typography>
+        </Box>
+
+        <Section title="How Picks Work">
+          <Rule>
+            Each week you pick teams against the spread. You must submit{' '}
+            <strong>{regularPicks} picks</strong> per week during the regular season.
+          </Rule>
+          <Rule>
+            Pick the team you think will cover the spread — not just win the game. If the spread is
+            Chiefs -6.5 and they win by 10, the Chiefs cover.
+          </Rule>
+          <Rule>A push (exactly on the spread) counts as a loss for your pick.</Rule>
+        </Section>
+
+        <Section title="When Games Lock">
+          <Rule>
+            Each game locks at its individual <strong>kickoff time</strong>. You can still make or
+            change picks for later games after early games have started.
+          </Rule>
+          <Rule>
+            For example, if the 1pm ET games have kicked off, you can still pick the 4pm ET or
+            Sunday Night Football games.
+          </Rule>
+          <Rule>No picks are accepted after a game has started. This is enforced server-side.</Rule>
+        </Section>
+
+        <Section title="Playoff Rounds">
+          <Rule>
+            Playoff weeks have different required pick counts and may include Saturday games.
+          </Rule>
+          <Stack spacing={1} sx={{ mt: 1 }}>
+            {[
+              { round: 'Wild Card', picks: wildCardPicks },
+              { round: 'Divisional', picks: divisionalPicks },
+              { round: 'Championship', picks: championshipPicks },
+              { round: 'Super Bowl', picks: superBowlPicks },
+            ].map(({ round, picks }) => (
+              <Box
+                key={round}
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  px: 2,
+                  py: 1,
+                  borderRadius: 1,
+                  bgcolor: 'action.hover',
+                }}
+              >
+                <Typography variant="body2" fontWeight={500}>
+                  {round}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {picks} {picks === 1 ? 'pick' : 'picks'}
+                </Typography>
+              </Box>
+            ))}
+          </Stack>
+        </Section>
+
+        <Section title="Scoring">
+          <Rule>
+            Each correct pick earns points. The juice (vig) set per league may adjust payout — check
+            your league settings for the exact rate.
+          </Rule>
+          <Rule>
+            If you miss the deadline for a game, that pick is forfeited. Submitting fewer than the
+            required picks means you lose those slots.
+          </Rule>
+          <Rule>The leaderboard updates as game results are confirmed.</Rule>
+        </Section>
+      </Stack>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/rules` route — public, no auth required, shareable with new users
- 4 sections: How Picks Work, When Games Lock, Playoff Rounds, Scoring
- Pick counts driven by `getEspnRequiredPicks` — stays in sync with game logic automatically
- "When Games Lock" references individual kickoff time, no "noon CST" copy
- Nav link added to AppLayout drawer (MenuBook icon, between Leaderboard and admin)

## Test plan
- [x] 5 new unit tests, all green
- [x] Full frontend suite: 156/156 passed
- [x] Pre-commit hooks passed

Closes frizat-257

🤖 Generated with [Claude Code](https://claude.com/claude-code)