### PR TITLE
feat(frizat-mon5): React Query PicksPage — invisible polls, pending picks preserved

### DIFF
--- a/Client.React/src/__tests__/leaderboard.test.tsx
+++ b/Client.React/src/__tests__/leaderboard.test.tsx
@@ -25,6 +25,7 @@ import { getLeaderboard } from '../api/leaderboard';
 const mockedGetLeaderboard = vi.mocked(getLeaderboard);
 
 const mockAdapter: SportAdapter = {
+  sport: 'nfl',
   loadCurrentGames: vi.fn(),
   loadHistoricalGames: vi.fn(),
   loadCurrentScores: vi.fn(),

--- a/Client.React/src/__tests__/picks.test.tsx
+++ b/Client.React/src/__tests__/picks.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import PicksPage from '../pages/PicksPage';
 import { createNflAdapter } from '../services/nflAdapter';
 import { createCompetition, createPick, createScores, createSpreadResponse } from '../test/fixtures';
@@ -104,8 +105,15 @@ const setupDefaults = async (options?: {
   });
 };
 
+const renderWithClient = (ui: React.ReactElement) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+};
+
 const renderPage = async () => {
-  render(<PicksPage adapter={createNflAdapter()} />);
+  renderWithClient(<PicksPage adapter={createNflAdapter()} />);
   await screen.findByText(/^Picks$/i);
   await waitFor(() => expect(screen.queryByRole('progressbar')).toBeNull());
 };
@@ -127,13 +135,13 @@ describe('PicksPage', () => {
   it('shows no league message when no league selected', async () => {
     sessionState.currentLeague = null;
     await setupDefaults();
-    render(<PicksPage adapter={createNflAdapter()} />);
+    renderWithClient(<PicksPage adapter={createNflAdapter()} />);
     await screen.findByText(/Please select a league/i);
   });
 
   it('shows odds not posted when odds missing', async () => {
     await setupDefaults({ oddsExist: false });
-    render(<PicksPage adapter={createNflAdapter()} />);
+    renderWithClient(<PicksPage adapter={createNflAdapter()} />);
     await screen.findByText(/Odds Not Posted/i);
   });
 
@@ -373,6 +381,97 @@ describe('PicksPage', () => {
     controls.forEach((control) => {
       expect(within(control).getByRole('button', { name: /^Over$/i })).toBeInTheDocument();
       expect(within(control).getByRole('button', { name: /^Under$/i })).toBeInTheDocument();
+    });
+  });
+
+  // ── Background refresh behavior (frizat-mon.5) ─────────────────────────────
+  // The poll refetch must be invisible: no spinner, and pending (unsubmitted)
+  // selections must survive. NFL poll interval is 300s (nflAdapter.pollIntervalMs).
+  describe('background poll refresh', () => {
+    const POLL_MS = 300_000;
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('preserves pending picks across a background poll refetch', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      await setupDefaults();
+      await renderPage();
+
+      await user.click(screen.getAllByRole('button', { name: /^Pick$/i })[0]);
+      await screen.findByRole('button', { name: /picked/i });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(POLL_MS);
+      });
+
+      expect(screen.getAllByRole('button', { name: /picked/i }).length).toBe(1);
+    });
+
+    it('does not show the full-page spinner during a background refetch', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      await setupDefaults();
+      await renderPage();
+
+      // Hold the next fetch in-flight forever so we can observe mid-refetch UI
+      mockedLoadScoresWithRetry.mockImplementation(() => new Promise(() => {}));
+      mockedGetScores.mockImplementation(() => new Promise(() => {}));
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(POLL_MS);
+      });
+
+      // Grid stays mounted, no spinner replaces the page
+      expect(screen.queryByRole('progressbar')).toBeNull();
+      expect(screen.getAllByRole('button', { name: /^Pick$/i }).length).toBeGreaterThan(0);
+    });
+
+    it('drops a pending pick with a toast when its game locks during refetch', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const futureDate = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
+      await setupDefaults({ gameDate: futureDate });
+      await renderPage();
+
+      await user.click(screen.getAllByRole('button', { name: /^Pick$/i })[0]);
+      await screen.findByRole('button', { name: /picked/i });
+
+      // Next poll: same games but kickoff has passed
+      const pastDate = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+      const startedScores = createScores({
+        week: 2,
+        postSeason: false,
+        events: [
+          {
+            id: '1',
+            season: { year: 2024, type: 2 },
+            week: { number: 2 },
+            date: pastDate,
+            competitions: [createCompetition({ homeTeam: 'BUF', awayTeam: 'MIA', gameStarted: true, date: pastDate })],
+          },
+          {
+            id: '2',
+            season: { year: 2024, type: 2 },
+            week: { number: 2 },
+            date: pastDate,
+            competitions: [createCompetition({ homeTeam: 'DAL', awayTeam: 'NYG', gameStarted: true, date: pastDate })],
+          },
+        ],
+      });
+      mockedGetScores.mockResolvedValue(startedScores);
+      mockedLoadScoresWithRetry.mockResolvedValue(startedScores);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(POLL_MS);
+      });
+
+      expect(screen.queryByRole('button', { name: /picked/i })).toBeNull();
+      expect(toastState.push).toHaveBeenCalledWith(
+        expect.stringMatching(/game.*(started|kicked off)/i),
+        expect.anything(),
+      );
     });
   });
 });

--- a/Client.React/src/__tests__/sharedPickLayout.test.tsx
+++ b/Client.React/src/__tests__/sharedPickLayout.test.tsx
@@ -3,8 +3,14 @@
  * If either adapter stops returning GameCard-renderable data, these tests fail.
  */
 import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { vi } from 'vitest';
 import PicksPage from '../pages/PicksPage';
+
+const renderWithClient = (ui: React.ReactElement) => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: Infinity } } });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+};
 import { createCfbAdapter } from '../services/cfbAdapter';
 import { createNflAdapter } from '../services/nflAdapter';
 import type { CfbSlateDto, CfbSpreadDto } from '../types/league';
@@ -55,12 +61,12 @@ describe('NFL PicksPage — GameCard layout regression', () => {
   });
 
   it('renders Pick buttons (GameCard pick mode)', async () => {
-    render(<PicksPage adapter={createNflAdapter()} />);
+    renderWithClient(<PicksPage adapter={createNflAdapter()} />);
     await waitFor(() => expect(screen.getAllByRole('button', { name: /^pick$/i }).length).toBeGreaterThan(0));
   });
 
   it('renders spread label -3 (GameCard spread display)', async () => {
-    render(<PicksPage adapter={createNflAdapter()} />);
+    renderWithClient(<PicksPage adapter={createNflAdapter()} />);
     await waitFor(() => expect(screen.getByText('-3')).toBeInTheDocument());
   });
 });
@@ -98,12 +104,12 @@ describe('CFB PicksPage (via adapter) — GameCard layout regression', () => {
   });
 
   it('renders Pick buttons (GameCard pick mode)', async () => {
-    render(<PicksPage adapter={createCfbAdapter()} />);
+    renderWithClient(<PicksPage adapter={createCfbAdapter()} />);
     await waitFor(() => expect(screen.getAllByRole('button', { name: /^pick$/i }).length).toBeGreaterThan(0));
   });
 
   it('renders spread labels -3.5 and +3.5 (GameCard spread display)', async () => {
-    render(<PicksPage adapter={createCfbAdapter()} />);
+    renderWithClient(<PicksPage adapter={createCfbAdapter()} />);
     await waitFor(() => {
       expect(screen.getByText('-3.5')).toBeInTheDocument();
       expect(screen.getByText('+3.5')).toBeInTheDocument();
@@ -111,7 +117,7 @@ describe('CFB PicksPage (via adapter) — GameCard layout regression', () => {
   });
 
   it('renders TeamHelmet for both teams', async () => {
-    render(<PicksPage adapter={createCfbAdapter()} />);
+    renderWithClient(<PicksPage adapter={createCfbAdapter()} />);
     await waitFor(() => {
       expect(screen.getByTestId('helmet-MICH')).toBeInTheDocument();
       expect(screen.getByTestId('helmet-PSU')).toBeInTheDocument();
@@ -122,7 +128,7 @@ describe('CFB PicksPage (via adapter) — GameCard layout regression', () => {
     vi.mocked(getCfbUserPicks).mockResolvedValue([
       { id: 1, userId: 'u1', userName: 'u1', leagueId: 1, cfbSlateId: 1, espnEventId: 100, team: 'MICH', pickType: 'Spread', season: 2025 }
     ]);
-    render(<PicksPage adapter={createCfbAdapter()} />);
+    renderWithClient(<PicksPage adapter={createCfbAdapter()} />);
     await waitFor(() => expect(screen.getByRole('button', { name: /^picked$/i })).toBeInTheDocument());
   });
 });

--- a/Client.React/src/pages/PicksPage.tsx
+++ b/Client.React/src/pages/PicksPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Button,
@@ -8,6 +8,7 @@ import {
   Typography,
 } from '@mui/material';
 import CheckroomIcon from '@mui/icons-material/Checkroom';
+import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
 import PageHeader from '../components/PageHeader';
 import WeekYearSelector from '../components/WeekYearSelector';
 import NoLeague from '../components/NoLeague';
@@ -36,115 +37,73 @@ export default function PicksPage({ adapter }: PicksPageProps) {
   const { currentLeague, leaguesLoaded } = useSession();
   const { user } = useAuth();
   const toast = useToast();
+  const queryClient = useQueryClient();
 
-  const [loading, setLoading] = useState(true);
-  const [games, setGames] = useState<GameView[]>([]);
-  const [hasOdds, setHasOdds] = useState(false);
-  const [requiredPicks, setRequiredPicks] = useState(4);
-  const [isPostSeason, setIsPostSeason] = useState(false);
-  const [week, setWeek] = useState(0);
-  const [season, setSeason] = useState(new Date().getFullYear());
-  const [existingPicks, setExistingPicks] = useState<Set<string>>(new Set());
+  // null = live current week (polls in background); non-null = historical navigation
+  const [weekState, setWeekState] = useState<WeekState | null>(null);
+  // Pending (unsubmitted) selections — local state only, never touched by refetches
   const [userPicks, setUserPicks] = useState<Set<string>>(new Set());
   const [storingPicks, setStoringPicks] = useState(false);
   const [showJerseys, setShowJerseys] = useState(false);
-  const [jerseyCache, setJerseyCache] = useState<Record<string, string>>({});
-  const [isCurrentWeek, setIsCurrentWeek] = useState(true);
-  const [maxWeek, setMaxWeek] = useState(adapter.weekSelectorConfig.maxRegularSeasonWeek);
-  const [maxSeason, setMaxSeason] = useState(adapter.weekSelectorConfig.minSeason);
-  const [isPageVisible, setIsPageVisible] = useState(true);
 
-  function applyLoaded(loaded: { games: GameView[]; hasOdds: boolean; requiredPicks: number; season: number; week: number; isPostSeason: boolean; existingPicks?: Set<string> }) {
-    setGames(loaded.games);
-    setHasOdds(loaded.hasOdds);
-    setRequiredPicks(loaded.requiredPicks);
-    setSeason(loaded.season);
-    setWeek(loaded.week);
-    setIsPostSeason(loaded.isPostSeason);
-    if (loaded.existingPicks !== undefined) {
-      setExistingPicks(loaded.existingPicks);
-    }
-    setUserPicks(new Set());
-  }
+  const isCurrentWeek = weekState === null;
+  const enabled = leaguesLoaded && !!currentLeague && !!user?.userId;
 
-  const reload = useCallback(async () => {
-    if (!currentLeague || !user?.userId) {
-      setLoading(false);
-      return;
-    }
-    setLoading(true);
-    try {
-      const result = await adapter.loadCurrentGames(currentLeague, user.userId);
-      const ep = new Set(result.userPicks.map(p => pickKey(p.gameId, p.team, p.pickType)));
-      applyLoaded({ ...result, existingPicks: ep });
-      setIsCurrentWeek(true);
-      setMaxWeek(result.maxWeek);
-      setMaxSeason(result.maxSeason);
-      if (adapter.loadJerseys) {
-        adapter.loadJerseys(result.season, result.week).then(setJerseyCache).catch(() => {});
-      }
-    } catch (err) {
-      console.error('[PicksPage] loadCurrentGames failed:', err);
-    } finally {
-      setLoading(false);
-    }
-  }, [currentLeague, user?.userId, adapter]);
+  const { data, isLoading } = useQuery({
+    queryKey: [adapter.sport, 'picks', currentLeague, user?.userId, weekState],
+    queryFn: () => weekState
+      ? adapter.loadHistoricalGames(currentLeague!, user!.userId, weekState)
+      : adapter.loadCurrentGames(currentLeague!, user!.userId),
+    enabled,
+    refetchInterval: isCurrentWeek && adapter.pollIntervalMs > 0 ? adapter.pollIntervalMs : false,
+    placeholderData: keepPreviousData,
+  });
 
-  const loadHistoricalWeek = useCallback(async (state: WeekState) => {
-    if (!currentLeague || !user?.userId) return;
-    setLoading(true);
-    try {
-      const result = await adapter.loadHistoricalGames(currentLeague, user.userId, state);
-      if (!result) {
-        setGames([]);
-        setHasOdds(false);
-        return;
-      }
-      const ep = new Set(result.userPicks.map(p => pickKey(p.gameId, p.team, p.pickType)));
-      applyLoaded({ ...result, existingPicks: ep });
-      if (adapter.loadJerseys) {
-        adapter.loadJerseys(result.season, result.week).then(setJerseyCache).catch(() => {});
-      }
-    } finally {
-      setLoading(false);
-    }
-  }, [currentLeague, user?.userId, adapter]);
+  const games = useMemo(() => data?.games ?? [], [data]);
+  const hasOdds = data?.hasOdds ?? false;
+  const requiredPicks = data?.requiredPicks ?? 4;
+  const season = weekState?.season ?? data?.season ?? new Date().getFullYear();
+  const week = weekState?.week ?? data?.week ?? 0;
+  const isPostSeason = weekState?.isPostSeason ?? data?.isPostSeason ?? false;
+  const maxWeek = data?.maxWeek ?? adapter.weekSelectorConfig.maxRegularSeasonWeek;
+  const maxSeason = data?.maxSeason ?? adapter.weekSelectorConfig.minSeason;
 
-  // Page visibility
+  const existingPicks = useMemo(
+    () => new Set((data?.userPicks ?? []).map(p => pickKey(p.gameId, p.team, p.pickType))),
+    [data],
+  );
+
+  // Reconcile pending selections after each (background) refresh: drop only picks
+  // that are now submitted server-side or whose game has locked since selection.
   useEffect(() => {
-    const handler = () => setIsPageVisible(!document.hidden);
-    document.addEventListener('visibilitychange', handler);
-    return () => document.removeEventListener('visibilitychange', handler);
-  }, []);
+    if (!data) return;
+    const lockedIds = new Set(games.filter(gameIsLocked).map(g => g.id));
+    const kept = [...userPicks].filter(k => !existingPicks.has(k) && !lockedIds.has(k.split('|')[0]));
+    if (kept.length === userPicks.size) return;
+    const droppedByLock = [...userPicks].some(k => !existingPicks.has(k) && lockedIds.has(k.split('|')[0]));
+    setUserPicks(new Set(kept));
+    if (droppedByLock) toast.push('Selection removed — game already kicked off', 'warning');
+  }, [data, games, existingPicks, userPicks, toast]);
 
-  // Load + polling
-  useEffect(() => {
-    if (!isCurrentWeek || !isPageVisible || !leaguesLoaded) return;
-    void reload();
-    if (adapter.pollIntervalMs <= 0) return;
-    const interval = setInterval(() => void reload(), adapter.pollIntervalMs);
-    return () => clearInterval(interval);
-  }, [reload, isCurrentWeek, isPageVisible, leaguesLoaded, adapter.pollIntervalMs]);
+  const { data: jerseyCache = {} } = useQuery({
+    queryKey: [adapter.sport, 'jerseys', data?.season, data?.week],
+    queryFn: () => adapter.loadJerseys!(data!.season, data!.week),
+    enabled: !!adapter.loadJerseys && !!data,
+    staleTime: Infinity,
+    retry: false,
+  });
 
   const handleWeekChange = useCallback((newWeek: number, meta?: { isPostSeason?: boolean }) => {
-    const ps = meta?.isPostSeason ?? isPostSeason;
-    setWeek(newWeek);
-    setIsPostSeason(ps);
-    setIsCurrentWeek(false);
-    void loadHistoricalWeek({ season, week: newWeek, isPostSeason: ps });
-  }, [isPostSeason, season, loadHistoricalWeek]);
+    setWeekState({ season, week: newWeek, isPostSeason: meta?.isPostSeason ?? isPostSeason });
+  }, [season, isPostSeason]);
 
   const handleSeasonChange = useCallback((newSeason: number) => {
-    setSeason(newSeason);
-    setIsCurrentWeek(false);
-    void loadHistoricalWeek({ season: newSeason, week, isPostSeason });
-  }, [week, isPostSeason, loadHistoricalWeek]);
+    setWeekState({ season: newSeason, week, isPostSeason });
+  }, [week, isPostSeason]);
 
-  const handleSeasonTypeChange = useCallback((ps: boolean) => {
-    // WeekYearSelector.handleSeasonTypeSelect also calls onWeekChange with the last available
-    // week — that handleWeekChange call loads the correct historical week. Don't double-load here.
-    setIsPostSeason(ps);
-    setIsCurrentWeek(false);
+  const handleSeasonTypeChange = useCallback((_ps: boolean) => {
+    // WeekYearSelector.handleSeasonTypeSelect also calls onWeekChange with the last
+    // available week and meta.isPostSeason — that call drives the load. No-op here.
   }, []);
 
   // Pick management
@@ -175,7 +134,7 @@ export default function PicksPage({ adapter }: PicksPageProps) {
       await adapter.submitPicks(currentLeague, { season, week, isPostSeason }, picks);
       toast.push(`${picks.length} Pick(s) Added`, 'success');
       setUserPicks(new Set());
-      await reload();
+      await queryClient.invalidateQueries({ queryKey: [adapter.sport, 'picks', currentLeague] });
     } catch {
       toast.push('Error Adding Picks', 'error');
     } finally {
@@ -188,7 +147,8 @@ export default function PicksPage({ adapter }: PicksPageProps) {
     setUserPicks(new Set());
   };
 
-  if (loading) return (
+  // First load only — background refetches (polling, SSE-adjacent) keep the grid mounted
+  if (!leaguesLoaded || isLoading) return (
     <Box><PageHeader title="Picks" />
       <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}><CircularProgress /></Box>
     </Box>
@@ -220,7 +180,7 @@ export default function PicksPage({ adapter }: PicksPageProps) {
           />
           {!isCurrentWeek && (
             <Box sx={{ display: 'flex', justifyContent: 'center', mt: -1, mb: 1 }}>
-              <Button size="small" variant="outlined" onClick={() => { setIsCurrentWeek(true); void reload(); }}>
+              <Button size="small" variant="outlined" onClick={() => setWeekState(null)}>
                 Current Week
               </Button>
             </Box>

--- a/Client.React/src/services/cfbAdapter.ts
+++ b/Client.React/src/services/cfbAdapter.ts
@@ -195,6 +195,7 @@ export function createCfbAdapter(): SportAdapter {
   }
 
   return {
+    sport: 'cfb',
     pollIntervalMs: 60_000,
     weekSelectorConfig: {
       regularWeekOptions: CFB_REGULAR_WEEKS,

--- a/Client.React/src/services/nflAdapter.ts
+++ b/Client.React/src/services/nflAdapter.ts
@@ -116,6 +116,7 @@ async function buildSituationMap(events: Event[]): Promise<Map<string, import('.
 
 export function createNflAdapter(): SportAdapter {
   return {
+    sport: 'nfl',
     pollIntervalMs: 300_000,
     sseUrl: `${import.meta.env.VITE_API_TARGET ?? ''}/api/espn/live-stream`,
     weekSelectorConfig: {

--- a/Client.React/src/services/sportAdapter.ts
+++ b/Client.React/src/services/sportAdapter.ts
@@ -93,6 +93,8 @@ export interface SportAdapter {
   loadHistoricalScores(leagueId: number, userId: string, week: WeekState): Promise<LoadedScores | null>;
 
   // Shared config
+  /** Stable sport identifier — used as the React Query cache key prefix */
+  sport: 'nfl' | 'cfb';
   pollIntervalMs: number;
   /** SSE endpoint URL for live score push. Undefined on adapters that don't support it (e.g. CFB). */
   sseUrl?: string;

--- a/docs/design/react-query-decision.md
+++ b/docs/design/react-query-decision.md
@@ -1,0 +1,98 @@
+# Design: React Query — Adopt (scoped), don't remove
+
+**Bead:** frizat-mon.1 · **Epic:** frizat-mon · **Date:** 2026-07-27 · **Author:** Claude (Fable 5)
+
+## Decision
+
+**Adopt `@tanstack/react-query` for the two polling pages (PicksPage, ScoresPage).**
+LeaderboardPage and session.tsx stay hand-rolled (one-shot loads; no benefit).
+Do not remove the dependency — it is already installed and provider-wired in `main.tsx`.
+
+## Why not remove it
+
+The minimal hand-rolled fix for the poll bugs (~15 lines/page: a `firstLoad` ref +
+preserving `userPicks`) leaves three problems:
+
+1. **Three copies of the same machinery.** PicksPage and ScoresPage each hand-roll
+   loading state, `setInterval` polling, page-visibility pause, and current-vs-historical
+   week juggling. ScoresPage additionally hand-rolls SSE-triggered reloads and a data
+   fingerprint hack (`fp(prev) === fp(result)`, ScoresPage.tsx:84-85) added to fight
+   re-render churn — evidence the hand-rolled path has already cost debugging time.
+2. **The pending-picks wipe is a symptom of mixed state.** `applyLoaded` owns both
+   server data and local selection state, so every refresh resets `userPicks`
+   (PicksPage.tsx:67). Any hand-rolled fix must remember to thread pending state
+   through every reload path, forever.
+3. **The dep is already paid for.** Bundle cost is sunk; `QueryClient` is instantiated;
+   removal is its own PR with zero user-facing benefit.
+
+## What RQ buys, mapped to current bugs
+
+| Current bug / hack | RQ mechanism |
+|---|---|
+| Poll flashes full-page spinner (both pages) | `isLoading` (first load only) vs `isFetching` (background) — render spinner only on `isLoading` |
+| Poll wipes pending picks (PicksPage.tsx:67) | Server data lives in query cache; pending `userPicks` stays in `useState` — refetch never touches it |
+| SSE event → spinner flash (ScoresPage.tsx:139) | `es.onmessage = () => queryClient.invalidateQueries({ queryKey })` — background refetch, no loading state change |
+| Page-visibility pause effect (both pages) | `refetchIntervalInBackground: false` (default) + `refetchOnWindowFocus` |
+| Fingerprint identity hack (ScoresPage.tsx:84-85) | RQ structural sharing keeps referential identity when data is unchanged — delete the hack |
+| Week navigation refetches everything, blanks page | `queryKey: [sport, 'scores', leagueId, season, week, isPostSeason]` + `placeholderData: keepPreviousData` — cached weeks render instantly |
+| Adaptive poll interval (active games 1× vs 4×) | `refetchInterval: (query) => query.state.data?.hasActiveGames ? base : base * 4` |
+
+## Migration plan
+
+### Step 1 — PicksPage (bead frizat-mon.5, do first)
+
+- Replace `reload`/`loadHistoricalWeek`/`loading`/`games`/etc. state with:
+  ```ts
+  const weekState = isCurrentWeek ? null : { season, week, isPostSeason };
+  const { data, isLoading } = useQuery({
+    queryKey: [adapter.sport, 'picks', currentLeague, user?.userId, weekState],
+    queryFn: () => weekState
+      ? adapter.loadHistoricalGames(currentLeague!, user!.userId, weekState)
+      : adapter.loadCurrentGames(currentLeague!, user!.userId),
+    enabled: leaguesLoaded && !!currentLeague && !!user?.userId,
+    refetchInterval: weekState ? false : adapter.pollIntervalMs,
+  });
+  ```
+- `existingPicks` derives from `data.userPicks` via `useMemo` — not `useState`.
+- Pending `userPicks` remains `useState<Set<string>>` — untouched by refetch.
+- On submit success: `queryClient.invalidateQueries({ queryKey: [adapter.sport, 'picks'] })`
+  replaces manual `reload()`.
+- Conflict rule: `useMemo` drops pending keys that now exist in `existingPicks` or whose
+  game became locked (toast once via effect).
+- Jersey cache: separate `useQuery` keyed `[sport, 'jerseys', season, week]`,
+  `staleTime: Infinity`.
+
+### Step 2 — ScoresPage
+
+- Same queryKey shape with `'scores'`; move SSE effect to
+  `invalidateQueries` instead of `reload()`; delete fingerprint hack and
+  visibility effect; keep `refetchInterval` callback for the active-games 1×/4× logic.
+- The "historical week == frozen current week" special case (ScoresPage.tsx:102-111)
+  survives as-is inside the queryFn selection.
+
+### Step 3 — (optional, later) LeaderboardPage / session
+
+Only if a concrete need appears (e.g. caching leaderboards across league switches).
+Not part of this epic.
+
+## Test impact
+
+- **Vitest:** wrap rendered pages in a `QueryClientProvider` test helper
+  (`src/test/`, `new QueryClient({ defaultOptions: { queries: { retry: false } } })`).
+  Existing assertions about rendered games/picks stay valid; assertions that spy on
+  reload timing change to waiting on rendered output (`findBy*`), which is what most
+  already do.
+- **e2e (mock + demo):** unaffected — RQ still issues the same HTTP requests through
+  axios/fetch; `page.route` interception in `e2e/helpers/routes.ts` works unchanged.
+- **New red-first tests for mon.5** (write before migrating):
+  1. pending picks survive a background refetch,
+  2. background refetch does not unmount the grid (no spinner),
+  3. pending pick on a game that became locked is dropped with a toast.
+
+## Risks
+
+- **Query key discipline:** current-week vs historical must be part of the key or
+  navigation will show stale week data. Mitigated by the `weekState` pattern above.
+- **Double-fetch on mount in StrictMode dev:** expected RQ behavior, harmless.
+- **`enabled` guards:** the `!currentLeague → <NoLeague/>` early return must come
+  before using `data`, same as today.


### PR DESCRIPTION
## Summary

- Replaces hand-rolled `reload()` polling in `PicksPage` with `useQuery` + `refetchInterval` so background refetches are invisible (no full-page spinner, no pick wipe)
- `userPicks` (pending, unsubmitted selections) is separate `useState` — React Query cache never touches it
- `keepPreviousData` keeps the current week's grid mounted while a historical week loads (no flash of empty state on week navigation)
- Reconciliation `useEffect` drops pending picks only when their game locks mid-session, firing a warning toast
- Jersey cache uses `staleTime: Infinity` (content-addressed by season+week)
- `adapter.sport` field added to `SportAdapter` as stable React Query cache key prefix
- Design decision doc added at `docs/design/react-query-decision.md`

## Test plan

- [x] 3 new TDD tests (red-first): `preserves pending picks across background poll`, `no full-page spinner during refetch`, `drops pick with toast on game lock`
- [x] `npm run test -- --run` — 215/215 pass
- [x] ESLint + TypeScript typecheck pass (pre-commit hooks)
- [x] Live verification on demo stack (NFL): initial load, Conf. Champ navigation, Current Week cache hit — zero spinner flash at any point, picks intact throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)