### PR TITLE
feat(commissioner): portal, ownership guards, #95 owner invite, ESPN TTL fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,25 @@ Admin pages are at `/admin/leagueManagement` — **only visible to `isAdmin(user
 - Red → Green → Refactor is the only acceptable order
 - If you catch yourself writing code without a failing test, stop and write the test first
 
+### What Requires a Test (mandatory checklist per feature)
+Every new or changed feature MUST have all of the following before the bead is closeable:
+
+| What changed | Required test |
+|---|---|
+| New backend controller endpoint | xUnit test in `Server.UnitTests/` covering: happy path, auth/ownership 403, and any error branch |
+| New frontend pure function / helper | Vitest unit test in `src/__tests__/` covering edge cases |
+| New page or significant UI component | At minimum: one e2e-mock Playwright test in `e2e/` (happy path + empty/error state) |
+| New nav link or conditional UI element | Unit test asserting visibility rules (shown/hidden based on role/state) |
+| New API route added to routes.ts helpers | Verify mock is wired — if missing, `isLeagueOwner` / session state silently falls back to defaults |
+| Security guard (ownership/admin check) | xUnit test: Forbid for unauthorized caller, Ok for authorized caller, Ok for admin |
+| Pick reveal / game kickoff logic | Unit test: scheduled=hidden, in_progress=visible, own picks always visible, ESPN null=fail-open |
+
+### Common Test Gaps to Watch For
+- **Controller ownership guard** — every new `Forbid()` branch needs its own test; don't assume coverage from similar endpoints
+- **Session-derived flags** (`isLeagueOwner`, `ownedLeagues`, sport filter) — test in `session.test.tsx`, not just in e2e
+- **New page with no route in `routes.ts`** — will 404 silently in all existing e2e tests; add the mock
+- **Frontend pick reveal** — `revealPicksForStartedGames` is tested in `sportAdapter.test.ts`; if you change it, update those tests first
+
 ## CRITICAL: Branch Rules
 - **NEVER push or commit directly to `main`** — all changes go through a PR
 - Branch flow: `feature/*` → PR → `dev` → PR → `main`
@@ -128,7 +147,8 @@ Every new user-facing feature MUST have:
 
 ### Definition of Done
 A bead is closeable ONLY when:
-- Full test suite passes: `dotnet test` + `npm run test -- --run` (189+ tests) + `npm run test:e2e -- --project=chromium` (40+ tests)
+- Full test suite passes: `dotnet test` + `npm run test -- --run` (208+ tests) + `npm run test:e2e -- --project=chromium` (47+ tests)
+- Every item in the **mandatory checklist** above is satisfied
 - `/simplify` and `/feature-dev:code-review` have been run and issues addressed
 - PR merged to `dev`, then PR merged to `main`
 

--- a/Client.React/e2e/admin.spec.ts
+++ b/Client.React/e2e/admin.spec.ts
@@ -40,6 +40,38 @@ test.describe('Admin pages (administrator role)', () => {
   });
 
   // -----------------------------------------------------------------------
+  // CFB Schedule Config
+  // -----------------------------------------------------------------------
+  test('CFB Schedule Config page renders heading and ESPN Week column', async ({ page }) => {
+    await adminAuth(page, '/admin/cfb-schedule');
+    await waitForSpinner(page);
+
+    await expect(page.getByRole('heading', { name: /CFB Schedule Config/i })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('columnheader', { name: 'ESPN Week' })).toBeVisible({ timeout: 5000 });
+  });
+
+  // -----------------------------------------------------------------------
+  // League Management — dialogs
+  // -----------------------------------------------------------------------
+  test('League Management — Add League button opens Create League dialog', async ({ page }) => {
+    await adminAuth(page, '/admin/leagueManagement');
+    await waitForSpinner(page);
+
+    await page.getByRole('button', { name: /add league/i }).click();
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 3000 });
+    await expect(page.getByRole('dialog').getByRole('heading', { name: /create league/i })).toBeVisible({ timeout: 3000 });
+  });
+
+  test('League Management — Assign Owner button opens Assign Owner dialog', async ({ page }) => {
+    await adminAuth(page, '/admin/leagueManagement');
+    await waitForSpinner(page);
+
+    await page.getByRole('button', { name: /assign owner/i }).first().click();
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 3000 });
+    await expect(page.getByRole('dialog').getByRole('heading', { name: /assign owner/i })).toBeVisible({ timeout: 3000 });
+  });
+
+  // -----------------------------------------------------------------------
   // Non-admin is redirected away from admin pages
   // -----------------------------------------------------------------------
   test('non-admin user is redirected to dashboard', async ({ page }) => {

--- a/Client.React/e2e/helpers/routes.ts
+++ b/Client.React/e2e/helpers/routes.ts
@@ -243,6 +243,7 @@ export async function setupRoutes(page: Page, options: SetupRoutesOptions = {}):
             registeredUserName: null,
             isExpired: false,
             isValid: true,
+            isLeagueOwner: false,
           },
         ]),
       });
@@ -331,6 +332,23 @@ export async function setupRoutes(page: Page, options: SetupRoutesOptions = {}):
 
     if (url.match(/\/api\/league\/\d+\/invite$/) && method === 'POST') {
       void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+      return;
+    }
+
+    if (url.match(/\/api\/league\/\d+\/owner\//) && method === 'PUT') {
+      void route.fulfill({ status: 204 });
+      return;
+    }
+
+    // ── CFB week configs ───────────────────────────────────────────────────
+    if (url.includes('/api/cfb/week-configs/') && method === 'GET') {
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { espnWeekNumber: 1, ivLeagueWeekNumber: 1, weekType: 'RegularSeason', scoringFormat: 'Spread', inScopeIvLeague: true, weekStartDate: '2025-08-30', weekEndDate: '2025-09-01', notes: null },
+        ]),
+      });
       return;
     }
 

--- a/Client.React/e2e/helpers/routes.ts
+++ b/Client.React/e2e/helpers/routes.ts
@@ -295,6 +295,56 @@ export async function setupRoutes(page: Page, options: SetupRoutesOptions = {}):
       return;
     }
 
+    // ── Commissioner portal ────────────────────────────────────────────────
+    if (url.includes('/api/league/my-leagues') && method === 'GET') {
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          authUser.claims.some(c => c.value === 'Administrator')
+            ? []
+            : [{ id: TEST_LEAGUE_ID, leagueName: 'Test League', leagueType: 'Nfl', ownerUserId: authUser.userId, dateCreated: new Date().toISOString() }]
+        ),
+      });
+      return;
+    }
+
+    if (url.match(/\/api\/league\/\d+\/cost$/) && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ memberCount: 5, cost: 100 }) });
+      return;
+    }
+
+    if (url.match(/\/api\/league\/\d+\/juice$/) && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ id: 1, leagueId: TEST_LEAGUE_ID, season: TEST_SEASON, juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5 }]) });
+      return;
+    }
+
+    if (url.match(/\/api\/league\/\d+\/juice\//) && (method === 'PUT' || method === 'POST')) {
+      void route.fulfill({ status: 204 });
+      return;
+    }
+
+    if (url.match(/\/api\/league\/\d+\/members\//) && method === 'DELETE') {
+      void route.fulfill({ status: 204 });
+      return;
+    }
+
+    if (url.match(/\/api\/league\/\d+\/invite$/) && method === 'POST') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+      return;
+    }
+
+    if (url.match(/\/api\/league\/\d+\/users$/) && method === 'GET') {
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { id: 'u1', leagueId: TEST_LEAGUE_ID, userId: authUser.userId, userName: authUser.name, leagueName: 'Test League', leagueOwnerUserId: authUser.userId, leagueType: 0, dateCreated: new Date().toISOString() },
+        ]),
+      });
+      return;
+    }
+
     // Pass through anything else (shouldn't happen in happy path)
     void route.continue();
   });

--- a/Client.React/e2e/leaguePortal.spec.ts
+++ b/Client.React/e2e/leaguePortal.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import { mockAuth, waitForSpinner, TEST_USER, ADMIN_USER } from './helpers/auth';
+
+// TEST_USER is wired in routes.ts to own "Test League" (NFL) via /api/league/my-leagues
+const ownerAuth = (page: Parameters<typeof mockAuth>[0]) =>
+  mockAuth(page, { authUser: TEST_USER, navigateTo: '/league/manage' });
+
+// ADMIN_USER returns [] from /api/league/my-leagues — not an owner
+const nonOwnerAuth = (page: Parameters<typeof mockAuth>[0]) =>
+  mockAuth(page, { authUser: ADMIN_USER, navigateTo: '/league/manage' });
+
+test.describe('Commissioner portal (/league/manage)', () => {
+  test('league owner sees portal with My Leagues heading', async ({ page }) => {
+    await ownerAuth(page);
+    await waitForSpinner(page);
+
+    await expect(page.getByRole('heading', { name: /my leagues/i })).toBeVisible({ timeout: 5000 });
+  });
+
+  test('non-owner sees empty-state message instead of portal', async ({ page }) => {
+    await nonOwnerAuth(page);
+    await waitForSpinner(page);
+
+    await expect(page.getByText(/you don.t own any leagues/i)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('heading', { name: /my leagues/i })).not.toBeVisible();
+  });
+
+  test('Members tab loads and shows cost chip', async ({ page }) => {
+    await ownerAuth(page);
+    await waitForSpinner(page);
+
+    // Members tab is selected by default
+    await expect(page.getByRole('tab', { name: /members/i })).toBeVisible();
+    // Cost chip — 5 members · $100/season from mocked /cost endpoint
+    await expect(page.getByText(/\$100/)).toBeVisible({ timeout: 5000 });
+  });
+
+  test('Juice Settings tab loads existing juice values', async ({ page }) => {
+    await ownerAuth(page);
+    await waitForSpinner(page);
+
+    await page.getByRole('tab', { name: /juice settings/i }).click();
+    await waitForSpinner(page);
+
+    // Mocked juice: 13 pts tease — "Tease Pts (Regular Season)" label should be visible
+    await expect(page.getByLabel(/tease pts \(regular season\)/i)).toBeVisible({ timeout: 5000 });
+  });
+
+  test('My Leagues nav link is visible for league owner', async ({ page }) => {
+    await ownerAuth(page);
+    await waitForSpinner(page);
+
+    await expect(page.getByRole('link', { name: /my leagues/i })).toBeVisible({ timeout: 5000 });
+  });
+
+  test('My Leagues nav link is hidden for non-owner', async ({ page }) => {
+    await nonOwnerAuth(page);
+    await waitForSpinner(page);
+
+    await expect(page.getByRole('link', { name: /my leagues/i })).not.toBeVisible();
+  });
+
+  test('Invite dialog opens and accepts email input', async ({ page }) => {
+    await ownerAuth(page);
+    await waitForSpinner(page);
+
+    await page.getByRole('button', { name: /invite player/i }).click();
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 3000 });
+    await page.getByRole('dialog').getByRole('textbox').fill('newplayer@test.com');
+    await expect(page.getByRole('dialog').getByRole('textbox')).toHaveValue('newplayer@test.com');
+  });
+});

--- a/Client.React/src/__tests__/sportAccess.test.tsx
+++ b/Client.React/src/__tests__/sportAccess.test.tsx
@@ -25,6 +25,8 @@ const sessionState = {
   hasNflAccess: true,
   hasCfbAccess: true,
   leaguesLoaded: true,
+  isLeagueOwner: false,
+  ownedLeagues: [] as { id: number; leagueName: string; leagueType: string; ownerUserId: string; dateCreated: string }[],
 };
 vi.mock('../services/session', () => ({ useSession: () => sessionState }));
 
@@ -46,7 +48,7 @@ describe('Sport access control', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Reset to defaults
-    Object.assign(sessionState, { currentLeague: 1, hasNflAccess: true, hasCfbAccess: true, leaguesLoaded: true });
+    Object.assign(sessionState, { currentLeague: 1, hasNflAccess: true, hasCfbAccess: true, leaguesLoaded: true, isLeagueOwner: false, ownedLeagues: [] });
     Object.assign(sportContext, { sport: 'NFL', isCfb: false, isNfl: true });
   });
 
@@ -89,5 +91,17 @@ describe('Sport access control', () => {
     renderLayout();
     expect(screen.getByText(/No.*access/i)).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /Go to/i })).not.toBeInTheDocument();
+  });
+
+  it('isLeagueOwner nav link is visible when user owns a league', () => {
+    sessionState.isLeagueOwner = true;
+    renderLayout();
+    expect(screen.getByRole('link', { name: /my leagues/i })).toBeInTheDocument();
+  });
+
+  it('isLeagueOwner nav link is hidden when user does not own a league', () => {
+    sessionState.isLeagueOwner = false;
+    renderLayout();
+    expect(screen.queryByRole('link', { name: /my leagues/i })).not.toBeInTheDocument();
   });
 });

--- a/Client.React/src/__tests__/sportAdapter.test.ts
+++ b/Client.React/src/__tests__/sportAdapter.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { revealPicksForStartedGames } from '../services/sportAdapter';
+import type { GameView, PickView } from '../services/sportAdapter';
+
+function makeGame(id: string, status: GameView['gameStatus']): GameView {
+  return {
+    id,
+    homeTeam: 'HME',
+    awayTeam: 'AWY',
+    homeSpread: null,
+    awaySpread: null,
+    overUnder: null,
+    homeScore: null,
+    awayScore: null,
+    gameStatus: status,
+    gameTime: new Date().toISOString(),
+  };
+}
+
+function makePick(gameId: string, userId: string): PickView {
+  return { gameId, team: 'HME', pickType: 'Spread', userId, userName: userId };
+}
+
+const ME = 'user-me';
+const OTHER = 'user-other';
+
+describe('revealPicksForStartedGames', () => {
+  it('hides other users picks for scheduled games', () => {
+    const games = [makeGame('g1', 'scheduled')];
+    const picks = [makePick('g1', ME), makePick('g1', OTHER)];
+
+    const result = revealPicksForStartedGames(picks, games, ME);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].userId).toBe(ME);
+  });
+
+  it('reveals other users picks once game is in_progress', () => {
+    const games = [makeGame('g1', 'in_progress')];
+    const picks = [makePick('g1', ME), makePick('g1', OTHER)];
+
+    const result = revealPicksForStartedGames(picks, games, ME);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('reveals other users picks for halftime games', () => {
+    const games = [makeGame('g1', 'halftime')];
+    const picks = [makePick('g1', ME), makePick('g1', OTHER)];
+
+    const result = revealPicksForStartedGames(picks, games, ME);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('reveals other users picks for final games', () => {
+    const games = [makeGame('g1', 'final')];
+    const picks = [makePick('g1', ME), makePick('g1', OTHER)];
+
+    const result = revealPicksForStartedGames(picks, games, ME);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('always shows the callers own picks regardless of game status', () => {
+    const games = [makeGame('g1', 'scheduled')];
+    const picks = [makePick('g1', ME)];
+
+    const result = revealPicksForStartedGames(picks, games, ME);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].userId).toBe(ME);
+  });
+
+  it('handles mixed week — hides other picks for scheduled, reveals for started', () => {
+    const games = [makeGame('g1', 'scheduled'), makeGame('g2', 'in_progress')];
+    const picks = [
+      makePick('g1', OTHER), // scheduled — hidden
+      makePick('g2', OTHER), // in_progress — visible
+      makePick('g1', ME),    // own pick — always visible
+    ];
+
+    const result = revealPicksForStartedGames(picks, games, ME);
+
+    expect(result).toHaveLength(2);
+    expect(result.some(p => p.userId === OTHER && p.gameId === 'g2')).toBe(true);
+    expect(result.some(p => p.userId === OTHER && p.gameId === 'g1')).toBe(false);
+  });
+
+  it('treats null gameStatus as not started — hides other picks', () => {
+    const games = [makeGame('g1', null)];
+    const picks = [makePick('g1', ME), makePick('g1', OTHER)];
+
+    const result = revealPicksForStartedGames(picks, games, ME);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].userId).toBe(ME);
+  });
+
+  it('returns empty array when no picks exist', () => {
+    const games = [makeGame('g1', 'in_progress')];
+    const result = revealPicksForStartedGames([], games, ME);
+    expect(result).toHaveLength(0);
+  });
+});

--- a/Client.React/src/__tests__/sportAdapter.test.ts
+++ b/Client.React/src/__tests__/sportAdapter.test.ts
@@ -13,7 +13,7 @@ function makeGame(id: string, status: GameView['gameStatus']): GameView {
     homeScore: null,
     awayScore: null,
     gameStatus: status,
-    gameTime: new Date().toISOString(),
+    gameTime: new Date(Date.now() + 3_600_000).toISOString(), // 1 hour in the future by default
   };
 }
 
@@ -101,5 +101,20 @@ describe('revealPicksForStartedGames', () => {
     const games = [makeGame('g1', 'in_progress')];
     const result = revealPicksForStartedGames([], games, ME);
     expect(result).toHaveLength(0);
+  });
+
+  it('reveals picks when status is scheduled but game time has already passed', () => {
+    const pastGame = { ...makeGame('g1', 'scheduled'), gameTime: new Date(Date.now() - 60_000).toISOString() };
+    const picks = [makePick('g1', ME), makePick('g1', OTHER)];
+    const result = revealPicksForStartedGames(picks, [pastGame], ME);
+    expect(result).toHaveLength(2);
+  });
+
+  it('hides picks when status is scheduled and game time is still in the future', () => {
+    const futureGame = { ...makeGame('g1', 'scheduled'), gameTime: new Date(Date.now() + 60_000).toISOString() };
+    const picks = [makePick('g1', ME), makePick('g1', OTHER)];
+    const result = revealPicksForStartedGames(picks, [futureGame], ME);
+    expect(result).toHaveLength(1);
+    expect(result[0].userId).toBe(ME);
   });
 });

--- a/Client.React/src/api/invitations.ts
+++ b/Client.React/src/api/invitations.ts
@@ -11,9 +11,9 @@ export async function getInvitationsByUser(userId: string) {
   return data;
 }
 
-export async function createInvitation(email: string, invitedByUserId: string, leagueId?: number | null) {
+export async function createInvitation(email: string, invitedByUserId: string, leagueId?: number | null, isLeagueOwner?: boolean) {
   const { data } = await http.post<InvitationDto>('/api/invitations', undefined, {
-    params: { email, invitedByUserId, ...(leagueId != null ? { leagueId } : {}) },
+    params: { email, invitedByUserId, ...(leagueId != null ? { leagueId } : {}), ...(isLeagueOwner ? { isLeagueOwner } : {}) },
   });
   return data;
 }

--- a/Client.React/src/pages/admin/InvitationsPage.tsx
+++ b/Client.React/src/pages/admin/InvitationsPage.tsx
@@ -7,12 +7,14 @@ import {
   Chip,
   CircularProgress,
   FormControl,
+  FormControlLabel,
   IconButton,
   InputLabel,
   MenuItem,
   Paper,
   Select,
   Stack,
+  Switch,
   Table,
   TableBody,
   TableCell,
@@ -39,6 +41,7 @@ export default function AdminInvitationsPage() {
   const [showExpired, setShowExpired] = useState(true);
   const [email, setEmail] = useState('');
   const [selectedLeagueId, setSelectedLeagueId] = useState<number | ''>('');
+  const [isLeagueOwner, setIsLeagueOwner] = useState(false);
   const [leagues, setLeagues] = useState<LeagueUserMappingDto[]>([]);
   const [creating, setCreating] = useState(false);
   const toast = useToast();
@@ -116,7 +119,7 @@ export default function AdminInvitationsPage() {
     setCreating(true);
     try {
       const leagueId = selectedLeagueId !== '' ? selectedLeagueId : null;
-      const invitation = await createInvitation(email, user.userId, leagueId);
+      const invitation = await createInvitation(email, user.userId, leagueId, leagueId != null ? isLeagueOwner : false);
       toast.push(`Invitation created for ${email}`, 'success');
       await sendEmail({
         toEmail: invitation.email,
@@ -125,6 +128,7 @@ export default function AdminInvitationsPage() {
       });
       await loadInvitations();
       setEmail('');
+      setIsLeagueOwner(false);
     } catch {
       toast.push('Error creating invitation', 'error');
     } finally {
@@ -215,6 +219,16 @@ export default function AdminInvitationsPage() {
                 ))}
               </Select>
             </FormControl>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={isLeagueOwner}
+                  onChange={(e) => setIsLeagueOwner(e.target.checked)}
+                  disabled={selectedLeagueId === ''}
+                />
+              }
+              label="Make commissioner"
+            />
             <Button variant="contained" onClick={handleCreateInvitation} disabled={creating}>
               {creating ? 'Inviting...' : 'Invite'}
             </Button>
@@ -246,6 +260,7 @@ export default function AdminInvitationsPage() {
                 <TableCell>Date Created</TableCell>
                 <TableCell>Email</TableCell>
                 <TableCell>League</TableCell>
+                <TableCell>Commissioner?</TableCell>
                 <TableCell>Status</TableCell>
                 <TableCell>Expires</TableCell>
                 <TableCell>Used By</TableCell>
@@ -258,6 +273,7 @@ export default function AdminInvitationsPage() {
                   <TableCell>{new Date(invitation.createdAt).toLocaleString()}</TableCell>
                   <TableCell>{invitation.email}</TableCell>
                   <TableCell>{invitation.leagueName ?? '-'}</TableCell>
+                  <TableCell>{invitation.isLeagueOwner ? <Chip size="small" label="Yes" color="warning" /> : '-'}</TableCell>
                   <TableCell>
                     {invitation.isUsed ? (
                       <Chip size="small" label="Used" color="success" />

--- a/Client.React/src/services/sportAdapter.ts
+++ b/Client.React/src/services/sportAdapter.ts
@@ -8,8 +8,17 @@ export type GameStatusValue = 'final' | 'in_progress' | 'halftime' | 'scheduled'
  * the write-side kickoff lock in AddPicks.
  */
 export function revealPicksForStartedGames(allPicks: PickView[], games: GameView[], userId: string): PickView[] {
+  const now = new Date();
   const startedIds = new Set(
-    games.filter(g => g.gameStatus !== 'scheduled' && g.gameStatus !== null).map(g => g.id)
+    games
+      .filter(g => {
+        // ESPN confirmed the game is underway or finished
+        if (g.gameStatus !== 'scheduled' && g.gameStatus !== null) return true;
+        // ESPN still says scheduled but kickoff time has passed — cache is stale
+        if (g.gameStatus === 'scheduled' && g.gameTime != null && new Date(g.gameTime) <= now) return true;
+        return false;
+      })
+      .map(g => g.id)
   );
   return allPicks.filter(p => p.userId === userId || startedIds.has(p.gameId));
 }

--- a/Client.React/src/types/admin.ts
+++ b/Client.React/src/types/admin.ts
@@ -63,6 +63,7 @@ export interface InvitationDto {
   isValid: boolean;
   leagueId?: number | null;
   leagueName?: string | null;
+  isLeagueOwner: boolean;
 }
 
 export interface EmailRequest {

--- a/Server.UnitTests/InvitationLeagueTests.cs
+++ b/Server.UnitTests/InvitationLeagueTests.cs
@@ -190,6 +190,104 @@ public class InvitationLeagueTests
         Assert.Empty(db.LeagueUserMapping);
     }
 
+    // ── IsLeagueOwner tests (#95) ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateInvitation_StoresIsLeagueOwner_WhenTrue()
+    {
+        var db = BuildDb(nameof(CreateInvitation_StoresIsLeagueOwner_WhenTrue));
+        var service = new InvitationService(BuildFactory(db));
+
+        var result = await service.CreateInvitationAsync("owner@example.com", "admin-1", leagueId: 5, isLeagueOwner: true);
+
+        Assert.True(result.IsLeagueOwner);
+    }
+
+    [Fact]
+    public async Task CreateUser_SetsLeagueOwner_WhenInvitationIsLeagueOwner()
+    {
+        var db = BuildDb(nameof(CreateUser_SetsLeagueOwner_WhenInvitationIsLeagueOwner));
+        // Seed an existing league with a placeholder owner
+        db.LeagueInfo.Add(new LeagueInfo { Id = 5, LeagueName = "Test League", OwnerUserId = "original-owner", LeagueType = FourPlayWebApp.Shared.Models.Enum.LeagueType.Nfl });
+        await db.SaveChangesAsync();
+
+        var userManager = BuildUserManager();
+        var invitationService = Substitute.For<IInvitationService>();
+        var config = Substitute.For<IConfiguration>();
+
+        var invitation = new Invitation
+        {
+            Id = 1,
+            InvitationCode = "owner-code",
+            Email = "newowner@example.com",
+            LeagueId = 5,
+            IsLeagueOwner = true,
+            ExpiresAt = DateTime.UtcNow.AddDays(7),
+        };
+
+        invitationService.ValidateInvitationAsync("owner-code").Returns(invitation);
+        invitationService.MarkInvitationAsUsedAsync("owner-code", Arg.Any<string>()).Returns(true);
+        userManager.FindByEmailAsync("newowner@example.com").Returns((ApplicationUser?)null);
+        userManager.CreateAsync(Arg.Any<ApplicationUser>(), Arg.Any<string>()).Returns(IdentityResult.Success);
+        userManager.GenerateEmailConfirmationTokenAsync(Arg.Any<ApplicationUser>()).Returns("token");
+        config["App:BaseUrl"].Returns("http://localhost");
+
+        var controller = BuildAuthController(userManager, invitationService, config, db);
+        await controller.CreateUser(new CreateUserRequest
+        {
+            Username = "newowner",
+            Email = "newowner@example.com",
+            Password = "Pass@123",
+            Code = "owner-code",
+        });
+
+        var league = await db.LeagueInfo.FindAsync(5);
+        Assert.NotNull(league);
+        Assert.NotEqual("original-owner", league.OwnerUserId);
+    }
+
+    [Fact]
+    public async Task CreateUser_DoesNotSetLeagueOwner_WhenIsLeagueOwnerFalse()
+    {
+        var db = BuildDb(nameof(CreateUser_DoesNotSetLeagueOwner_WhenIsLeagueOwnerFalse));
+        db.LeagueInfo.Add(new LeagueInfo { Id = 5, LeagueName = "Test League", OwnerUserId = "original-owner", LeagueType = FourPlayWebApp.Shared.Models.Enum.LeagueType.Nfl });
+        await db.SaveChangesAsync();
+
+        var userManager = BuildUserManager();
+        var invitationService = Substitute.For<IInvitationService>();
+        var config = Substitute.For<IConfiguration>();
+
+        var invitation = new Invitation
+        {
+            Id = 2,
+            InvitationCode = "player-code",
+            Email = "player@example.com",
+            LeagueId = 5,
+            IsLeagueOwner = false,
+            ExpiresAt = DateTime.UtcNow.AddDays(7),
+        };
+
+        invitationService.ValidateInvitationAsync("player-code").Returns(invitation);
+        invitationService.MarkInvitationAsUsedAsync("player-code", Arg.Any<string>()).Returns(true);
+        userManager.FindByEmailAsync("player@example.com").Returns((ApplicationUser?)null);
+        userManager.CreateAsync(Arg.Any<ApplicationUser>(), Arg.Any<string>()).Returns(IdentityResult.Success);
+        userManager.GenerateEmailConfirmationTokenAsync(Arg.Any<ApplicationUser>()).Returns("token");
+        config["App:BaseUrl"].Returns("http://localhost");
+
+        var controller = BuildAuthController(userManager, invitationService, config, db);
+        await controller.CreateUser(new CreateUserRequest
+        {
+            Username = "player",
+            Email = "player@example.com",
+            Password = "Pass@123",
+            Code = "player-code",
+        });
+
+        var league = await db.LeagueInfo.FindAsync(5);
+        Assert.NotNull(league);
+        Assert.Equal("original-owner", league.OwnerUserId);
+    }
+
     // ── Builder ───────────────────────────────────────────────────────────────
 
     private static AuthController BuildAuthController(

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -1,4 +1,5 @@
 using FourPlayWebApp.Server.Controllers;
+using FourPlayWebApp.Server.Models;
 using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Interfaces;
@@ -307,5 +308,103 @@ public class LeagueOwnershipTests
 
         var leagues = Assert.IsAssignableFrom<IEnumerable<LeagueInfoDto>>(result!.Value);
         Assert.Equal(2, leagues.Count());
+    }
+
+    [Fact]
+    public async Task GetLeagueUserMappings_ReturnsForbid_WhenCallerIsNotOwnerOrAdmin()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
+
+        var result = await ctrl.GetLeagueUserMappings(1);
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetLeagueUserMappings_ReturnsOk_WhenCallerIsOwner()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
+        repo.GetLeagueUserMappingsAsync(1).Returns(
+        [
+            new LeagueUserMapping
+            {
+                LeagueId = 1,
+                UserId = OwnerId,
+                League = new LeagueInfo { Id = 1, LeagueName = "L", OwnerUserId = OwnerId, LeagueType = LeagueType.Nfl },
+                User = new ApplicationUser { Id = OwnerId, UserName = "owner" },
+            },
+        ]);
+
+        var result = await ctrl.GetLeagueUserMappings(1);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+        await repo.Received(1).GetLeagueUserMappingsAsync(1);
+    }
+
+    [Fact]
+    public async Task InviteToLeague_ReturnsForbid_WhenCallerIsNotOwnerOrAdmin()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
+
+        var result = await ctrl.InviteToLeague(1, new LeagueInviteDto("target@example.com"));
+
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public async Task InviteToLeague_ReturnsOk_WhenCallerIsOwner()
+    {
+        var invSvc = Substitute.For<IInvitationService>();
+        invSvc.CreateInvitationAsync("target@example.com", OwnerId, 1)
+              .Returns(new Invitation { Id = 1, Email = "target@example.com", InvitationCode = "code-abc" });
+
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
+
+        var store = Substitute.For<IUserStore<ApplicationUser>>();
+        var userManager = Substitute.For<UserManager<ApplicationUser>>(
+            store, null, null, null, null, null, null, null, null);
+        var ctrl = new LeagueController(
+            new MemoryCache(new MemoryCacheOptions()),
+            repo,
+            NullLogger<LeagueController>.Instance,
+            userManager,
+            Substitute.For<ISpreadCalculatorBuilder>(),
+            Substitute.For<IEspnCacheService>(),
+            invSvc);
+        ctrl.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = BuildPrincipal(OwnerId) }
+        };
+
+        var result = await ctrl.InviteToLeague(1, new LeagueInviteDto("target@example.com"));
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task AssignLeagueOwner_CallsRepo_WhenCallerIsAdmin()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId, isAdmin: true));
+
+        var result = await ctrl.AssignLeagueOwner(1, "new-owner");
+
+        Assert.IsType<NoContentResult>(result);
+        await repo.Received(1).UpdateLeagueOwnerAsync(1, "new-owner");
+    }
+
+    [Fact]
+    public async Task CreateLeague_ReturnsConflict_WhenLeagueNameAlreadyExists()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId, isAdmin: true));
+        repo.LeagueExistsAsync(Arg.Any<string>()).Returns(true);
+
+        var dto = new LeagueCreateDto("Existing League", LeagueType.Nfl, OwnerId, 2025, 13, 10, 6, 5);
+        var result = await ctrl.CreateLeague(dto);
+
+        Assert.IsType<ConflictObjectResult>(result);
     }
 }

--- a/Server.UnitTests/PicksTests.cs
+++ b/Server.UnitTests/PicksTests.cs
@@ -523,4 +523,55 @@ public class PicksTests
         var returned = Assert.IsAssignableFrom<IEnumerable<NflPickDto>>(ok.Value).ToList();
         Assert.Equal(2, returned.Count);
     }
+
+    /// <summary>
+    /// ESPN says STATUS_SCHEDULED but the scheduled kickoff time is in the past — the
+    /// cache is just stale. Picks must be revealed because the game has de facto started.
+    /// </summary>
+    [Fact]
+    public async Task GetLeaguePicks_ShowsOtherPicksForScheduledStatus_WhenKickoffTimeHasPassed()
+    {
+        var repo = BuildRepoWithPicks(
+            MakeNflPick(UserId,      "BUF"),
+            MakeNflPick(OtherUserId, "MIA"));
+
+        // Build a stale-cache scenario: ESPN still says SCHEDULED but Date is 30 min ago
+        var staleScheduled = new EspnScores
+        {
+            Events =
+            [
+                new Event
+                {
+                    Id = "e1", Season = new Season { Year = Season, Type = 2 }, Week = new Week { Number = Week },
+                    Date = DateTimeOffset.UtcNow.AddMinutes(-30),
+                    Competitions =
+                    [
+                        new Competition
+                        {
+                            Id = "c1", Date = DateTimeOffset.UtcNow.AddMinutes(-30),
+                            Competitors =
+                            [
+                                new Competitor { Team = new EspnTeam { Abbreviation = "BUF" }, HomeAway = HomeAway.Home },
+                                new Competitor { Team = new EspnTeam { Abbreviation = "MIA" }, HomeAway = HomeAway.Away }
+                            ],
+                            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Completed = false } },
+                            Odds = []
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var espn = Substitute.For<IEspnCacheService>();
+        espn.GetScoresAsync().Returns(staleScheduled);
+
+        var controller = BuildController(repo, espn, BuildPrincipal(UserId));
+
+        var result = await controller.GetLeaguePicks(LeagueId, Season, Week);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var returned = Assert.IsAssignableFrom<IEnumerable<NflPickDto>>(ok.Value).ToList();
+        // Both picks must be visible — the game has kicked off even though ESPN cache is stale
+        Assert.Equal(2, returned.Count);
+    }
 }

--- a/Server/Controllers/AuthController.cs
+++ b/Server/Controllers/AuthController.cs
@@ -290,6 +290,14 @@ public class AuthController(
                 LeagueId = invitation.LeagueId.Value,
                 UserId = newUser.Id,
             });
+
+            if (invitation.IsLeagueOwner)
+            {
+                var leagueInfo = await db.LeagueInfo.FindAsync(invitation.LeagueId.Value);
+                if (leagueInfo is not null)
+                    leagueInfo.OwnerUserId = newUser.Id;
+            }
+
             await db.SaveChangesAsync();
         }
 

--- a/Server/Controllers/InvitationController.cs
+++ b/Server/Controllers/InvitationController.cs
@@ -28,9 +28,9 @@ public class InvitationController(IInvitationService invitationService, IEmailSe
     }
 
     [HttpPost]
-    public async Task<ActionResult<InvitationDto>> Create([FromQuery] string email, [FromQuery] string invitedByUserId, [FromQuery] int? leagueId = null)
+    public async Task<ActionResult<InvitationDto>> Create([FromQuery] string email, [FromQuery] string invitedByUserId, [FromQuery] int? leagueId = null, [FromQuery] bool isLeagueOwner = false)
     {
-        var invitation = await invitationService.CreateInvitationAsync(email, invitedByUserId, leagueId);
+        var invitation = await invitationService.CreateInvitationAsync(email, invitedByUserId, leagueId, isLeagueOwner);
         return CreatedAtAction(nameof(GetAll), new { id = invitation.Id }, invitation.ToDto());
     }
 

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -304,7 +304,7 @@ public class LeagueController(
             if (espnScores?.Events is not null) {
                 var notStartedTeams = espnScores.Events
                     .SelectMany(e => e.Competitions)
-                    .Where(c => c.Status?.Type?.Name == TypeName.StatusScheduled)
+                    .Where(c => c.Status?.Type?.Name == TypeName.StatusScheduled && c.Date > DateTimeOffset.UtcNow)
                     .SelectMany(c => c.Competitors.Select(comp => comp.Team?.Abbreviation))
                     .Where(a => a is not null)
                     .ToHashSet(StringComparer.OrdinalIgnoreCase)!;

--- a/Server/Migrations/20260701154823_AddInvitation_IsLeagueOwner.Designer.cs
+++ b/Server/Migrations/20260701154823_AddInvitation_IsLeagueOwner.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701154823_AddInvitation_IsLeagueOwner")]
+    partial class AddInvitation_IsLeagueOwner
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/20260701154823_AddInvitation_IsLeagueOwner.cs
+++ b/Server/Migrations/20260701154823_AddInvitation_IsLeagueOwner.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInvitation_IsLeagueOwner : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsLeagueOwner",
+                table: "Invitations",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsLeagueOwner",
+                table: "Invitations");
+        }
+    }
+}

--- a/Server/Models/Invitation.cs
+++ b/Server/Models/Invitation.cs
@@ -33,6 +33,8 @@ public class Invitation
 
     public DateTimeOffset? ExpiresAt { get; set; } = DateTimeOffset.UtcNow.AddDays(7);
 
+    public bool IsLeagueOwner { get; set; } = false;
+
     public bool IsUsed { get; set; } = false;
 
     public DateTimeOffset? UsedAt { get; set; }

--- a/Server/Models/Mappers/InvitationMapper.cs
+++ b/Server/Models/Mappers/InvitationMapper.cs
@@ -22,7 +22,8 @@ public static class InvitationMapper
             IsExpired = invitation.IsExpired,
             IsValid = invitation.IsValid,
             LeagueId = invitation.LeagueId,
-            LeagueName = invitation.League?.LeagueName
+            LeagueName = invitation.League?.LeagueName,
+            IsLeagueOwner = invitation.IsLeagueOwner
         };
     }
 

--- a/Server/Services/Interfaces/IInvitationService.cs
+++ b/Server/Services/Interfaces/IInvitationService.cs
@@ -15,7 +15,7 @@ public interface IInvitationService
     /// <param name="email">Email to invite</param>
     /// <param name="invitedByUserId">User ID of the person sending the invite</param>
     /// <returns>The created invitation</returns>
-    Task<Invitation> CreateInvitationAsync(string email, string invitedByUserId, int? leagueId = null);
+    Task<Invitation> CreateInvitationAsync(string email, string invitedByUserId, int? leagueId = null, bool isLeagueOwner = false);
 
     /// <summary>
     /// Validate if the invitation code is valid

--- a/Server/Services/InvitationService.cs
+++ b/Server/Services/InvitationService.cs
@@ -21,7 +21,7 @@ public class InvitationService(IDbContextFactory<ApplicationDbContext> dbContext
         Log.Information("Invitation with ID {Id} deleted", id);
     }
 
-    public async Task<Invitation> CreateInvitationAsync(string email, string invitedByUserId, int? leagueId = null)
+    public async Task<Invitation> CreateInvitationAsync(string email, string invitedByUserId, int? leagueId = null, bool isLeagueOwner = false)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync();
 
@@ -30,6 +30,7 @@ public class InvitationService(IDbContextFactory<ApplicationDbContext> dbContext
             Email = email,
             InvitedByUserId = invitedByUserId,
             LeagueId = leagueId,
+            IsLeagueOwner = isLeagueOwner,
             CreatedAt = DateTimeOffset.UtcNow,
             ExpiresAt = DateTimeOffset.UtcNow.AddDays(7)
         };

--- a/Shared/Models/Data/Dtos/InvitationDto.cs
+++ b/Shared/Models/Data/Dtos/InvitationDto.cs
@@ -19,4 +19,5 @@ public class InvitationDto
     public bool IsValid { get; set; }
     public int? LeagueId { get; set; }
     public string? LeagueName { get; set; }
+    public bool IsLeagueOwner { get; set; }
 }


### PR DESCRIPTION
## Summary

- **Commissioner portal** (`/league/manage`) — league owners can manage members, juice settings, and invite players without needing global admin access
- **#95 — League owner invite flag** — admins can designate a new user as commissioner at invite time; `Invitation.IsLeagueOwner` auto-assigns `LeagueInfo.OwnerUserId` on registration (no 2-step manual reassignment)
- **ESPN cache TTL pick-reveal fix** — picks are now revealed as soon as the scheduled kickoff time passes, not up to 5 min later when the cache refreshes
- **Server-side pick reveal gate** — `GetLeaguePicks` now enforces the same scheduled-game hide rule as the frontend, so direct API callers can't bypass it
- **Security tightening** — `GET /{leagueId}/users`, `POST /{leagueId}/invite`, `UpdateJuice`, `RemoveMember` all gate on owner-or-admin; IDOR fixed on `GetLeagueUserMappingsForUser`
- **Test coverage** — 296 xUnit / 212 Vitest / 50 Playwright (all green); TDD checklist added to CLAUDE.md

## Closes
- GH #59 — Commissioner portal
- GH #95 — League owner invite type
- GH #96 — Ownership security guards

## Test plan
- [ ] `dotnet test` — 296 passed
- [ ] `npm run test -- --run` — 212 passed
- [ ] `npm run test:e2e -- --project=chromium` — 50 passed
- [ ] `npm run typecheck` — clean
- [ ] Manual: log in as admin, create invitation with "Make commissioner" toggle ON for a league, register via the invite link, verify the user appears as league owner in `/league/manage`
- [ ] Manual: verify other users' picks are hidden until game time passes (not until ESPN cache refreshes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)