### PR TITLE
feat: league-aware invitations, demo mode, live game DTO

### DIFF
--- a/Client.React/src/api/invitations.ts
+++ b/Client.React/src/api/invitations.ts
@@ -11,10 +11,15 @@ export async function getInvitationsByUser(userId: string) {
   return data;
 }
 
-export async function createInvitation(email: string, invitedByUserId: string) {
+export async function createInvitation(email: string, invitedByUserId: string, leagueId?: number | null) {
   const { data } = await http.post<InvitationDto>('/api/invitations', undefined, {
-    params: { email, invitedByUserId },
+    params: { email, invitedByUserId, ...(leagueId != null ? { leagueId } : {}) },
   });
+  return data;
+}
+
+export async function validateInvitation(code: string) {
+  const { data } = await http.get<InvitationDto | null>(`/api/invitations/validate/${encodeURIComponent(code)}`);
   return data;
 }
 

--- a/Client.React/src/pages/account/RegisterPage.tsx
+++ b/Client.React/src/pages/account/RegisterPage.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Button, Card, CardActions, CardContent, Stack, TextField, Typography } from '@mui/material';
+import { Alert, Button, Card, CardActions, CardContent, Stack, TextField, Typography } from '@mui/material';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { createUser } from '../../api/auth';
+import { validateInvitation } from '../../api/invitations';
 import { useToast } from '../../services/toast';
 
 const schema = z
@@ -34,6 +35,7 @@ export default function RegisterPage() {
   const params = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const inviteCode = params.get('inviteCode') ?? '';
   const returnUrl = params.get('returnUrl') ?? '/';
+  const [leagueName, setLeagueName] = useState<string | null>(null);
 
   const {
     register,
@@ -52,7 +54,12 @@ export default function RegisterPage() {
 
   useEffect(() => {
     document.title = 'Register';
-  }, []);
+    if (inviteCode) {
+      void validateInvitation(inviteCode).then((inv) => {
+        if (inv?.leagueName) setLeagueName(inv.leagueName);
+      });
+    }
+  }, [inviteCode]);
 
   const onSubmit = async (values: FormValues) => {
     const result = await createUser({
@@ -74,6 +81,11 @@ export default function RegisterPage() {
   return (
     <Stack spacing={3} sx={{ maxWidth: 640, margin: '0 auto', paddingTop: 6 }}>
       <Typography variant="h4">Register</Typography>
+      {leagueName && (
+        <Alert severity="info">
+          You've been invited to join <strong>{leagueName}</strong>
+        </Alert>
+      )}
       <Card>
         <CardContent>
           <Stack spacing={2} component="form" onSubmit={handleSubmit(onSubmit)}>

--- a/Client.React/src/pages/admin/InvitationsPage.tsx
+++ b/Client.React/src/pages/admin/InvitationsPage.tsx
@@ -6,8 +6,12 @@ import {
   CardContent,
   Chip,
   CircularProgress,
+  FormControl,
   IconButton,
+  InputLabel,
+  MenuItem,
   Paper,
+  Select,
   Stack,
   Table,
   TableBody,
@@ -24,7 +28,9 @@ import PageHeader from '../../components/PageHeader';
 import { useToast } from '../../services/toast';
 import { useAuth } from '../../services/auth';
 import { createInvitation, deleteInvitation, getAllInvitations, sendEmail } from '../../api/invitations';
+import { getLeagueUserMappingsForUser } from '../../api/league';
 import type { InvitationDto } from '../../types/admin';
+import type { LeagueUserMappingDto } from '../../types/league';
 
 export default function AdminInvitationsPage() {
   const [invitations, setInvitations] = useState<InvitationDto[]>([]);
@@ -32,6 +38,8 @@ export default function AdminInvitationsPage() {
   const [showUsed, setShowUsed] = useState(true);
   const [showExpired, setShowExpired] = useState(true);
   const [email, setEmail] = useState('');
+  const [selectedLeagueId, setSelectedLeagueId] = useState<number | ''>('');
+  const [leagues, setLeagues] = useState<LeagueUserMappingDto[]>([]);
   const [creating, setCreating] = useState(false);
   const toast = useToast();
   const { user } = useAuth();
@@ -45,7 +53,12 @@ export default function AdminInvitationsPage() {
 
   useEffect(() => {
     void loadInvitations();
-  }, []);
+    if (user?.userId) {
+      void getLeagueUserMappingsForUser(user.userId).then((mappings) => {
+        setLeagues(mappings ?? []);
+      });
+    }
+  }, [user?.userId]);
 
   const filteredInvitations = useMemo(
     () =>
@@ -102,7 +115,8 @@ export default function AdminInvitationsPage() {
     }
     setCreating(true);
     try {
-      const invitation = await createInvitation(email, user.userId);
+      const leagueId = selectedLeagueId !== '' ? selectedLeagueId : null;
+      const invitation = await createInvitation(email, user.userId, leagueId);
       toast.push(`Invitation created for ${email}`, 'success');
       await sendEmail({
         toEmail: invitation.email,
@@ -186,8 +200,23 @@ export default function AdminInvitationsPage() {
               onChange={(e) => setEmail(e.target.value)}
               fullWidth
             />
+            <FormControl sx={{ minWidth: 180 }}>
+              <InputLabel>League (optional)</InputLabel>
+              <Select
+                value={selectedLeagueId}
+                label="League (optional)"
+                onChange={(e) => setSelectedLeagueId(e.target.value as number | '')}
+              >
+                <MenuItem value=""><em>No league</em></MenuItem>
+                {leagues.map((m) => (
+                  <MenuItem key={m.leagueId} value={m.leagueId}>
+                    {m.leagueName ?? `League ${m.leagueId}`}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
             <Button variant="contained" onClick={handleCreateInvitation} disabled={creating}>
-              {creating ? 'Creating...' : 'Create Invitation'}
+              {creating ? 'Inviting...' : 'Invite'}
             </Button>
           </Stack>
         </CardContent>
@@ -216,6 +245,7 @@ export default function AdminInvitationsPage() {
               <TableRow>
                 <TableCell>Date Created</TableCell>
                 <TableCell>Email</TableCell>
+                <TableCell>League</TableCell>
                 <TableCell>Status</TableCell>
                 <TableCell>Expires</TableCell>
                 <TableCell>Used By</TableCell>
@@ -227,6 +257,7 @@ export default function AdminInvitationsPage() {
                 <TableRow key={invitation.id}>
                   <TableCell>{new Date(invitation.createdAt).toLocaleString()}</TableCell>
                   <TableCell>{invitation.email}</TableCell>
+                  <TableCell>{invitation.leagueName ?? '-'}</TableCell>
                   <TableCell>
                     {invitation.isUsed ? (
                       <Chip size="small" label="Used" color="success" />

--- a/Client.React/src/types/admin.ts
+++ b/Client.React/src/types/admin.ts
@@ -62,6 +62,8 @@ export interface InvitationDto {
   registeredUserName?: string | null;
   isExpired: boolean;
   isValid: boolean;
+  leagueId?: number | null;
+  leagueName?: string | null;
 }
 
 export interface EmailRequest {

--- a/Server.UnitTests/AuthControllerTests.cs
+++ b/Server.UnitTests/AuthControllerTests.cs
@@ -1,4 +1,5 @@
 using FourPlayWebApp.Server.Controllers;
+using FourPlayWebApp.Server.Data;
 using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Shared.Models.Account;
@@ -8,6 +9,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -70,6 +72,11 @@ public class AuthControllerTests
         refreshTokenService ??= Substitute.For<IRefreshTokenService>();
         environment     ??= BuildDevEnvironment();
 
+        var db = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase("AuthControllerTests_" + Guid.NewGuid())
+                .Options);
+
         var controller = new AuthController(
             userManager,
             signInManager,
@@ -80,7 +87,8 @@ public class AuthControllerTests
             Substitute.For<IConfiguration>(),
             refreshTokenService,
             jwtTokenService,
-            environment
+            environment,
+            db
         );
 
         var httpContext = new DefaultHttpContext();

--- a/Server.UnitTests/ChangePasswordTests.cs
+++ b/Server.UnitTests/ChangePasswordTests.cs
@@ -1,4 +1,5 @@
 using FourPlayWebApp.Server.Controllers;
+using FourPlayWebApp.Server.Data;
 using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Shared.Models.Account;
@@ -8,6 +9,7 @@ using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using System.Security.Claims;
@@ -35,6 +37,11 @@ public class ChangePasswordTests
             Substitute.For<IUserClaimsPrincipalFactory<ApplicationUser>>(),
             null, null, null, null);
 
+        var db = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase("ChangePasswordTests_" + Guid.NewGuid())
+                .Options);
+
         var controller = new AuthController(
             userManager,
             signInManager,
@@ -45,7 +52,8 @@ public class ChangePasswordTests
             Substitute.For<IConfiguration>(),
             Substitute.For<IRefreshTokenService>(),
             Substitute.For<IJwtTokenService>(),
-            Substitute.For<IWebHostEnvironment>()
+            Substitute.For<IWebHostEnvironment>(),
+            db
         );
 
         controller.ControllerContext = new ControllerContext

--- a/Server.UnitTests/EmailProcessTests.cs
+++ b/Server.UnitTests/EmailProcessTests.cs
@@ -1,4 +1,5 @@
 using FourPlayWebApp.Server.Controllers;
+using FourPlayWebApp.Server.Data;
 using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Shared.Models.Account;
@@ -8,6 +9,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -52,6 +54,11 @@ public class EmailProcessTests
             Substitute.For<IUserClaimsPrincipalFactory<ApplicationUser>>(),
             null, null, null, null);
 
+        var db = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase("EmailProcessTests_" + Guid.NewGuid())
+                .Options);
+
         var controller = new AuthController(
             userManager,
             signInManager,
@@ -62,7 +69,8 @@ public class EmailProcessTests
             Substitute.For<IConfiguration>(),
             Substitute.For<IRefreshTokenService>(),
             Substitute.For<IJwtTokenService>(),
-            Substitute.For<IWebHostEnvironment>()
+            Substitute.For<IWebHostEnvironment>(),
+            db
         );
 
         controller.ControllerContext = new ControllerContext

--- a/Server.UnitTests/InvitationLeagueTests.cs
+++ b/Server.UnitTests/InvitationLeagueTests.cs
@@ -1,0 +1,228 @@
+using FourPlayWebApp.Server.Controllers;
+using FourPlayWebApp.Server.Data;
+using FourPlayWebApp.Server.Models;
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Models.Identity;
+using FourPlayWebApp.Server.Services;
+using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Shared.Models.Account;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+/// <summary>
+/// TDD tests for league-aware invitations (frizat-ecj).
+/// All tests are written RED first — they will fail until implementation is added.
+/// </summary>
+public class InvitationLeagueTests
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static ApplicationDbContext BuildDb(string name) =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(name)
+            .Options);
+
+    private static IDbContextFactory<ApplicationDbContext> BuildFactory(ApplicationDbContext db)
+    {
+        var factory = Substitute.For<IDbContextFactory<ApplicationDbContext>>();
+        factory.CreateDbContextAsync().Returns(db);
+        return factory;
+    }
+
+    private static UserManager<ApplicationUser> BuildUserManager()
+    {
+        var store = Substitute.For<IUserStore<ApplicationUser>>();
+        var mgr = Substitute.For<UserManager<ApplicationUser>>(
+            store, null, null, null, null, null, null, null, null);
+        mgr.GetAccessFailedCountAsync(Arg.Any<ApplicationUser>()).Returns(0);
+        return mgr;
+    }
+
+    private static IWebHostEnvironment BuildDevEnv()
+    {
+        var env = Substitute.For<IWebHostEnvironment>();
+        env.EnvironmentName.Returns("Development");
+        return env;
+    }
+
+    // ── InvitationService tests ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateInvitation_StoresLeagueId_WhenProvided()
+    {
+        var db = BuildDb(nameof(CreateInvitation_StoresLeagueId_WhenProvided));
+        var service = new InvitationService(BuildFactory(db));
+
+        var result = await service.CreateInvitationAsync("user@example.com", "admin-1", leagueId: 42);
+
+        Assert.Equal(42, result.LeagueId);
+    }
+
+    [Fact]
+    public async Task CreateInvitation_NullLeagueId_WhenNotProvided()
+    {
+        var db = BuildDb(nameof(CreateInvitation_NullLeagueId_WhenNotProvided));
+        var service = new InvitationService(BuildFactory(db));
+
+        var result = await service.CreateInvitationAsync("user@example.com", "admin-1");
+
+        Assert.Null(result.LeagueId);
+    }
+
+    [Fact]
+    public async Task ValidateInvitation_ReturnsLeagueId_WhenLeagueAssigned()
+    {
+        var db = BuildDb(nameof(ValidateInvitation_ReturnsLeagueId_WhenLeagueAssigned));
+        db.Invitations.Add(new Invitation
+        {
+            InvitationCode = "test-code-123",
+            Email = "user@example.com",
+            LeagueId = 7,
+            ExpiresAt = DateTime.UtcNow.AddDays(7),
+        });
+        await db.SaveChangesAsync();
+
+        var service = new InvitationService(BuildFactory(db));
+        var result = await service.ValidateInvitationAsync("test-code-123");
+
+        Assert.NotNull(result);
+        Assert.Equal(7, result.LeagueId);
+    }
+
+    // ── AuthController tests ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateUser_AutoAssignsLeague_WhenInvitationHasLeagueId()
+    {
+        // Arrange
+        var db = BuildDb(nameof(CreateUser_AutoAssignsLeague_WhenInvitationHasLeagueId));
+        var userManager = BuildUserManager();
+        var invitationService = Substitute.For<IInvitationService>();
+        var config = Substitute.For<IConfiguration>();
+
+        var invitation = new Invitation
+        {
+            Id = 1,
+            InvitationCode = "code-abc",
+            Email = "newuser@example.com",
+            LeagueId = 5,
+            ExpiresAt = DateTime.UtcNow.AddDays(7),
+        };
+
+        invitationService.ValidateInvitationAsync("code-abc").Returns(invitation);
+        invitationService.MarkInvitationAsUsedAsync("code-abc", Arg.Any<string>()).Returns(true);
+
+        userManager.FindByEmailAsync("newuser@example.com").Returns((ApplicationUser?)null);
+        userManager.CreateAsync(Arg.Any<ApplicationUser>(), Arg.Any<string>())
+            .Returns(IdentityResult.Success);
+        userManager.GenerateEmailConfirmationTokenAsync(Arg.Any<ApplicationUser>())
+            .Returns("token");
+
+        config["App:BaseUrl"].Returns("http://localhost");
+
+        var controller = BuildAuthController(userManager, invitationService, config, db);
+
+        // Act
+        var result = await controller.CreateUser(new CreateUserRequest
+        {
+            Username = "newuser",
+            Email = "newuser@example.com",
+            Password = "Pass@123",
+            Code = "code-abc",
+        });
+
+        // Assert — LeagueUserMapping must exist for the new user in league 5
+        var mapping = db.LeagueUserMapping.FirstOrDefault(m => m.LeagueId == 5);
+        Assert.NotNull(mapping);
+    }
+
+    [Fact]
+    public async Task CreateUser_NoLeagueAssignment_WhenInvitationHasNoLeagueId()
+    {
+        // Arrange
+        var db = BuildDb(nameof(CreateUser_NoLeagueAssignment_WhenInvitationHasNoLeagueId));
+        var userManager = BuildUserManager();
+        var invitationService = Substitute.For<IInvitationService>();
+        var config = Substitute.For<IConfiguration>();
+
+        var invitation = new Invitation
+        {
+            Id = 2,
+            InvitationCode = "code-xyz",
+            Email = "user2@example.com",
+            LeagueId = null,
+            ExpiresAt = DateTime.UtcNow.AddDays(7),
+        };
+
+        invitationService.ValidateInvitationAsync("code-xyz").Returns(invitation);
+        invitationService.MarkInvitationAsUsedAsync("code-xyz", Arg.Any<string>()).Returns(true);
+
+        userManager.FindByEmailAsync("user2@example.com").Returns((ApplicationUser?)null);
+        userManager.CreateAsync(Arg.Any<ApplicationUser>(), Arg.Any<string>())
+            .Returns(IdentityResult.Success);
+        userManager.GenerateEmailConfirmationTokenAsync(Arg.Any<ApplicationUser>())
+            .Returns("token");
+
+        config["App:BaseUrl"].Returns("http://localhost");
+
+        var controller = BuildAuthController(userManager, invitationService, config, db);
+
+        // Act
+        await controller.CreateUser(new CreateUserRequest
+        {
+            Username = "user2",
+            Email = "user2@example.com",
+            Password = "Pass@123",
+            Code = "code-xyz",
+        });
+
+        // Assert — no LeagueUserMapping should be created
+        Assert.Empty(db.LeagueUserMapping);
+    }
+
+    // ── Builder ───────────────────────────────────────────────────────────────
+
+    private static AuthController BuildAuthController(
+        UserManager<ApplicationUser> userManager,
+        IInvitationService invitationService,
+        IConfiguration config,
+        ApplicationDbContext db)
+    {
+        var signInManager = Substitute.For<SignInManager<ApplicationUser>>(
+            userManager,
+            Substitute.For<IHttpContextAccessor>(),
+            Substitute.For<IUserClaimsPrincipalFactory<ApplicationUser>>(),
+            null, null, null, null);
+
+        var controller = new AuthController(
+            userManager,
+            signInManager,
+            Substitute.For<IEmailSender>(),
+            Substitute.For<IEmailSender<ApplicationUser>>(),
+            invitationService,
+            NullLogger<AuthController>.Instance,
+            config,
+            Substitute.For<IRefreshTokenService>(),
+            Substitute.For<IJwtTokenService>(),
+            BuildDevEnv(),
+            db
+        );
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext(),
+        };
+
+        return controller;
+    }
+}

--- a/Server/Controllers/AuthController.cs
+++ b/Server/Controllers/AuthController.cs
@@ -1,4 +1,6 @@
-﻿using FourPlayWebApp.Server.Models.Identity;
+﻿using FourPlayWebApp.Server.Data;
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Shared.Models.Account;
 using FourPlayWebApp.Shared.Models.Account.Dto;
@@ -23,7 +25,7 @@ public class AuthController(
     IEmailSender emailSender, IEmailSender<ApplicationUser> emailSenderApplication,
     IInvitationService invitationService, ILogger<AuthController> logger,
     IConfiguration config, IRefreshTokenService refreshTokenService, IJwtTokenService jwtTokenService,
-    IWebHostEnvironment environment)
+    IWebHostEnvironment environment, ApplicationDbContext db)
     : ControllerBase {
     private readonly TimeSpan _refreshTokenLifetime = TimeSpan.FromDays(14); // 14 days
     private bool UseSecureCookies => !environment.IsDevelopment() || Request.IsHttps;
@@ -276,6 +278,17 @@ public class AuthController(
         // Mark invitation as used
         var invitationResult = await invitationService.MarkInvitationAsUsedAsync(user.Code, newUser.Id);
         if (!invitationResult) return BadRequest("Invalid invitation code or already used/expired.");
+
+        // Auto-assign user to league if invitation specifies one
+        if (invitation.LeagueId.HasValue)
+        {
+            db.LeagueUserMapping.Add(new LeagueUserMapping
+            {
+                LeagueId = invitation.LeagueId.Value,
+                UserId = newUser.Id,
+            });
+            await db.SaveChangesAsync();
+        }
 
         // Send confirmation email server-side — do not rely on client making a second call.
         // Failure is logged but must not prevent the user account from being returned as created.

--- a/Server/Controllers/InvitationController.cs
+++ b/Server/Controllers/InvitationController.cs
@@ -28,9 +28,9 @@ public class InvitationController(IInvitationService invitationService, IEmailSe
     }
 
     [HttpPost]
-    public async Task<ActionResult<InvitationDto>> Create([FromQuery] string email, [FromQuery] string invitedByUserId)
+    public async Task<ActionResult<InvitationDto>> Create([FromQuery] string email, [FromQuery] string invitedByUserId, [FromQuery] int? leagueId = null)
     {
-        var invitation = await invitationService.CreateInvitationAsync(email, invitedByUserId);
+        var invitation = await invitationService.CreateInvitationAsync(email, invitedByUserId, leagueId);
         return CreatedAtAction(nameof(GetAll), new { id = invitation.Id }, invitation.ToDto());
     }
 

--- a/Server/Migrations/20260406191523_AddLeagueIdToInvitation.Designer.cs
+++ b/Server/Migrations/20260406191523_AddLeagueIdToInvitation.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260406191523_AddLeagueIdToInvitation")]
+    partial class AddLeagueIdToInvitation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/20260406191523_AddLeagueIdToInvitation.cs
+++ b/Server/Migrations/20260406191523_AddLeagueIdToInvitation.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLeagueIdToInvitation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "LeagueId",
+                table: "Invitations",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invitations_LeagueId",
+                table: "Invitations",
+                column: "LeagueId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Invitations_LeagueInfo_LeagueId",
+                table: "Invitations",
+                column: "LeagueId",
+                principalTable: "LeagueInfo",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Invitations_LeagueInfo_LeagueId",
+                table: "Invitations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Invitations_LeagueId",
+                table: "Invitations");
+
+            migrationBuilder.DropColumn(
+                name: "LeagueId",
+                table: "Invitations");
+        }
+    }
+}

--- a/Server/Models/Invitation.cs
+++ b/Server/Models/Invitation.cs
@@ -1,3 +1,4 @@
+using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Models.Identity;
 using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations;
@@ -12,7 +13,7 @@ public class Invitation
 
     [Required]
     public string InvitationCode { get; set; } = Guid.NewGuid().ToString("N");
-    
+
     [Required, EmailAddress]
     public string Email { get; set; } = string.Empty;
 
@@ -20,6 +21,11 @@ public class Invitation
 
     [ForeignKey("InvitedByUserId")]
     public ApplicationUser? InvitedByUser { get; set; }
+
+    public int? LeagueId { get; set; }
+
+    [ForeignKey("LeagueId")]
+    public LeagueInfo? League { get; set; }
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 

--- a/Server/Models/Mappers/InvitationMapper.cs
+++ b/Server/Models/Mappers/InvitationMapper.cs
@@ -20,7 +20,9 @@ public static class InvitationMapper
             RegisteredUserId = invitation.RegisteredUserId,
             RegisteredUserName = invitation.RegisteredUser?.UserName, // from ApplicationUser
             IsExpired = invitation.IsExpired,
-            IsValid = invitation.IsValid
+            IsValid = invitation.IsValid,
+            LeagueId = invitation.LeagueId,
+            LeagueName = invitation.League?.LeagueName
         };
     }
 

--- a/Server/Services/Interfaces/IInvitationService.cs
+++ b/Server/Services/Interfaces/IInvitationService.cs
@@ -15,7 +15,7 @@ public interface IInvitationService
     /// <param name="email">Email to invite</param>
     /// <param name="invitedByUserId">User ID of the person sending the invite</param>
     /// <returns>The created invitation</returns>
-    Task<Invitation> CreateInvitationAsync(string email, string invitedByUserId);
+    Task<Invitation> CreateInvitationAsync(string email, string invitedByUserId, int? leagueId = null);
 
     /// <summary>
     /// Validate if the invitation code is valid

--- a/Server/Services/InvitationService.cs
+++ b/Server/Services/InvitationService.cs
@@ -21,7 +21,7 @@ public class InvitationService(IDbContextFactory<ApplicationDbContext> dbContext
         Log.Information("Invitation with ID {Id} deleted", id);
     }
 
-    public async Task<Invitation> CreateInvitationAsync(string email, string invitedByUserId)
+    public async Task<Invitation> CreateInvitationAsync(string email, string invitedByUserId, int? leagueId = null)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync();
 
@@ -29,6 +29,7 @@ public class InvitationService(IDbContextFactory<ApplicationDbContext> dbContext
         {
             Email = email,
             InvitedByUserId = invitedByUserId,
+            LeagueId = leagueId,
             CreatedAt = DateTime.UtcNow,
             ExpiresAt = DateTime.UtcNow.AddDays(7)
         };
@@ -46,6 +47,7 @@ public class InvitationService(IDbContextFactory<ApplicationDbContext> dbContext
         await using var dbContext = await dbContextFactory.CreateDbContextAsync();
 
         var invitation = await dbContext.Invitations
+            .Include(i => i.League)
             .FirstOrDefaultAsync(i => i.InvitationCode == code);
 
         if (invitation == null)
@@ -96,6 +98,7 @@ public class InvitationService(IDbContextFactory<ApplicationDbContext> dbContext
         return await dbContext.Invitations
             .Include(i => i.InvitedByUser)
             .Include(i => i.RegisteredUser)
+            .Include(i => i.League)
             .OrderByDescending(i => i.CreatedAt)
             .ToListAsync();
     }

--- a/Shared/Models/Data/Dtos/InvitationDto.cs
+++ b/Shared/Models/Data/Dtos/InvitationDto.cs
@@ -17,4 +17,6 @@ public class InvitationDto
     public string? RegisteredUserName { get; set; }
     public bool IsExpired { get; set; }
     public bool IsValid { get; set; }
+    public int? LeagueId { get; set; }
+    public string? LeagueName { get; set; }
 }


### PR DESCRIPTION
## Summary
- **frizat-ecj**: League-aware invitations — admin picks a league when inviting, new user is auto-assigned to that league on registration; `RegisterPage` shows league banner from invite context
- **frizat-0x4**: Live game DTO — ESPN live data surfaced via `LiveGameDto`, `FieldPosition` component, frozen demo ESPN JSON
- **demo mode**: Local Docker Postgres, `DemoDataSeeder` (fake users/picks/games), `start-demo.sh` script, `.env.backend.example`

## Test plan
- [ ] `dotnet test` — all backend tests green
- [ ] `npm run test -- --run` — all Vitest tests green (67+ tests)
- [ ] CI checks passed on PR #50 (frontend ✓, backend ✓, Vercel ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)