### PR TITLE
fix(8n3): fix remaining runtime bugs from security review

### DIFF
--- a/Client.React/src/__tests__/leaderboard.test.tsx
+++ b/Client.React/src/__tests__/leaderboard.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import LeaderboardPage from '../pages/LeaderboardPage';
 import { vi } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { createLeaderboardEntry, createLeaderboardWeekResult, createScores } from '../test/fixtures';
 
 const sessionState = {
   currentLeague: 1 as number | null,
@@ -35,23 +36,19 @@ describe('LeaderboardPage', () => {
   });
 
   it('renders leaderboard with valid data', async () => {
-    mockedGetScores.mockResolvedValue({
-      season: { year: 2025, type: 2 },
-      week: { number: 2 },
-      events: [{ id: '1', season: { year: 2025, type: 2 }, week: { number: 2 }, date: new Date().toISOString(), competitions: [] }],
-    });
+    mockedGetScores.mockResolvedValue(createScores({ week: 2 }));
 
     mockedGetLeaderboard.mockResolvedValue([
-      {
+      createLeaderboardEntry({
         userId: '123',
         userName: 'TestUser',
         rank: '1',
         total: 5,
         weekResults: [
-          { week: 1, score: 25, weekResult: 'Won' },
-          { week: 2, score: 20, weekResult: 'Lost' },
+          createLeaderboardWeekResult({ week: 1, score: 25, weekResult: 'Won' }),
+          createLeaderboardWeekResult({ week: 2, score: 20, weekResult: 'Lost' }),
         ],
-      },
+      }),
     ]);
 
     render(
@@ -66,6 +63,39 @@ describe('LeaderboardPage', () => {
     await screen.findByText(/TestUser/i);
     expect(screen.getByText(/TestUser/i)).toBeInTheDocument();
     expect(screen.getByText('25')).toBeInTheDocument();
+  });
+
+  it('renders without crash when users have ragged weekResults', async () => {
+    // A user with fewer entries than maxWeek causes weekResults[weekIndex] to be
+    // undefined — guard must return an empty cell instead of crashing.
+    mockedGetScores.mockResolvedValue(createScores({ week: 3 }));
+
+    mockedGetLeaderboard.mockResolvedValue([
+      createLeaderboardEntry({
+        userId: '123',
+        userName: 'TestUser',
+        rank: '1',
+        total: 5,
+        weekResults: [
+          createLeaderboardWeekResult({ week: 1, score: 25, weekResult: 'Won' }),
+          createLeaderboardWeekResult({ week: 2, score: 20, weekResult: 'Won' }),
+          createLeaderboardWeekResult({ week: 3, score: 15, weekResult: 'Won' }),
+        ],
+      }),
+      createLeaderboardEntry({ userId: '456', userName: 'NewUser', rank: '2', total: 0, weekResults: [] }),
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={['/leaderboard']}>
+        <Routes>
+          <Route path="/leaderboard" element={<LeaderboardPage />} />
+          <Route path="/leaguepicker" element={<div>League Picker</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByText(/TestUser/i);
+    expect(screen.getByText(/NewUser/i)).toBeInTheDocument();
   });
 
   it('shows no league message when no league selected', async () => {

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -20,7 +20,7 @@ const authState = {
 vi.mock('../services/session', () => ({ useSession: () => sessionState }));
 vi.mock('../services/auth', () => ({ useAuth: () => authState }));
 
-vi.mock('../api/espn', () => ({ getScores: vi.fn(), loadScoresWithRetry: vi.fn() }));
+vi.mock('../api/espn', () => ({ getScores: vi.fn(), loadScoresWithRetry: vi.fn(), getWeekScores: vi.fn() }));
 vi.mock('../api/league', () => ({
   calculateSpreadBatch: vi.fn(),
   doOddsExist: vi.fn(),
@@ -32,12 +32,13 @@ vi.mock('../utils/time', async (importOriginal) => {
   return { ...actual, isPastNoonCst: vi.fn().mockReturnValue(false) };
 });
 
-import { getScores, loadScoresWithRetry } from '../api/espn';
+import { getScores, loadScoresWithRetry, getWeekScores } from '../api/espn';
 import { calculateSpreadBatch, doOddsExist, getLeaguePicks } from '../api/league';
 import { getNextSpreadJob } from '../services/spreadRelease';
 
 const mockedGetScores = vi.mocked(getScores);
 const mockedLoadScoresWithRetry = vi.mocked(loadScoresWithRetry);
+const mockedGetWeekScores = vi.mocked(getWeekScores);
 const mockedDoOddsExist = vi.mocked(doOddsExist);
 const mockedGetLeaguePicks = vi.mocked(getLeaguePicks);
 const mockedCalculateSpreadBatch = vi.mocked(calculateSpreadBatch);
@@ -84,6 +85,7 @@ describe('ScoresPage', () => {
     sessionState.currentLeague = 1;
     mockedGetScores.mockReset();
     mockedLoadScoresWithRetry.mockReset();
+    mockedGetWeekScores.mockReset();
     mockedDoOddsExist.mockReset();
     mockedGetLeaguePicks.mockReset();
     mockedCalculateSpreadBatch.mockReset();
@@ -380,6 +382,21 @@ describe('ScoresPage', () => {
     const { getByTestId } = await renderPage();
     const badge = getByTestId('badge-BUF-spread');
     expect(badge.querySelector('.MuiBadge-badge')).toHaveTextContent('3');
+  });
+
+  it('loadHistoricalWeek calls doOddsExist with internal week not raw ESPN week', async () => {
+    // oddsExist:true required so the full page renders and WeekYearSelector is visible
+    await setupDefaults({ week: 1, postSeason: true, oddsExist: true });
+    mockedCalculateSpreadBatch.mockResolvedValue({ results: {} });
+    await renderPage();
+
+    mockedGetWeekScores.mockResolvedValue(createScores({ week: 2, postSeason: true, gameStarted: true }));
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    await waitFor(() => {
+      // ESPN week 2 postseason → internal week 20 (getWeekFromEspnWeek(2, true))
+      expect(mockedDoOddsExist).toHaveBeenCalledWith(1, expect.any(Number), 20);
+    });
   });
 
   it('toggles to matrix view', async () => {

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -150,6 +150,9 @@ export default function LeaderboardPage() {
                       {Array.from({ length: maxWeek }).map((_, idx) => {
                         const weekIndex = maxWeek - idx - 1;
                         const weekValue = row.weekResults[weekIndex];
+                        if (!weekValue) {
+                          return <TableCell key={idx} />;
+                        }
                         return (
                           <TableCell key={idx} sx={getWeekSx(weekValue.weekResult)}>
                             {weekValue.score}

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -131,10 +131,12 @@ export default function ScoresPage() {
       setWeek(selectedWeek);
       setSeason(selectedSeason);
 
-      const oddsExist = await doOddsExist(currentLeague, selectedSeason, selectedWeek);
+      const nflWeek = getWeekFromEspnWeek(selectedWeek, selectedIsPostSeason);
+      const [oddsExist, picksResult] = await Promise.all([
+        doOddsExist(currentLeague, selectedSeason, nflWeek),
+        getLeaguePicks(currentLeague, selectedSeason, nflWeek),
+      ]);
       setHasOdds(oddsExist);
-
-      const picksResult = await getLeaguePicks(currentLeague, selectedSeason, getWeekFromEspnWeek(selectedWeek, selectedIsPostSeason));
       setPicks(picksResult ?? []);
 
       if (oddsExist) {
@@ -552,8 +554,8 @@ export default function ScoresPage() {
                                 competition={competition}
                                 homeSpread={spreadCache[homeAbbr]?.spread ?? null}
                                 awaySpread={spreadCache[awayAbbr]?.spread ?? null}
-                                over={spreadCache[awayAbbr]?.over ?? null}
-                                under={spreadCache[awayAbbr]?.under ?? null}
+                                over={spreadCache[homeAbbr]?.over ?? null}
+                                under={spreadCache[homeAbbr]?.under ?? null}
                                 isPostSeason={isPostSeason}
                               />
                             )}

--- a/Server.UnitTests/NflScoresJobTests.cs
+++ b/Server.UnitTests/NflScoresJobTests.cs
@@ -229,6 +229,71 @@ public class NflScoresJobTests
     }
 
     // -----------------------------------------------------------------------
+    // Calendar null-guard — no RegularSeason or PostSeason entry
+    // -----------------------------------------------------------------------
+
+    private static EspnScores BuildSeasonScores(bool includeRegularSeason, bool includePostSeason)
+    {
+        var entries = new List<EspnCalendar>();
+        if (includeRegularSeason)
+        {
+            entries.Add(new EspnCalendar
+            {
+                Value = (long)TypeOfSeason.RegularSeason,
+                Entries = new[]
+                {
+                    new CalendarEntry { Value = 1, StartDate = new DateTimeOffset(2025, 9, 4, 0, 0, 0, TimeSpan.Zero), EndDate = new DateTimeOffset(2025, 9, 10, 0, 0, 0, TimeSpan.Zero) }
+                }
+            });
+        }
+        if (includePostSeason)
+        {
+            entries.Add(new EspnCalendar
+            {
+                Value = (long)TypeOfSeason.PostSeason,
+                Entries = new[]
+                {
+                    new CalendarEntry { Value = 1, StartDate = new DateTimeOffset(2026, 1, 11, 0, 0, 0, TimeSpan.Zero), EndDate = new DateTimeOffset(2026, 1, 19, 0, 0, 0, TimeSpan.Zero) }
+                }
+            });
+        }
+
+        return new EspnScores
+        {
+            Leagues = new[]
+            {
+                new EspnLeague
+                {
+                    Season = new LeagueSeason { Year = 2025 },
+                    Calendar = entries.ToArray()
+                }
+            }
+        };
+    }
+
+    [Fact]
+    public async Task Execute_WhenCalendarHasNoRegularSeasonEntry_DoesNotThrow()
+    {
+        _espnApi.GetSeasonScores(Arg.Any<int>())
+                .Returns(BuildSeasonScores(includeRegularSeason: false, includePostSeason: true));
+
+        // Should not throw NullReferenceException when regularSeason is null.
+        // The job continues and processes postSeason entries.
+        var exception = await Record.ExceptionAsync(() => BuildJob().Execute(_context));
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task Execute_WhenCalendarHasNoPostSeasonEntry_DoesNotThrow()
+    {
+        _espnApi.GetSeasonScores(Arg.Any<int>())
+                .Returns(BuildSeasonScores(includeRegularSeason: true, includePostSeason: false));
+
+        // Should not throw NullReferenceException when postSeason is null
+        await BuildJob().Execute(_context);
+    }
+
+    // -----------------------------------------------------------------------
     // Season week mapping — correct NflWeek assigned
     // -----------------------------------------------------------------------
 

--- a/Server.UnitTests/PicksTests.cs
+++ b/Server.UnitTests/PicksTests.cs
@@ -43,10 +43,11 @@ public class PicksTests
     private static LeagueController BuildController(
         ILeagueRepository repo,
         IEspnCacheService espnCacheService,
-        ClaimsPrincipal? principal = null)
+        ClaimsPrincipal? principal = null,
+        IMemoryCache? cache = null)
     {
         var controller = new LeagueController(
-            new MemoryCache(new MemoryCacheOptions()),
+            cache ?? new MemoryCache(new MemoryCacheOptions()),
             repo,
             NullLogger<LeagueController>.Instance,
             BuildUserManager(),
@@ -235,5 +236,37 @@ public class PicksTests
         await repo.Received(1).AddNflPicksAsync(
             Arg.Is<IEnumerable<NflPicks>>(picks =>
                 picks.All(p => p.UserId == jwtUserId)));
+    }
+
+    /// <summary>
+    /// frizat-8n3: After AddPicks writes successfully, the picks cache for that
+    /// league/season/week must be invalidated so the next read reflects the new picks.
+    /// </summary>
+    [Fact]
+    public async Task AddPicks_AfterSuccessfulWrite_InvalidatesPicksCache()
+    {
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var cacheKey = $"picks_{LeagueId}_{Season}_{Week}";
+
+        // Prime the cache with a stale list
+        cache.Set(cacheKey, new List<NflPickDto> { new() { Team = "STALE" } });
+        Assert.True(cache.TryGetValue(cacheKey, out _), "Cache must be primed before AddPicks");
+
+        var futureKickoff = DateTimeOffset.UtcNow.AddHours(2);
+
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetNflWeeksAsync(Season).Returns([MakeNflWeek()]);
+        repo.GetUserNflPicksAsync(UserId, LeagueId, Season, Week).Returns([]);
+        repo.AddNflPicksAsync(Arg.Any<IEnumerable<NflPicks>>()).Returns(Task.CompletedTask);
+
+        var espn = Substitute.For<IEspnCacheService>();
+        espn.GetScoresAsync().Returns(BuildScores(futureKickoff));
+
+        var controller = BuildController(repo, espn, BuildPrincipal(UserId), cache);
+
+        await controller.AddPicks([MakePick("BUF")]);
+
+        // Cache entry must be removed so subsequent reads reload from DB
+        Assert.False(cache.TryGetValue(cacheKey, out _), "Cache must be cleared after AddPicks");
     }
 }

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -363,6 +363,7 @@ public class LeagueController(
         if (newPicks.Count + existingPicks.Count > requiredPicks)
             return BadRequest($"Too many picks. Maximum allowed for week {first.NflWeek} is {requiredPicks}");
         await repo.AddNflPicksAsync(newPicks);
+        memoryCache.Remove($"picks_{first.LeagueId}_{first.Season}_{first.NflWeek}");
         return Ok(newPicks.Count);
     }
 

--- a/Server/Jobs/NFLScoresJob.cs
+++ b/Server/Jobs/NFLScoresJob.cs
@@ -21,7 +21,7 @@ public class NflScoresJob(IEspnApiService espn, ILeagueRepository leagueReposito
             for (var j = 1; j < 19; j++) {
                 // TODO: how do i know the year?
                 var scores = await espn.GetWeekScores(j, DateTime.UtcNow.AddYears(i).Year);
-                if (scores is null)
+                if (scores is null || scores.Events is null)
                     break;
                 var results = scores.Events.SelectMany(x => x.Competitions,
                         (x, y) => new CompetitionBySeason { Id = int.Parse(x.Id), Season = x.Season, Competition = y })
@@ -36,7 +36,7 @@ public class NflScoresJob(IEspnApiService espn, ILeagueRepository leagueReposito
                     continue; // Skip week 4 as ESPN treats week 4 as the Pro Bowl
                 // TODO: how do i know the year?
                 var scores = await espn.GetWeekScores(j, DateTime.UtcNow.AddYears(i).Year, true);
-                if (scores is null)
+                if (scores is null || scores.Events is null)
                     break;
                 var results = scores.Events.SelectMany(x => x.Competitions,
                         (x, y) => new CompetitionBySeason { Id = int.Parse(x.Id), Season = x.Season, Competition = y })
@@ -57,15 +57,19 @@ public class NflScoresJob(IEspnApiService espn, ILeagueRepository leagueReposito
             if (scores.Leagues is null || scores.Leagues.Length == 0 || scores.Leagues[0].Calendar is null || scores.Leagues[0].Calendar.Length == 0)
                 continue;
             var regularSeason = scores.Leagues[0].Calendar.FirstOrDefault(x => x.Value == (int)TypeOfSeason.RegularSeason);
-            weekList.AddRange(regularSeason.Entries.Select(x => new NflWeeks()
+            if (regularSeason is not null)
             {
-                NflWeek = (int)x.Value,
-                Season = (int)scores.Leagues[0].Season.Year,
-                StartDate = x.StartDate,
-                EndDate = x.EndDate
-            }));
+                weekList.AddRange(regularSeason.Entries.Select(x => new NflWeeks()
+                {
+                    NflWeek = (int)x.Value,
+                    Season = (int)scores.Leagues[0].Season.Year,
+                    StartDate = x.StartDate,
+                    EndDate = x.EndDate
+                }));
+            }
             // Skip week 4 as ESPN treats week 4 as the Pro Bowl
             var postSeason = scores.Leagues[0].Calendar.FirstOrDefault(x => x.Value == (int)TypeOfSeason.PostSeason);
+            if (postSeason is null) continue;
             weekList.AddRange(postSeason.Entries.Where(x => x.Value != 4).Select(x => new NflWeeks()
             {
                 NflWeek = GameHelpers.GetWeekFromEspnWeek(x.Value == 5 ? 4 : x.Value, true),


### PR DESCRIPTION
## Summary

- **NFLScoresJob**: null-guard `regularSeason`/`postSeason` from `FirstOrDefault` + guard `Events` on both score-ingestion loops (NullReferenceException on bye weeks)
- **LeagueController**: invalidate picks cache after `AddNflPicksAsync` write so next read reflects new picks
- **ScoresPage**: `doOddsExist` in `loadHistoricalWeek` now wraps week with `getWeekFromEspnWeek` (postseason historical weeks were querying the wrong week); also parallelizes `doOddsExist` + `getLeaguePicks` with `Promise.all`
- **ScoresPage**: ScoreTicker `over`/`under` reads from `spreadCache[homeAbbr]` (was `awayAbbr`)
- **LeaderboardPage**: guard `weekResults[weekIndex]` undefined when users have ragged week data (crash fix)

## Test plan

- [ ] `dotnet test` — 206 passed, 0 failed
- [ ] `npm run test -- --run` — 138 passed, 0 failed
- [ ] New tests: `Execute_WhenCalendarHasNoRegularSeasonEntry_DoesNotThrow`, `Execute_WhenCalendarHasNoPostSeasonEntry_DoesNotThrow`, `AddPicks_AfterSuccessfulWrite_InvalidatesPicksCache`, ragged leaderboard crash test, `loadHistoricalWeek` week mapping test

🤖 Generated with [Claude Code](https://claude.com/claude-code)