### PR TITLE
fix(8n3): security fixes — pick user spoofing, missing admin guards, ForgotPassword enumeration

### DIFF
--- a/Server.UnitTests/AuthControllerTests.cs
+++ b/Server.UnitTests/AuthControllerTests.cs
@@ -394,4 +394,26 @@ public class AuthControllerTests
             .FirstOrDefault(h => h is not null && h.StartsWith("RefreshToken="));
         Assert.NotNull(refreshCookie);
     }
+
+    /// <summary>
+    /// frizat-8n3: ForgotPassword must return 200 OK even when the email is not found.
+    /// Returning 400 leaks whether an account exists for that email (user enumeration).
+    /// </summary>
+    [Fact]
+    public async Task ForgotPassword_UnknownEmail_ReturnsOk()
+    {
+        var userManager = BuildUserManager();
+        userManager.FindByEmailAsync(Arg.Any<string>()).Returns((ApplicationUser?)null);
+
+        var controller = BuildController(userManager: userManager);
+
+        var result = await controller.ForgotPassword(new ForgotPasswordRequest
+        {
+            Email    = "nobody@example.com",
+            ResetUrl = "https://example.com/reset",
+        });
+
+        // Must return 200, not 400 — leaking user existence is a security issue
+        Assert.IsType<OkResult>(result.Result);
+    }
 }

--- a/Server.UnitTests/AuthControllerTests.cs
+++ b/Server.UnitTests/AuthControllerTests.cs
@@ -99,10 +99,7 @@ public class AuthControllerTests
         new() { Id = id, UserName = userName, Email = $"{userName}@example.com" };
 
     private static ClaimsPrincipal BuildPrincipal(string userId) =>
-        new(new ClaimsIdentity(
-        [
-            new Claim(ClaimTypes.NameIdentifier, userId),
-        ], "Test"));
+        TestPrincipalFactory.Build(userId);
 
     // ── Test 1: User not found → Unauthorized ────────────────────────────────
 

--- a/Server.UnitTests/AuthorizationTests.cs
+++ b/Server.UnitTests/AuthorizationTests.cs
@@ -22,6 +22,11 @@ public class AuthorizationTests
         nameof(LeagueController.AddNewSpreads),
         nameof(LeagueController.RemoveSpreads),
         nameof(LeagueController.RemovePicks),
+        // frizat-8n3: these were missing [Authorize(Roles = "Administrator")]
+        nameof(LeagueController.AddLeagueUser),
+        nameof(LeagueController.AddLeagueUserMapping),
+        nameof(LeagueController.AddLeagueInfo),
+        nameof(LeagueController.AddLeagueJuiceMapping),
     ];
 
     [Theory]

--- a/Server.UnitTests/ChangePasswordTests.cs
+++ b/Server.UnitTests/ChangePasswordTests.cs
@@ -57,12 +57,7 @@ public class ChangePasswordTests
     }
 
     private static ClaimsPrincipal BuildPrincipal(string userId, string email) =>
-        new(new ClaimsIdentity(
-        [
-            new Claim(ClaimTypes.NameIdentifier, userId),
-            new Claim(ClaimTypes.Email, email),
-            new Claim(ClaimTypes.Name, email),
-        ], "Test"));
+        TestPrincipalFactory.Build(userId, email);
 
     [Fact]
     public async Task ChangePassword_UsesJwtClaim_NotBodyEmail()

--- a/Server.UnitTests/PicksTests.cs
+++ b/Server.UnitTests/PicksTests.cs
@@ -65,10 +65,7 @@ public class PicksTests
     }
 
     private static ClaimsPrincipal BuildPrincipal(string userId) =>
-        new(new ClaimsIdentity(
-        [
-            new Claim(ClaimTypes.NameIdentifier, userId),
-        ], "Test"));
+        TestPrincipalFactory.Build(userId);
 
     /// <summary>
     /// Builds a minimal ESPN scores payload with two games:

--- a/Server.UnitTests/PicksTests.cs
+++ b/Server.UnitTests/PicksTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using System.Security.Claims;
 
 namespace FourPlayWebApp.Server.UnitTests;
 
@@ -41,7 +42,8 @@ public class PicksTests
     /// </summary>
     private static LeagueController BuildController(
         ILeagueRepository repo,
-        IEspnCacheService espnCacheService)
+        IEspnCacheService espnCacheService,
+        ClaimsPrincipal? principal = null)
     {
         var controller = new LeagueController(
             new MemoryCache(new MemoryCacheOptions()),
@@ -51,12 +53,22 @@ public class PicksTests
             Substitute.For<ISpreadCalculatorBuilder>(),
             espnCacheService);
 
+        var httpContext = new DefaultHttpContext();
+        if (principal is not null)
+            httpContext.User = principal;
+
         controller.ControllerContext = new ControllerContext
         {
-            HttpContext = new DefaultHttpContext()
+            HttpContext = httpContext
         };
         return controller;
     }
+
+    private static ClaimsPrincipal BuildPrincipal(string userId) =>
+        new(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.NameIdentifier, userId),
+        ], "Test"));
 
     /// <summary>
     /// Builds a minimal ESPN scores payload with two games:
@@ -126,7 +138,7 @@ public class PicksTests
         var espn = Substitute.For<IEspnCacheService>();
         espn.GetScoresAsync().Returns(BuildScores(pastKickoff));
 
-        var controller = BuildController(repo, espn);
+        var controller = BuildController(repo, espn, BuildPrincipal(UserId));
         var picks = new[] { MakePick("BUF") };
 
         // Act
@@ -151,7 +163,7 @@ public class PicksTests
         var espn = Substitute.For<IEspnCacheService>();
         espn.GetScoresAsync().Returns(BuildScores(futureKickoff));
 
-        var controller = BuildController(repo, espn);
+        var controller = BuildController(repo, espn, BuildPrincipal(UserId));
         var picks = new[] { MakePick("BUF") };
 
         // Act
@@ -174,7 +186,7 @@ public class PicksTests
         var espn = Substitute.For<IEspnCacheService>();
         espn.GetScoresAsync().Returns((EspnScores?)null);
 
-        var controller = BuildController(repo, espn);
+        var controller = BuildController(repo, espn, BuildPrincipal(UserId));
         var picks = new[] { MakePick("BUF") };
 
         // Act
@@ -182,5 +194,49 @@ public class PicksTests
 
         // Assert — no ESPN data → fail open, let picks through
         Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    /// <summary>
+    /// frizat-8n3: AddPicks must use the authenticated user's ID from the JWT claim,
+    /// not the UserId in the request DTO. Without the fix, a user can submit picks on
+    /// behalf of another user by setting UserId in the JSON body.
+    /// </summary>
+    [Fact]
+    public async Task AddPicks_UsesJwtClaimUserId_NotDtoUserId()
+    {
+        // Arrange — JWT says "jwt-user-id", but DTO has "attacker-user-id"
+        const string jwtUserId = "jwt-user-id";
+        const string attackerUserId = "attacker-user-id";
+
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetNflWeeksAsync(Season).Returns([MakeNflWeek()]);
+        // After the fix the controller will use jwtUserId; set up mock for that userId
+        repo.GetUserNflPicksAsync(jwtUserId, LeagueId, Season, Week).Returns([]);
+        repo.AddNflPicksAsync(Arg.Any<IEnumerable<NflPicks>>()).Returns(Task.CompletedTask);
+
+        var espn = Substitute.For<IEspnCacheService>();
+        espn.GetScoresAsync().Returns((EspnScores?)null);
+
+        var principal = BuildPrincipal(jwtUserId);
+        var controller = BuildController(repo, espn, principal);
+
+        // Pick DTO has attacker's userId
+        var pick = new NflPickDto
+        {
+            LeagueId = LeagueId,
+            UserId   = attackerUserId,
+            Team     = "BUF",
+            Pick     = PickType.Spread,
+            NflWeek  = Week,
+            Season   = Season,
+        };
+
+        // Act
+        var result = await controller.AddPicks([pick]);
+
+        // Assert — picks saved must use the JWT claim userId, not the DTO value
+        await repo.Received(1).AddNflPicksAsync(
+            Arg.Is<IEnumerable<NflPicks>>(picks =>
+                picks.All(p => p.UserId == jwtUserId)));
     }
 }

--- a/Server.UnitTests/TestPrincipalFactory.cs
+++ b/Server.UnitTests/TestPrincipalFactory.cs
@@ -1,0 +1,15 @@
+using System.Security.Claims;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+internal static class TestPrincipalFactory
+{
+    public static ClaimsPrincipal Build(string userId, string? email = null) =>
+        new(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.NameIdentifier, userId),
+            .. (email is not null
+                ? (Claim[])[new Claim(ClaimTypes.Email, email), new Claim(ClaimTypes.Name, email)]
+                : []),
+        ], "Test"));
+}

--- a/Server/Auth/AppRoles.cs
+++ b/Server/Auth/AppRoles.cs
@@ -1,0 +1,6 @@
+namespace FourPlayWebApp.Server.Auth;
+
+public static class AppRoles
+{
+    public const string Administrator = "Administrator";
+}

--- a/Server/Controllers/AuthController.cs
+++ b/Server/Controllers/AuthController.cs
@@ -306,8 +306,8 @@ public class AuthController(
 
         var user = await userManager.FindByEmailAsync(model.Email);
         if (user == null)
-            return BadRequest("Invalid request.");
-        
+            return Ok(); // Don't reveal whether the email exists
+
         var token = await userManager.GeneratePasswordResetTokenAsync(user);
         var code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(token));
         var callbackUrl = $"{model.ResetUrl}?code={code}";

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using System.Net.Mime;
+using System.Security.Claims;
 
 namespace FourPlayWebApp.Server.Controllers;
 
@@ -300,6 +301,9 @@ public class LeagueController(
     public async Task<ActionResult<int>> AddPicks([FromBody] IEnumerable<NflPickDto> picksDto) {
         if (!picksDto.Any())
             return BadRequest("No picks provided");
+        var authenticatedUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrEmpty(authenticatedUserId))
+            return Unauthorized();
         var weekId = await repo.GetNflWeeksAsync(picksDto.First().Season);
         var picksList = new List<NflPicks>();
         foreach (var pick in picksDto) {
@@ -308,7 +312,7 @@ public class LeagueController(
                 return BadRequest("Nfl Week Does Not Exist for the given season");
             picksList.Add((NflPicks)(new NflPicks {
                 LeagueId = pick.LeagueId,
-                UserId = pick.UserId,
+                UserId = authenticatedUserId,
                 Team = pick.Team,
                 Pick = pick.Pick,
                 NflWeek = pick.NflWeek,
@@ -540,6 +544,7 @@ public class LeagueController(
 
     // ---------- Adds for core entities ----------
     [HttpPost("league-user")]
+    [Authorize(Roles = "Administrator")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> AddLeagueUser([FromBody] LeagueUsersDto leagueUserDto) {
         var leagueUser = new LeagueUsers {
@@ -550,6 +555,7 @@ public class LeagueController(
     }
 
     [HttpPost("league-user-mapping")]
+    [Authorize(Roles = "Administrator")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> AddLeagueUserMapping([FromBody] LeagueUserMappingDto mappingDto) {
         var mapping = new LeagueUserMapping {
@@ -562,6 +568,7 @@ public class LeagueController(
     }
 
     [HttpPost("league-info")]
+    [Authorize(Roles = "Administrator")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> AddLeagueInfo([FromBody] LeagueInfoDto leagueInfoDto) {
         var leagueInfo = new LeagueInfo {
@@ -574,6 +581,7 @@ public class LeagueController(
     }
 
     [HttpPost("league-juice-mapping")]
+    [Authorize(Roles = "Administrator")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> AddLeagueJuiceMapping([FromBody] LeagueJuiceMappingDto mappingDto) {
         var mapping = new LeagueJuiceMapping {

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -1,4 +1,5 @@
-﻿using FourPlayWebApp.Server.Models.Data;
+﻿using FourPlayWebApp.Server.Auth;
+using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
@@ -299,43 +300,54 @@ public class LeagueController(
     [HttpPost("picks")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<ActionResult<int>> AddPicks([FromBody] IEnumerable<NflPickDto> picksDto) {
-        if (!picksDto.Any())
+        var picksDtoList = picksDto.ToList();
+        if (picksDtoList.Count == 0)
             return BadRequest("No picks provided");
         var authenticatedUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (string.IsNullOrEmpty(authenticatedUserId))
             return Unauthorized();
-        var weekId = await repo.GetNflWeeksAsync(picksDto.First().Season);
+
+        // Validate request shape before any I/O
+        if (picksDtoList.Select(x => x.NflWeek).Distinct().Count() > 1)
+            return BadRequest("All picks must be for the same NFL week");
+        if (picksDtoList.Select(x => x.Season).Distinct().Count() > 1)
+            return BadRequest("All picks must be for the same NFL Season");
+        if (picksDtoList.Select(x => x.LeagueId).Distinct().Count() > 1)
+            return BadRequest("All picks must be for the same League");
+
+        var first = picksDtoList[0];
+
+        // Fetch weeks, ESPN scores, and existing picks concurrently
+        var weekTask          = repo.GetNflWeeksAsync(first.Season);
+        var espnTask          = espnCacheService.GetScoresAsync();
+        var existingPicksTask = repo.GetUserNflPicksAsync(authenticatedUserId, first.LeagueId, first.Season, first.NflWeek);
+        await Task.WhenAll(weekTask, espnTask, existingPicksTask);
+
+        var weekId        = weekTask.Result;
+        var espnScores    = espnTask.Result;
+        var existingPicks = existingPicksTask.Result;
+
         var picksList = new List<NflPicks>();
-        foreach (var pick in picksDto) {
+        foreach (var pick in picksDtoList) {
             var week = weekId.FirstOrDefault(x => x.NflWeek == pick.NflWeek);
             if (week is null)
                 return BadRequest("Nfl Week Does Not Exist for the given season");
-            picksList.Add((NflPicks)(new NflPicks {
-                LeagueId = pick.LeagueId,
-                UserId = authenticatedUserId,
-                Team = pick.Team,
-                Pick = pick.Pick,
-                NflWeek = pick.NflWeek,
-                Season = pick.Season,
+            picksList.Add(new NflPicks {
+                LeagueId    = pick.LeagueId,
+                UserId      = authenticatedUserId,
+                Team        = pick.Team,
+                Pick        = pick.Pick,
+                NflWeek     = pick.NflWeek,
+                Season      = pick.Season,
                 DateCreated = pick.DateCreated,
-                NflWeekId = week.Id
-            }));
+                NflWeekId   = week.Id
+            });
         }
-        if (picksList.Select(x => x.NflWeek).Distinct().Count() > 1)
-            return BadRequest("All picks must be for the same NFL week");
-        if (picksList.Select(x => x.Season).Distinct().Count() > 1)
-            return BadRequest("All picks must be for the same NFL Season");
-        if (picksList.Select(x => x.LeagueId).Distinct().Count() > 1)
-            return BadRequest("All picks must be for the same League");
-        if (picksList.Select(x => x.UserId).Distinct().Count() > 1)
-            return BadRequest("All picks must be for the same User");
+
         // Guard: reject picks for any game that has already kicked off
-        var espnScores = await espnCacheService.GetScoresAsync();
         if (espnScores?.Events is not null)
         {
-            var allCompetitions = espnScores.Events
-                .SelectMany(e => e.Competitions)
-                .ToList();
+            var allCompetitions = espnScores.Events.SelectMany(e => e.Competitions).ToList();
             var now = DateTimeOffset.UtcNow;
             foreach (var pick in picksList)
             {
@@ -346,13 +358,12 @@ public class LeagueController(
             }
         }
 
-        var existingPicks = await repo.GetUserNflPicksAsync(picksList.First().UserId, picksList.First().LeagueId, picksList.First().Season, picksList.First().NflWeek);
-        var newPicks = picksList.Except(existingPicks);
-        var requiredPicks = GameHelpers.GetRequiredPicks(picksList.First().NflWeek);
-        if (newPicks.Count() + existingPicks.Count > requiredPicks)
-            return BadRequest($"Too many picks. Maximum allowed for week {picksList.First().NflWeek} is {requiredPicks}");
+        var newPicks = picksList.Except(existingPicks).ToList();
+        var requiredPicks = GameHelpers.GetRequiredPicks(first.NflWeek);
+        if (newPicks.Count + existingPicks.Count > requiredPicks)
+            return BadRequest($"Too many picks. Maximum allowed for week {first.NflWeek} is {requiredPicks}");
         await repo.AddNflPicksAsync(newPicks);
-        return Ok(newPicks.Count());
+        return Ok(newPicks.Count);
     }
 
     [HttpDelete("picks")]
@@ -544,7 +555,7 @@ public class LeagueController(
 
     // ---------- Adds for core entities ----------
     [HttpPost("league-user")]
-    [Authorize(Roles = "Administrator")]
+    [Authorize(Roles = AppRoles.Administrator)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> AddLeagueUser([FromBody] LeagueUsersDto leagueUserDto) {
         var leagueUser = new LeagueUsers {
@@ -555,7 +566,7 @@ public class LeagueController(
     }
 
     [HttpPost("league-user-mapping")]
-    [Authorize(Roles = "Administrator")]
+    [Authorize(Roles = AppRoles.Administrator)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> AddLeagueUserMapping([FromBody] LeagueUserMappingDto mappingDto) {
         var mapping = new LeagueUserMapping {
@@ -568,7 +579,7 @@ public class LeagueController(
     }
 
     [HttpPost("league-info")]
-    [Authorize(Roles = "Administrator")]
+    [Authorize(Roles = AppRoles.Administrator)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> AddLeagueInfo([FromBody] LeagueInfoDto leagueInfoDto) {
         var leagueInfo = new LeagueInfo {
@@ -581,7 +592,7 @@ public class LeagueController(
     }
 
     [HttpPost("league-juice-mapping")]
-    [Authorize(Roles = "Administrator")]
+    [Authorize(Roles = AppRoles.Administrator)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> AddLeagueJuiceMapping([FromBody] LeagueJuiceMappingDto mappingDto) {
         var mapping = new LeagueJuiceMapping {


### PR DESCRIPTION
## Summary
Three security vulnerabilities fixed as part of frizat-8n3:

- **Pick user spoofing**: `AddPicks` now resolves `UserId` from the JWT claim (`User.FindFirstValue(ClaimTypes.NameIdentifier)`) instead of the request DTO. Previously any authenticated user could submit picks on behalf of another user.
- **Missing admin guards**: `AddLeagueUser`, `AddLeagueUserMapping`, `AddLeagueInfo`, `AddLeagueJuiceMapping` now require `[Authorize(Roles="Administrator")]`. Previously any authenticated user could call these endpoints.
- **ForgotPassword user enumeration**: Returns `200 OK` when email is not found instead of `400 Bad Request`. Prevents attackers from probing which emails have accounts.

## Test plan
- [x] `dotnet test` — 199 passing, 0 failing
- [x] `npm run test -- --run` — 136 passing, 0 failing
- [x] Red tests written first for all 3 fixes before implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)