### PR TITLE
fix(frizat-mon3): CORS fails fast when ALLOWED_ORIGINS unset outside Development

### DIFF
--- a/Server.UnitTests/CorsStartupValidationTests.cs
+++ b/Server.UnitTests/CorsStartupValidationTests.cs
@@ -1,0 +1,48 @@
+using FourPlayWebApp.Server.Infrastructure;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+public class CorsStartupValidationTests
+{
+    [Fact]
+    public void ParseAndValidateCorsOrigins_ThrowsInProduction_WhenEmpty()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => StartupValidation.ParseAndValidateCorsOrigins(null, isDevelopment: false));
+        Assert.Contains("ALLOWED_ORIGINS", ex.Message);
+    }
+
+    [Fact]
+    public void ParseAndValidateCorsOrigins_ThrowsInProduction_WhenWhitespace()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => StartupValidation.ParseAndValidateCorsOrigins("  ", isDevelopment: false));
+        Assert.Contains("ALLOWED_ORIGINS", ex.Message);
+    }
+
+    [Fact]
+    public void ParseAndValidateCorsOrigins_SucceedsInDevelopment_WhenEmpty()
+    {
+        var result = StartupValidation.ParseAndValidateCorsOrigins(null, isDevelopment: true);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ParseAndValidateCorsOrigins_ParsesOrigins_InProduction()
+    {
+        var result = StartupValidation.ParseAndValidateCorsOrigins(
+            "https://ivleague.com, https://cfb.ivleague.com", isDevelopment: false);
+        Assert.Equal(2, result.Length);
+        Assert.Contains("https://ivleague.com", result);
+        Assert.Contains("https://cfb.ivleague.com", result);
+    }
+
+    [Fact]
+    public void ParseAndValidateCorsOrigins_ParsesOrigins_InDevelopment()
+    {
+        var result = StartupValidation.ParseAndValidateCorsOrigins(
+            "http://localhost:5173", isDevelopment: true);
+        Assert.Single(result);
+        Assert.Equal("http://localhost:5173", result[0]);
+    }
+}

--- a/Server/Infrastructure/StartupValidation.cs
+++ b/Server/Infrastructure/StartupValidation.cs
@@ -1,0 +1,21 @@
+namespace FourPlayWebApp.Server.Infrastructure;
+
+internal static class StartupValidation
+{
+    /// <summary>
+    /// Parses ALLOWED_ORIGINS env var. Throws in non-Development when empty so a
+    /// misconfigured deploy cannot silently open wildcard CORS.
+    /// </summary>
+    internal static string[] ParseAndValidateCorsOrigins(string? originsEnv, bool isDevelopment)
+    {
+        var origins = (originsEnv ?? string.Empty)
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        if (origins.Length == 0 && !isDevelopment)
+            throw new InvalidOperationException(
+                "ALLOWED_ORIGINS must be set in non-Development environments. " +
+                "Configure a comma-separated list of allowed origins (e.g. https://ivleague.com,https://cfb.ivleague.com).");
+
+        return origins;
+    }
+}

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -227,9 +227,11 @@ builder.Services.AddRateLimiter(options =>
 builder.Services.AddAuthorization();
 builder.Services.AddMemoryCache();
 
-// CORS — allow configured origins (comma-separated ALLOWED_ORIGINS env var)
-var allowedOrigins = (Environment.GetEnvironmentVariable("ALLOWED_ORIGINS") ?? "")
-    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+// CORS — allow configured origins (comma-separated ALLOWED_ORIGINS env var).
+// Fails fast in non-Development when ALLOWED_ORIGINS is unset to prevent wildcard CORS in prod.
+var allowedOrigins = FourPlayWebApp.Server.Infrastructure.StartupValidation.ParseAndValidateCorsOrigins(
+    Environment.GetEnvironmentVariable("ALLOWED_ORIGINS"),
+    builder.Environment.IsDevelopment());
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
@@ -237,7 +239,7 @@ builder.Services.AddCors(options =>
         if (allowedOrigins.Length > 0)
             policy.WithOrigins(allowedOrigins).AllowAnyHeader().AllowAnyMethod().AllowCredentials();
         else
-            policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod();
+            policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod(); // Dev only — validated above
     });
 });
 // Add Invitation Service


### PR DESCRIPTION
## Summary

- `ALLOWED_ORIGINS` unset in Production previously silently fell back to `AllowAnyOrigin()` — any origin could make credentialed requests
- New `StartupValidation.ParseAndValidateCorsOrigins()` throws `InvalidOperationException` at startup in non-Development when the var is empty, mirroring the existing email/JWT fail-fast pattern
- Dev keeps the permissive fallback unchanged
- 5 unit tests: Production throws on null/whitespace, Development passes on empty, both parse correctly when set

## Test plan

- [x] `dotnet test --filter CorsStartupValidation` → 5/5 pass
- [x] Full `dotnet test` → 347/347 pass (0 regressions)
- [ ] Verify Railway prod env has `ALLOWED_ORIGINS` set before merging to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)