### PR TITLE
chore(frizat-mon2): gitignore memory/ and .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -371,3 +371,7 @@ $RECYCLE.BIN/
 Client.React/coverage/
 Client.React/playwright-report/
 Client.React/test-results/
+
+# Claude Code
+memory/
+.claude/worktrees/


### PR DESCRIPTION
## Summary

- Adds `memory/` and `.claude/worktrees/` to `.gitignore` so Claude Code session files can never be accidentally committed via `git add -A`
- `settings.local.json` is already covered by the global gitignore (`~/.config/git/ignore`) — no changes needed there

🤖 Generated with [Claude Code](https://claude.com/claude-code)