### PR TITLE
fix: move /rules into AppLayout, restore page header, revert password sync

### DIFF
--- a/Client.React/src/App.tsx
+++ b/Client.React/src/App.tsx
@@ -113,9 +113,8 @@ export default function App() {
         />
         <Route path="/account/manage" element={<ManageAccountPage />} />
         <Route path="/account/manage/changepassword" caseSensitive={false} element={<ChangePasswordPage />} />
+        <Route path="/rules" caseSensitive={false} element={<RulesPage />} />
       </Route>
-
-      <Route path="/rules" caseSensitive={false} element={<RulesPage />} />
       <Route path="/account" element={<Navigate to="/account/login" replace />} />
       <Route path="*" element={<NotFoundPage />} />
     </Routes>

--- a/Client.React/src/pages/RulesPage.tsx
+++ b/Client.React/src/pages/RulesPage.tsx
@@ -1,5 +1,6 @@
 import { Box, Container, Divider, Paper, Stack, Typography } from '@mui/material';
 import { getEspnRequiredPicks } from '../utils/gameHelpers';
+import PageHeader from '../components/PageHeader';
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -29,16 +30,9 @@ export default function RulesPage() {
   const superBowlPicks = getEspnRequiredPicks(5, true);
 
   return (
-    <Container maxWidth="sm" sx={{ py: 4 }}>
+    <Container maxWidth="sm" sx={{ py: 2 }}>
+      <PageHeader title="How FourPlay Works" subtitle="Everything you need to know before making your picks." />
       <Stack spacing={3}>
-        <Box>
-          <Typography variant="h4" fontWeight={700}>
-            How FourPlay Works
-          </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-            Everything you need to know before making your picks.
-          </Typography>
-        </Box>
 
         <Section title="How Picks Work">
           <Rule>

--- a/Server/Jobs/UserManagerJob.cs
+++ b/Server/Jobs/UserManagerJob.cs
@@ -70,24 +70,25 @@ public class UserManagerJob(
     /// </summary>
     /// <param name="emailAddress">email</param>
     internal async Task CreateUser(string emailAddress) {
-        // Ensure user exists
+        var adminPassword = configuration["ADMIN_PASSWORD"] ?? throw new InvalidOperationException("ADMIN_PASSWORD not set");
         var adminUser = await userManager.FindByEmailAsync(emailAddress);
-        if (adminUser == null)
+        if (adminUser != null) {
+            return;
+        }
+
+        adminUser = new ApplicationUser()
         {
-            adminUser = new ApplicationUser()
-            {
-                UserName = configuration["ADMIN_USERNAME"] ?? throw new InvalidOperationException("ADMIN_USERNAME configuration is required"),
-                Email = emailAddress,
-                EmailConfirmed = true
-            };
-            var result = await userManager.CreateAsync(adminUser, configuration["ADMIN_PASSWORD"] ?? throw new Exception("ADMIN_PASSWORD not set"));
-            if (!result.Succeeded)
-            {
-                Log.Error("Failed to create admin user {Email}. Errors: {Errors}",
-                    emailAddress,
-                    string.Join(", ", result.Errors.Select(e => e.Description)));
-                throw new Exception("Failed to create admin user.");
-            }
+            UserName = configuration["ADMIN_USERNAME"] ?? throw new InvalidOperationException("ADMIN_USERNAME configuration is required"),
+            Email = emailAddress,
+            EmailConfirmed = true
+        };
+        var result = await userManager.CreateAsync(adminUser, adminPassword);
+        if (!result.Succeeded)
+        {
+            Log.Error("Failed to create admin user {Email}. Errors: {Errors}",
+                emailAddress,
+                string.Join(", ", result.Errors.Select(e => e.Description)));
+            throw new InvalidOperationException("Failed to create admin user.");
         }
     }
 


### PR DESCRIPTION
## Summary
- `/rules` route was outside `RequireAuth`/`AppLayout` — page rendered without nav header or proper page chrome, causing the scoring bubble to overlap the footer
- Added `PageHeader` to `RulesPage` for consistent title treatment
- Reverted `UserManagerJob` password sync: create-only behavior restored (no reset on every startup)

## Test plan
- [ ] Navigate to `/rules` — header/nav visible, no bubble overlap at bottom
- [ ] Admin user creation still works on fresh DB
- [ ] Existing admin user password not touched on restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)