### PR TITLE
fix: DateTime → DateTimeOffset in Invitation (unblocks PR #55)

### DIFF
--- a/Server/Models/Invitation.cs
+++ b/Server/Models/Invitation.cs
@@ -27,13 +27,13 @@ public class Invitation
     [ForeignKey("LeagueId")]
     public LeagueInfo? League { get; set; }
 
-    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
 
-    public DateTime? ExpiresAt { get; set; } = DateTime.UtcNow.AddDays(7);
+    public DateTimeOffset? ExpiresAt { get; set; } = DateTimeOffset.UtcNow.AddDays(7);
 
     public bool IsUsed { get; set; } = false;
 
-    public DateTime? UsedAt { get; set; }
+    public DateTimeOffset? UsedAt { get; set; }
 
     public string? RegisteredUserId { get; set; }
 
@@ -41,7 +41,7 @@ public class Invitation
     public ApplicationUser? RegisteredUser { get; set; }
 
     [NotMapped]
-    public bool IsExpired => ExpiresAt.HasValue && ExpiresAt.Value < DateTime.UtcNow;
+    public bool IsExpired => ExpiresAt.HasValue && ExpiresAt.Value < DateTimeOffset.UtcNow;
 
     [NotMapped]
     public bool IsValid => !IsUsed && !IsExpired;

--- a/Server/Services/InvitationService.cs
+++ b/Server/Services/InvitationService.cs
@@ -30,8 +30,8 @@ public class InvitationService(IDbContextFactory<ApplicationDbContext> dbContext
             Email = email,
             InvitedByUserId = invitedByUserId,
             LeagueId = leagueId,
-            CreatedAt = DateTime.UtcNow,
-            ExpiresAt = DateTime.UtcNow.AddDays(7)
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(7)
         };
 
         dbContext.Invitations.Add(invitation);
@@ -62,7 +62,7 @@ public class InvitationService(IDbContextFactory<ApplicationDbContext> dbContext
             return null;
         }
 
-        if (invitation.ExpiresAt >= DateTime.UtcNow) return invitation;
+        if (invitation.ExpiresAt >= DateTimeOffset.UtcNow) return invitation;
         Log.Information("Invitation with code {Code} has expired", code);
         return null;
 
@@ -75,14 +75,14 @@ public class InvitationService(IDbContextFactory<ApplicationDbContext> dbContext
         var invitation = await dbContext.Invitations
             .FirstOrDefaultAsync(i => i.InvitationCode == code);
 
-        if (invitation == null || invitation.IsUsed || invitation.ExpiresAt < DateTime.UtcNow)
+        if (invitation == null || invitation.IsUsed || invitation.ExpiresAt < DateTimeOffset.UtcNow)
         {
             Log.Warning("Cannot mark invitation {Code} as used - invalid state", code);
             return false;
         }
 
         invitation.IsUsed = true;
-        invitation.UsedAt = DateTime.UtcNow;
+        invitation.UsedAt = DateTimeOffset.UtcNow;
         invitation.RegisteredUserId = registeredUserId;
 
         await dbContext.SaveChangesAsync();

--- a/Shared/Models/Data/Dtos/InvitationDto.cs
+++ b/Shared/Models/Data/Dtos/InvitationDto.cs
@@ -9,10 +9,10 @@ public class InvitationDto
     public string Email { get; set; } = string.Empty;
     public string? InvitedByUserId { get; set; }
     public string? InvitedByUserName { get; set; }
-    public DateTime CreatedAt { get; set; }
-    public DateTime? ExpiresAt { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset? ExpiresAt { get; set; }
     public bool IsUsed { get; set; }
-    public DateTime? UsedAt { get; set; }
+    public DateTimeOffset? UsedAt { get; set; }
     public string? RegisteredUserId { get; set; }
     public string? RegisteredUserName { get; set; }
     public bool IsExpired { get; set; }


### PR DESCRIPTION
## Summary
- `main` still has `DateTime.UtcNow` in `Invitation.cs` and `InvitationService.cs` from the ecj merge (#50/#51)
- `dev` has `DateTimeOffset.UtcNow` from the 896 refactor
- This causes an unresolvable conflict in PR #55 (dev→main) because git sees both branches modifying the same lines with different types
- This PR aligns `main` with dev so the PR #55 merge is clean

## After merging
PR #55 (dev→main) should show no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)