### PR TITLE
chore: sync dev → main

### DIFF
--- a/Client.React/src/__tests__/FieldPosition.test.tsx
+++ b/Client.React/src/__tests__/FieldPosition.test.tsx
@@ -17,9 +17,10 @@ function buildSituation(overrides?: Partial<GameSituation>): GameSituation {
 }
 
 describe('FieldPosition', () => {
-  it('renders nothing when situation is null', () => {
+  it('renders a placeholder element (not null) when situation is null', () => {
     const { container } = render(<FieldPosition situation={null} />);
-    expect(container.firstChild).toBeNull();
+    expect(container.firstChild).not.toBeNull();
+    expect(screen.queryByTestId('field-position-bar')).toBeNull();
   });
 
   it('renders down and distance text', () => {

--- a/Client.React/src/app/theme.ts
+++ b/Client.React/src/app/theme.ts
@@ -7,9 +7,9 @@ export function createAppTheme(mode: 'light' | 'dark') {
     mode,
     // Professional dark navy primary with vibrant sports orange accent
     primary: {
-      main: '#1a2847', // Professional dark navy
-      dark: '#0f1729',
-      light: '#2a3d5f',
+      main: isDark ? '#3b82f6' : '#1a2847',
+      dark: isDark ? '#2563eb' : '#0f1729',
+      light: isDark ? '#60a5fa' : '#2a3d5f',
       contrastText: '#FFFFFF',
     },
     secondary: {

--- a/Client.React/src/components/FieldPosition.tsx
+++ b/Client.React/src/components/FieldPosition.tsx
@@ -9,7 +9,7 @@ interface FieldPositionProps {
 const YARD_MARKERS = [10, 20, 30, 40, 50, 60, 70, 80, 90];
 
 export default function FieldPosition({ situation }: FieldPositionProps) {
-  if (!situation) return null;
+  if (!situation) return <Box sx={{ mt: 1, height: 24 + 4 + 20, mx: 1 }} />;
 
   const { yardLine, isHomePossession, isRedZone, downDistanceText } = situation;
   const fieldColor = isRedZone ? 'error.dark' : 'success.dark';

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -300,6 +300,7 @@ export default function AppLayout() {
           flexGrow: 1,
           p: { xs: 0, sm: 3 },
           width: { xs: '100%', md: `calc(100% - ${open ? drawerWidth : 0}px)` },
+          minHeight: '100vh',
           transition: theme.transitions.create(['width', 'margin'], {
             easing: theme.transitions.easing.sharp,
             duration: theme.transitions.duration.leavingScreen,

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -6,7 +6,6 @@ import {
   CardContent,
   CircularProgress,
   Grid,
-  Paper,
   Table,
   TableBody,
   TableCell,
@@ -132,7 +131,7 @@ export default function LeaderboardPage() {
           <Grid size={12}>
           </Grid>
           <Grid size={12}>
-            <Paper sx={{ p: 2 }}>
+            <Box>
               <Box sx={{ overflowX: 'auto' }}><Table size="small">
                 <TableHead>
                   <TableRow>
@@ -231,7 +230,7 @@ export default function LeaderboardPage() {
                   </Card>
                 </Grid>
               </Grid>
-            </Paper>
+            </Box>
           </Grid>
         </Grid>
       )}

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -122,6 +122,11 @@ export default function LeaderboardPage() {
   return (
     <Box>
       <PageHeader title="Leaderboard" />
+      {leaderboard.length === 0 && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 4, textAlign: 'center' }}>
+          No leaderboard data yet for this season.
+        </Typography>
+      )}
       {leaderboard.length > 0 && (
         <Grid container spacing={2}>
           <Grid size={12}>

--- a/Client.React/src/pages/PicksPage.tsx
+++ b/Client.React/src/pages/PicksPage.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Button,
+  Card,
+  CardContent,
   CircularProgress,
   Grid,
   Paper,
@@ -341,7 +343,8 @@ export default function PicksPage() {
   if (!hasOdds) return <SpreadRelease />;
 
   return (
-    <Box>
+    <Card sx={{ minHeight: 'calc(100vh - 128px)' }}>
+      <CardContent>
       <PageHeader title="Picks" />
       {scores && (
         <Box sx={{ mb: 3 }}>
@@ -544,6 +547,7 @@ export default function PicksPage() {
             })
         )}
       </Grid>
-    </Box>
+      </CardContent>
+    </Card>
   );
 }

--- a/Client.React/src/pages/RulesPage.tsx
+++ b/Client.React/src/pages/RulesPage.tsx
@@ -33,7 +33,7 @@ export default function RulesPage() {
   const superBowlPicks = getEspnRequiredPicks(5, true);
 
   return (
-    <Card sx={{ maxWidth: 600, mx: 'auto' }}>
+    <Card sx={{ minHeight: 'calc(100vh - 128px)' }}>
       <CardContent>
         <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 2 }}>
           <IconButton onClick={() => navigate(-1)} sx={{ mr: 1, mt: 0.5 }}>

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -445,13 +445,11 @@ export default function ScoresPage() {
                               <img src={getHomeTeamLogo(competition)} width={50} />
                             </Stack>
 
-                            {!isHalfTime(competition) && (
-                              <FieldPosition
-                                situation={liveGames.find(
-                                  (g) => g.homeTeam === homeAbbr && g.awayTeam === awayAbbr
-                                )?.situation ?? null}
-                              />
-                            )}
+                            <FieldPosition
+                              situation={isHalfTime(competition) ? null : (liveGames.find(
+                                (g) => g.homeTeam === homeAbbr && g.awayTeam === awayAbbr
+                              )?.situation ?? null)}
+                            />
 
                             <Stack direction="row" alignItems="center" sx={{ mt: 3, gap: 1.5, px: 1 }}>
                               {getIcon(competition, awayAbbr)}

--- a/Server/Services/DemoDataSeeder.cs
+++ b/Server/Services/DemoDataSeeder.cs
@@ -60,6 +60,7 @@ public class DemoDataSeeder(ApplicationDbContext db, UserManager<ApplicationUser
         await SeedLeagueJuiceMappingAsync(league);
         await SeedNflScoresAsync();
         await SeedDemoUsersAsync(league);
+        await SeedHistoricalWeeksAsync(league);
 
         Log.Information("DemoDataSeeder: seed complete");
     }
@@ -280,6 +281,97 @@ public class DemoDataSeeder(ApplicationDbContext db, UserManager<ApplicationUser
         }
         await db.SaveChangesAsync();
         Log.Information("DemoDataSeeder: seeded picks for {Username}", user.UserName);
+    }
+
+    // Historical weeks 1-7: same 4 games every week, home teams always cover
+    // Winning user picks: KC, DAL, PHI, BUF (all home = all cover)
+    // Losing user picks:  DEN, DAL, PHI, BUF (DEN = wrong = loss)
+    private static readonly string[] HistWinPicks = ["KC", "DAL", "PHI", "BUF"];
+    private static readonly string[] HistLosePicks = ["DEN", "DAL", "PHI", "BUF"];
+
+    // Win pattern per user per week (weeks 1-7, index 0-6); true = win that week
+    // Scoring: WeeklyCost=5. Week 5 = all win → carryover → WeeklyCost=10 for week 6.
+    // Result: Alice +95, frizat +65, Carlos +35, Bob -25, Dana/Eve -85
+    private static readonly Dictionary<string, bool[]> HistWinPatterns = new()
+    {
+        ["Alice"]  = [true,  true,  true,  true,  true, true,  true],
+        ["Bob"]    = [false, true,  false, false, true, true,  false],
+        ["Carlos"] = [true,  false, true,  false, true, true,  true],
+        ["Dana"]   = [false, false, true,  false, true, false, false],
+        ["Eve"]    = [false, false, false, true,  true, false, false],
+    };
+
+    private async Task SeedHistoricalWeeksAsync(LeagueInfo? league)
+    {
+        if (league == null) return;
+        if (await db.NflSpreads.AnyAsync(s => s.Season == DemoSeason && s.NflWeek == 1))
+            return;
+
+        var adminEmail = configuration["ADMIN_EMAIL"] ?? throw new InvalidOperationException("ADMIN_EMAIL required");
+        var adminUser = await userManager.FindByEmailAsync(adminEmail);
+        if (adminUser == null) return;
+
+        // Admin (frizat) win pattern: W W L W W W W
+        bool[] adminWins = [true, true, false, true, true, true, true];
+
+        // Build user list
+        var users = new List<(ApplicationUser User, bool[] Wins)> { (adminUser, adminWins) };
+        foreach (var (username, _) in DemoUsers)
+        {
+            var u = await userManager.FindByNameAsync(username);
+            if (u != null && HistWinPatterns.TryGetValue(username, out var pattern))
+                users.Add((u, pattern));
+        }
+
+        for (int week = 1; week <= 7; week++)
+        {
+            var weekGameTime = new DateTimeOffset(2023, 9, 4, 17, 0, 0, TimeSpan.Zero).AddDays((week - 1) * 7 + 3);
+
+            // NflWeeks
+            if (!await db.NflWeeks.AnyAsync(w => w.Season == DemoSeason && w.NflWeek == week))
+            {
+                var weekStart = new DateTimeOffset(2023, 9, 4, 0, 0, 0, TimeSpan.Zero).AddDays((week - 1) * 7);
+                db.NflWeeks.Add(new NflWeeks { Season = DemoSeason, NflWeek = week, StartDate = weekStart, EndDate = weekStart.AddDays(6) });
+                await db.SaveChangesAsync();
+            }
+            var nflWeek = await db.NflWeeks.FirstAsync(w => w.Season == DemoSeason && w.NflWeek == week);
+
+            // NflSpreads (4 games, home teams favored)
+            db.NflSpreads.AddRange(
+                new NflSpreads { Season = DemoSeason, NflWeek = week, HomeTeam = "KC",  AwayTeam = "DEN", HomeTeamSpread = -7.0, AwayTeamSpread = 7.0, OverUnder = 47.5, GameTime = weekGameTime },
+                new NflSpreads { Season = DemoSeason, NflWeek = week, HomeTeam = "DAL", AwayTeam = "CLE", HomeTeamSpread = -6.0, AwayTeamSpread = 6.0, OverUnder = 44.5, GameTime = weekGameTime },
+                new NflSpreads { Season = DemoSeason, NflWeek = week, HomeTeam = "PHI", AwayTeam = "NYG", HomeTeamSpread = -4.0, AwayTeamSpread = 4.0, OverUnder = 43.5, GameTime = weekGameTime },
+                new NflSpreads { Season = DemoSeason, NflWeek = week, HomeTeam = "BUF", AwayTeam = "NYJ", HomeTeamSpread = -3.0, AwayTeamSpread = 3.0, OverUnder = 46.5, GameTime = weekGameTime }
+            );
+
+            // NflScores (all home teams win and cover)
+            db.NflScores.AddRange(
+                new NflScores { Season = DemoSeason, NflWeek = week, HomeTeam = "KC",  AwayTeam = "DEN", HomeTeamScore = 24, AwayTeamScore = 14, GameTime = weekGameTime },
+                new NflScores { Season = DemoSeason, NflWeek = week, HomeTeam = "DAL", AwayTeam = "CLE", HomeTeamScore = 28, AwayTeamScore = 20, GameTime = weekGameTime },
+                new NflScores { Season = DemoSeason, NflWeek = week, HomeTeam = "PHI", AwayTeam = "NYG", HomeTeamScore = 20, AwayTeamScore = 13, GameTime = weekGameTime },
+                new NflScores { Season = DemoSeason, NflWeek = week, HomeTeam = "BUF", AwayTeam = "NYJ", HomeTeamScore = 17, AwayTeamScore = 10, GameTime = weekGameTime }
+            );
+            await db.SaveChangesAsync();
+
+            // NflPicks
+            int weekIdx = week - 1;
+            foreach (var (user, wins) in users)
+            {
+                var picks = wins[weekIdx] ? HistWinPicks : HistLosePicks;
+                foreach (var team in picks)
+                {
+                    db.NflPicks.Add(new NflPicks
+                    {
+                        UserId = user.Id, LeagueId = league.Id, Team = team,
+                        Pick = PickType.Spread, NflWeek = week, Season = DemoSeason,
+                        NflWeekId = nflWeek.Id, DateCreated = DateTimeOffset.UtcNow,
+                    });
+                }
+            }
+            await db.SaveChangesAsync();
+        }
+
+        Log.Information("DemoDataSeeder: seeded historical weeks 1-7 for {UserCount} users", users.Count);
     }
 
     private static NflSpreads Spread(string home, string away, double homeSpread, double awaySpread, double ou, string gameTimeUtc) =>

--- a/Server/Services/DemoDataSeeder.cs
+++ b/Server/Services/DemoDataSeeder.cs
@@ -57,9 +57,31 @@ public class DemoDataSeeder(ApplicationDbContext db, UserManager<ApplicationUser
         await SeedSpreadsAsync();
         var league = await SeedLeagueAsync();
         await SeedLeagueMemberAsync(league);
+        await SeedLeagueJuiceMappingAsync(league);
         await SeedDemoUsersAsync(league);
 
         Log.Information("DemoDataSeeder: seed complete");
+    }
+
+    private async Task SeedLeagueJuiceMappingAsync(LeagueInfo? league)
+    {
+        if (league == null) return;
+
+        if (await db.LeagueJuiceMapping.AnyAsync(m => m.LeagueId == league.Id && m.Season == DemoSeason))
+            return;
+
+        db.LeagueJuiceMapping.Add(new LeagueJuiceMapping
+        {
+            LeagueId = league.Id,
+            Season = DemoSeason,
+            Juice = 13,
+            JuiceDivisional = 10,
+            JuiceConference = 6,
+            WeeklyCost = 5,
+            DateCreated = DateTimeOffset.UtcNow,
+        });
+        await db.SaveChangesAsync();
+        Log.Information("DemoDataSeeder: created LeagueJuiceMapping for Demo League season {Season}", DemoSeason);
     }
 
     private async Task SeedNflWeekAsync()

--- a/Server/Services/DemoDataSeeder.cs
+++ b/Server/Services/DemoDataSeeder.cs
@@ -58,6 +58,7 @@ public class DemoDataSeeder(ApplicationDbContext db, UserManager<ApplicationUser
         var league = await SeedLeagueAsync();
         await SeedLeagueMemberAsync(league);
         await SeedLeagueJuiceMappingAsync(league);
+        await SeedNflScoresAsync();
         await SeedDemoUsersAsync(league);
 
         Log.Information("DemoDataSeeder: seed complete");
@@ -185,6 +186,24 @@ public class DemoDataSeeder(ApplicationDbContext db, UserManager<ApplicationUser
         db.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = league.Id, UserId = adminUser.Id });
         await db.SaveChangesAsync();
         Log.Information("DemoDataSeeder: added admin to Demo League");
+    }
+
+    private async Task SeedNflScoresAsync()
+    {
+        if (await db.NflScores.AnyAsync(s => s.Season == DemoSeason && s.NflWeek == DemoWeek))
+            return;
+
+        // 4 final games from frozen sample_espn_nfl.json for 2023 week 8
+        var scores = new List<NflScores>
+        {
+            new() { Season = DemoSeason, NflWeek = DemoWeek, HomeTeam = "DAL", AwayTeam = "LAR", HomeTeamScore = 28, AwayTeamScore = 20, GameTime = new DateTimeOffset(2023, 10, 29, 17, 0, 0, TimeSpan.Zero) },
+            new() { Season = DemoSeason, NflWeek = DemoWeek, HomeTeam = "GB",  AwayTeam = "MIN", HomeTeamScore = 17, AwayTeamScore = 24, GameTime = new DateTimeOffset(2023, 10, 29, 17, 0, 0, TimeSpan.Zero) },
+            new() { Season = DemoSeason, NflWeek = DemoWeek, HomeTeam = "MIA", AwayTeam = "NE",  HomeTeamScore = 31, AwayTeamScore = 17, GameTime = new DateTimeOffset(2023, 10, 29, 17, 0, 0, TimeSpan.Zero) },
+            new() { Season = DemoSeason, NflWeek = DemoWeek, HomeTeam = "WAS", AwayTeam = "PHI", HomeTeamScore = 7,  AwayTeamScore = 38, GameTime = new DateTimeOffset(2023, 10, 29, 17, 0, 0, TimeSpan.Zero) },
+        };
+        db.NflScores.AddRange(scores);
+        await db.SaveChangesAsync();
+        Log.Information("DemoDataSeeder: seeded {Count} final NflScores for week {Week}", scores.Count, DemoWeek);
     }
 
     private async Task SeedDemoUsersAsync(LeagueInfo? league)


### PR DESCRIPTION
## Summary
- Fix dark mode primary color — week selector button text now visible
- `FieldPosition` returns placeholder Box when null — all score cards same height
- `AppLayout` main gets `minHeight: 100vh` — gradient fills full viewport
- `RulesPage` and `PicksPage` wrapped in full-height `Card` — no gradient bleed at bottom
- Leaderboard: remove outer `Paper` wrapper — table renders on gradient like Scores page
- Demo seeder: seed `LeagueJuiceMapping`, 4 final `NflScores` (week 8), and 7 weeks of historical picks/scores for all 6 demo users so leaderboard shows realistic standings

## Test plan
- [ ] Dark mode: week selector buttons show visible text
- [ ] Scores page: all game cards same height
- [ ] Rules/Picks pages: card fills full viewport height
- [ ] Leaderboard: table on gradient background (no white box), 8 weeks of history in demo mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)