### PR TITLE
fix(ui): gradient consistency + picks page layout

### DIFF
--- a/Client.React/src/app/global.css
+++ b/Client.React/src/app/global.css
@@ -2,7 +2,7 @@
 
 :root {
   --bg-1: #f8fafc;
-  --bg-2: #e2e8f0;
+  --bg-2: #f1f4f8;
   --bg-3: #cbd5f5;
   --ink-1: #0f172a;
   --ink-2: #334155;
@@ -39,14 +39,20 @@ body {
   margin: 0;
   font-family: "Space Grotesk", "Segoe UI", system-ui, sans-serif;
   color: var(--ink-1);
-  background: radial-gradient(80% 50% at 10% -10%, var(--bg-3), transparent 60%),
-    radial-gradient(70% 45% at 90% -20%, #fde68a33, transparent 55%),
+  background: radial-gradient(80% 50% at 10% -10%, rgba(203, 213, 245, 0.25), transparent 60%),
+    radial-gradient(70% 45% at 90% -20%, rgba(253, 230, 138, 0.1), transparent 55%),
     linear-gradient(180deg, var(--bg-1), var(--bg-2));
   min-height: 100vh;
   -webkit-font-smoothing: antialiased;
   -webkit-touch-callout: none;
   -webkit-tap-highlight-color: transparent;
   transition: background 0.3s ease, color 0.3s ease;
+}
+
+[data-theme='dark'] body {
+  background: radial-gradient(80% 50% at 10% -10%, rgba(30, 58, 95, 0.5), transparent 60%),
+    radial-gradient(70% 45% at 90% -20%, rgba(253, 230, 138, 0.04), transparent 55%),
+    linear-gradient(180deg, var(--bg-1), var(--bg-2));
 }
 
 /* iOS safe area support */

--- a/Client.React/src/app/global.css
+++ b/Client.React/src/app/global.css
@@ -39,8 +39,8 @@ body {
   margin: 0;
   font-family: "Space Grotesk", "Segoe UI", system-ui, sans-serif;
   color: var(--ink-1);
-  background: radial-gradient(1200px 600px at 10% -10%, var(--bg-3), transparent 60%),
-    radial-gradient(900px 500px at 90% -20%, #fde68a33, transparent 55%),
+  background: radial-gradient(80% 50% at 10% -10%, var(--bg-3), transparent 60%),
+    radial-gradient(70% 45% at 90% -20%, #fde68a33, transparent 55%),
     linear-gradient(180deg, var(--bg-1), var(--bg-2));
   min-height: 100vh;
   -webkit-font-smoothing: antialiased;

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -298,6 +298,8 @@ export default function AppLayout() {
         component="main"
         sx={{
           flexGrow: 1,
+          display: 'flex',
+          flexDirection: 'column',
           p: { xs: 0, sm: 3 },
           width: { xs: '100%', md: `calc(100% - ${open ? drawerWidth : 0}px)` },
           minHeight: '100vh',
@@ -308,7 +310,7 @@ export default function AppLayout() {
         }}
       >
         <Toolbar />
-        <Box className="page-shell">
+        <Box className="page-shell" sx={{ flex: 1 }}>
           <Outlet />
         </Box>
       </Box>

--- a/Client.React/src/pages/PicksPage.tsx
+++ b/Client.React/src/pages/PicksPage.tsx
@@ -2,8 +2,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Button,
-  Card,
-  CardContent,
   CircularProgress,
   Grid,
   Paper,
@@ -343,8 +341,7 @@ export default function PicksPage() {
   if (!hasOdds) return <SpreadRelease />;
 
   return (
-    <Card sx={{ minHeight: 'calc(100vh - 128px)' }}>
-      <CardContent>
+    <Box>
       <PageHeader title="Picks" />
       {scores && (
         <Box sx={{ mb: 3 }}>
@@ -547,7 +544,6 @@ export default function PicksPage() {
             })
         )}
       </Grid>
-      </CardContent>
-    </Card>
+    </Box>
   );
 }


### PR DESCRIPTION
## Summary
- Remove `Card`/`CardContent` wrapper from PicksPage so it renders natively on the gradient (like ScoresPage)
- Fix AppLayout `page-shell` to always fill viewport height (`display:flex` column + `flex:1`) — prevents gradient cutoff on short-content pages
- Switch radial gradient sizes from fixed-px to viewport-percentage so coverage is consistent on all screen widths
- Reduce radial gradient opacities and lighten `--bg-2` endpoint to eliminate visible color bands on desktop/landscape
- Add `[data-theme='dark'] body` gradient override with dark-appropriate colors

## Test plan
- [ ] Portrait mobile: gradient looks clean top to bottom
- [ ] Desktop/landscape: no color blobs or gray bands at edges
- [ ] Dark mode: no lavender tint on dark background
- [ ] `npm run test -- --run` passes (145 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)