### PR TITLE
chore: rebrand FourPlay → IV League

### DIFF
--- a/Client.React/index.html
+++ b/Client.React/index.html
@@ -7,11 +7,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=yes, maximum-scale=5" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="FourPlay" />
+    <meta name="apple-mobile-web-app-title" content="IV League" />
     <meta name="theme-color" content="#1a2847" />
-    <meta name="description" content="FourPlay - Premium sports prediction league platform" />
+    <meta name="description" content="IV League - Private sports pick'em league. Pick against the spread, beat your friends." />
 
-    <title>FourPlay</title>
+    <title>IV League</title>
     <link rel="stylesheet" href="/Icons/Weather/css/weather-icons.min.css" />
     <link rel="stylesheet" href="https://unpkg.com/flipdown/dist/flipdown.css" />
   </head>

--- a/Client.React/src/__tests__/RulesPage.test.tsx
+++ b/Client.React/src/__tests__/RulesPage.test.tsx
@@ -13,7 +13,7 @@ function renderPage() {
 describe('RulesPage', () => {
   it('renders the page title', () => {
     renderPage();
-    expect(screen.getByText(/how fourplay works/i)).toBeInTheDocument();
+    expect(screen.getByText(/how iv league works/i)).toBeInTheDocument();
   });
 
   it('explains the 13-point tease mechanic', () => {

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -85,7 +85,7 @@ export default function AppLayout() {
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" sx={{ flexGrow: 1 }}>
-            FourPlay
+            IV League
           </Typography>
           <Stack direction="row" spacing={1} alignItems="center">
             <Typography variant="body2" sx={{ opacity: 0.8 }}>

--- a/Client.React/src/pages/HomePage.tsx
+++ b/Client.React/src/pages/HomePage.tsx
@@ -76,7 +76,7 @@ export default function HomePage() {
                 <Typography variant="h6" className="hero-subtitle">
                   {isAuthed
                     ? 'Your picks are waiting. Check the leaderboard and see where you stand.'
-                    : "FourPlay is what fantasy football should have been — no draft, no waiver wire, no dead lineups. Pick NFL games against the spread each week and watch the leaderboard."}
+                    : "IV League is what fantasy football should have been — no draft, no waiver wire, no dead lineups. Pick NFL games against the spread each week and watch the leaderboard."}
                 </Typography>
                 {!isAuthed && (
                   <Stack spacing={1} sx={{ mb: 3 }}>
@@ -156,7 +156,7 @@ export default function HomePage() {
               Fantasy Is Complicated. This Isn't.
             </Typography>
             <Typography variant="subtitle1" align="center" color="text.secondary" sx={{ mb: 5 }}>
-              You've been on a fantasy team that fell apart by Week 6. FourPlay goes all the way to the Super Bowl.
+              You've been on a fantasy team that fell apart by Week 6. IV League goes all the way to the Super Bowl.
             </Typography>
             <Grid container spacing={3}>
               <Grid size={{ xs: 12, md: 6 }}>
@@ -174,7 +174,7 @@ export default function HomePage() {
               </Grid>
               <Grid size={{ xs: 12, md: 6 }}>
                 <Paper elevation={3} sx={{ p: 3, borderRadius: 2, border: '2px solid', borderColor: 'secondary.main', height: '100%' }}>
-                  <Typography variant="h6" fontWeight={700} sx={{ mb: 2.5 }}>FourPlay</Typography>
+                  <Typography variant="h6" fontWeight={700} sx={{ mb: 2.5 }}>IV League</Typography>
                   <Stack spacing={1.5}>
                     {fourplayWins.map(item => (
                       <Stack key={item} direction="row" alignItems="center" spacing={1.5}>
@@ -237,7 +237,7 @@ export default function HomePage() {
                 Got an Invite? You're Ready.
               </Typography>
               <Typography variant="subtitle1" className="cta-subtitle">
-                FourPlay leagues are private and invite-only. If someone sent you a link, register below and you're in.
+                IV League is private and invite-only. If someone sent you a link, register below and you're in.
               </Typography>
               <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} justifyContent="center" sx={{ mb: 2 }}>
                 <Button
@@ -268,7 +268,7 @@ export default function HomePage() {
 
       <Dialog open={rulesOpen} onClose={() => setRulesOpen(false)} maxWidth="md" fullWidth scroll="paper">
         <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          How FourPlay Works
+          How IV League Works
           <IconButton onClick={() => setRulesOpen(false)} size="small">
             <CloseIcon />
           </IconButton>

--- a/Client.React/src/pages/RulesPage.tsx
+++ b/Client.React/src/pages/RulesPage.tsx
@@ -399,7 +399,7 @@ export default function RulesPage() {
       <CardContent>
         <Box sx={{ mb: 2 }}>
           <PageHeader
-            title="How FourPlay Works"
+            title="How IV League Works"
             subtitle="Pick four teased lines each week. Sounds easy — it isn't."
           />
         </Box>

--- a/Client.React/src/pages/account/LoginPage.tsx
+++ b/Client.React/src/pages/account/LoginPage.tsx
@@ -82,7 +82,7 @@ export default function LoginPage() {
             lineHeight: 1,
           }}
         >
-          FOURPLAY
+          IV LEAGUE
         </Typography>
         <Typography variant="h5" sx={{ fontWeight: 600 }}>
           Log in

--- a/Client.React/src/pages/admin/InvitationsPage.tsx
+++ b/Client.React/src/pages/admin/InvitationsPage.tsx
@@ -96,7 +96,7 @@ export default function AdminInvitationsPage() {
     <h1>You're Invited to Join!</h1>
     <p>Hello,</p>
     <p>
-      You've been invited to join FourPlay at <strong>${window.location.origin}</strong>.
+      You've been invited to join IV League at <strong>${window.location.origin}</strong>.
       Click the button below to create your account and get started.
     </p>
     <a href="${registrationUrl}" class="button">Create Your Account</a>
@@ -120,7 +120,7 @@ export default function AdminInvitationsPage() {
       toast.push(`Invitation created for ${email}`, 'success');
       await sendEmail({
         toEmail: invitation.email,
-        subject: 'FourPlay Invitation',
+        subject: 'IV League Invitation',
         htmlBody: generateInvitationEmailHtml(invitation),
       });
       await loadInvitations();
@@ -147,7 +147,7 @@ export default function AdminInvitationsPage() {
   const handleSendEmail = async (invitation: InvitationDto) => {
     await sendEmail({
       toEmail: invitation.email,
-      subject: 'FourPlay Invitation',
+      subject: 'IV League Invitation',
       htmlBody: generateInvitationEmailHtml(invitation),
     });
     toast.push(`Invitation e-mail sent to ${invitation.email}`, 'success');

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -95,7 +95,7 @@ else
 builder.Services.AddHttpClient<IJerseyCacheService, JerseyCacheService>(c => {
     c.BaseAddress = new Uri("https://www.gridiron-uniforms.com/GUD/");
     // Some servers dislike aggressive headers; set a reasonable user agent
-    c.DefaultRequestHeaders.UserAgent.ParseAdd("FourPlayJerseyCache/1.0");
+    c.DefaultRequestHeaders.UserAgent.ParseAdd("IVLeagueJerseyCache/1.0");
     c.DefaultRequestHeaders.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("text/html"));
 });
 #endregion

--- a/Server/Services/GoogleEmailSender.cs
+++ b/Server/Services/GoogleEmailSender.cs
@@ -26,7 +26,7 @@ public class GoogleEmailSender(ILogger<GoogleEmailSender> logger) : IEmailSender
 
         try {
             using var message = new MailMessage {
-                From = new MailAddress(_userName, "FourPlay"),
+                From = new MailAddress(_userName, "IV League"),
                 Subject = subject,
                 Body = htmlBody,
                 IsBodyHtml = true
@@ -61,7 +61,7 @@ public class GoogleEmailSender(ILogger<GoogleEmailSender> logger) : IEmailSender
                       <p>If you didn\u2019t create an account, you can safely ignore this message.</p>
                       """);
 
-        return SendEmailAsync(email, "Confirm your FourPlay email", body);
+        return SendEmailAsync(email, "Confirm your IV League email", body);
     }
 
     public Task SendPasswordResetLinkAsync(ApplicationUser user, string email, string resetLink) {
@@ -79,7 +79,7 @@ public class GoogleEmailSender(ILogger<GoogleEmailSender> logger) : IEmailSender
                       <p>If you didn’t request this change, you can safely ignore this email.</p>
                       """);
 
-        return SendEmailAsync(email, "Reset your FourPlay password", body);
+        return SendEmailAsync(email, "Reset your IV League password", body);
     }
 
     public async Task SendPasswordResetCodeAsync(ApplicationUser user, string email, string resetCode) {
@@ -97,11 +97,11 @@ public class GoogleEmailSender(ILogger<GoogleEmailSender> logger) : IEmailSender
                       <p>If you didn’t request this change, you can safely ignore this email.</p>
                       """);
 
-        await SendEmailAsync(email, "Your FourPlay password reset code", body);
+        await SendEmailAsync(email, "Your IV League password reset code", body);
     }
 
     /// <summary>
-    /// Send a simple templated notification using the FourPlay template.
+    /// Send a simple templated notification using the IV League template.
     /// Accepts an optional ApplicationUser to personalize the message, but is not required.
     /// </summary>
     public Task SendTemplatedMessageAsync(ApplicationUser? user, string email, string title, string message) {
@@ -116,7 +116,7 @@ public class GoogleEmailSender(ILogger<GoogleEmailSender> logger) : IEmailSender
     #region Private Template Helpers
 
     /// <summary>
-    /// Builds a unified FourPlay email layout with consistent design.
+    /// Builds a unified IV League email layout with consistent design.
     /// </summary>
     private static string BuildEmailTemplate(string title, string message) {
         var sb = new StringBuilder();
@@ -135,18 +135,18 @@ public class GoogleEmailSender(ILogger<GoogleEmailSender> logger) : IEmailSender
                 <table width="520" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 4px 12px rgba(0,0,0,0.08);">
                   <tr>
                     <td style="background-color:#4f46e5;padding:18px;text-align:center;color:#ffffff;font-size:22px;font-weight:bold;">
-                      FourPlay
+                      IV League
                     </td>
                   </tr>
                   <tr>
                     <td style="padding:36px 44px;color:#333333;font-size:15px;line-height:1.6;">
                       {message}
-                      <p style="margin-top:32px;font-size:13px;color:#777;text-align:center;">Thanks,<br/>The FourPlay Team</p>
+                      <p style="margin-top:32px;font-size:13px;color:#777;text-align:center;">Thanks,<br/>The IV League Team</p>
                     </td>
                   </tr>
                   <tr>
                     <td style="background-color:#f2f2f2;padding:14px;text-align:center;font-size:12px;color:#888888;">
-                      &copy; {DateTime.UtcNow.Year} FourPlay. All rights reserved.
+                      &copy; {DateTime.UtcNow.Year} IV League. All rights reserved.
                     </td>
                   </tr>
                 </table>
@@ -161,7 +161,7 @@ public class GoogleEmailSender(ILogger<GoogleEmailSender> logger) : IEmailSender
     }
 
     /// <summary>
-    /// Public wrapper for external callers that want the FourPlay HTML-wrapped body.
+    /// Public wrapper for external callers that want the IV League HTML-wrapped body.
     /// </summary>
     public static string CreateTemplatedBody(string title, string message) => BuildEmailTemplate(title, message);
 


### PR DESCRIPTION
## Summary
All user-visible "FourPlay" references updated to "IV League". Internal identifiers (C# namespaces, env vars, DB names, JWT issuer) unchanged.

**Changed:**
- Browser tab title, PWA title, meta description
- Nav bar, login page heading (`FOURPLAY` → `IV LEAGUE`)
- Homepage marketing copy
- Rules page header + rules dialog title
- Invite email subject + body copy
- Outgoing email From name, subjects, HTML template footer
- Jersey cache User-Agent string
- RulesPage test updated to match new heading

**Unchanged (internal only):**
- `FourPlayWebApp` C# namespaces
- `FOURPLAY_EMAIL_USER` / `FOURPLAY_EMAIL_PASS` env vars
- DB name `fourplay_dev`, git repo `fourplay_web`

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `npm run test -- --run` — 153 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)