### PR TITLE
fix(frizat-mon6): membership guards on league info/juice/userExists endpoints

### DIFF
--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -407,4 +407,155 @@ public class LeagueOwnershipTests
 
         Assert.IsType<ConflictObjectResult>(result);
     }
+
+    // ─── mon.6: membership guards on info / juice / userExists ─────────────
+
+    private static LeagueInfo StubLeague(int id = 1) =>
+        new() { Id = id, LeagueName = "Test", OwnerUserId = OwnerId };
+
+    // GetLeagueInfo
+
+    [Fact]
+    public async Task GetLeagueInfo_ReturnsForbid_ForNonMember()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId));
+        repo.GetLeagueInfoAsync(1).Returns(StubLeague());
+        repo.UserExistsInLeagueAsync(AttackerId, 1).Returns(false);
+
+        var result = await ctrl.GetLeagueInfo(1);
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetLeagueInfo_ReturnsOk_ForMember()
+    {
+        const string memberId = "member-003";
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(memberId));
+        repo.GetLeagueInfoAsync(1).Returns(StubLeague());
+        repo.UserExistsInLeagueAsync(memberId, 1).Returns(true);
+
+        var result = await ctrl.GetLeagueInfo(1);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetLeagueInfo_ReturnsOk_ForAdmin()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId, isAdmin: true));
+        repo.GetLeagueInfoAsync(1).Returns(StubLeague());
+
+        var result = await ctrl.GetLeagueInfo(1);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    // GetLeagueJuice
+
+    [Fact]
+    public async Task GetLeagueJuice_ReturnsForbid_ForNonMember()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId));
+        repo.UserExistsInLeagueAsync(AttackerId, 1).Returns(false);
+
+        var result = await ctrl.GetLeagueJuice(1);
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetLeagueJuice_ReturnsOk_ForMember()
+    {
+        const string memberId = "member-003";
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(memberId));
+        repo.UserExistsInLeagueAsync(memberId, 1).Returns(true);
+        repo.GetLeagueJuiceMappingAsync(1).Returns([]);
+
+        var result = await ctrl.GetLeagueJuice(1);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetLeagueJuice_ReturnsOk_ForAdmin()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId, isAdmin: true));
+        repo.GetLeagueJuiceMappingAsync(1).Returns([]);
+
+        var result = await ctrl.GetLeagueJuice(1);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    // GetLeagueJuiceForSeason
+
+    [Fact]
+    public async Task GetLeagueJuiceForSeason_ReturnsForbid_ForNonMember()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId));
+        repo.UserExistsInLeagueAsync(AttackerId, 1).Returns(false);
+
+        var result = await ctrl.GetLeagueJuiceForSeason(1, 2025);
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetLeagueJuiceForSeason_ReturnsOk_ForMember()
+    {
+        const string memberId = "member-003";
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(memberId));
+        repo.UserExistsInLeagueAsync(memberId, 1).Returns(true);
+        repo.GetLeagueJuiceMappingAsync(1, 2025).Returns((LeagueJuiceMapping?)null);
+
+        var result = await ctrl.GetLeagueJuiceForSeason(1, 2025);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetLeagueJuiceForSeason_ReturnsOk_ForAdmin()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId, isAdmin: true));
+        repo.GetLeagueJuiceMappingAsync(1, 2025).Returns((LeagueJuiceMapping?)null);
+
+        var result = await ctrl.GetLeagueJuiceForSeason(1, 2025);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    // UserExistsInLeague — self-lookup or admin only
+
+    [Fact]
+    public async Task UserExistsInLeague_ReturnsForbid_ForNonSelf()
+    {
+        var (ctrl, _) = BuildControllerWithRepo(BuildPrincipal(AttackerId));
+
+        var result = await ctrl.UserExistsInLeague(OwnerId, 1);
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task UserExistsInLeague_ReturnsOk_ForSelf()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.UserExistsInLeagueAsync(OwnerId, 1).Returns(true);
+
+        var result = await ctrl.UserExistsInLeague(OwnerId, 1);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task UserExistsInLeague_ReturnsOk_ForAdmin()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId, isAdmin: true));
+        repo.UserExistsInLeagueAsync(OwnerId, 1).Returns(false);
+
+        var result = await ctrl.UserExistsInLeague(OwnerId, 1);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
 }

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -36,6 +36,9 @@ public class LeagueController(
     [HttpGet("{leagueId:int}")]
     [ProducesResponseType(typeof(LeagueInfoDto), StatusCodes.Status200OK)]
     public async Task<ActionResult<LeagueInfoDto>> GetLeagueInfo(int leagueId) {
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!User.IsInRole(AppRoles.Administrator) && !await repo.UserExistsInLeagueAsync(callerId!, leagueId))
+            return Forbid();
         var info = await repo.GetLeagueInfoAsync(leagueId);
         var dtoInfos = new LeagueInfoDto {
             LeagueName = info.LeagueName,
@@ -82,6 +85,9 @@ public class LeagueController(
     [HttpGet("{leagueId:int}/juice")]
     [ProducesResponseType(typeof(List<LeagueJuiceMappingDto>), StatusCodes.Status200OK)]
     public async Task<ActionResult<List<LeagueJuiceMappingDto>>> GetLeagueJuice(int leagueId) {
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!User.IsInRole(AppRoles.Administrator) && !await repo.UserExistsInLeagueAsync(callerId!, leagueId))
+            return Forbid();
         var mappings = await repo.GetLeagueJuiceMappingAsync(leagueId);
         var dtoMappings = mappings.Select(m => new LeagueJuiceMappingDto {
             LeagueId = m.LeagueId,
@@ -99,6 +105,9 @@ public class LeagueController(
     [HttpGet("{leagueId:int}/juice/{season:int}")]
     [ProducesResponseType(typeof(LeagueJuiceMappingDto), StatusCodes.Status200OK)]
     public async Task<ActionResult<LeagueJuiceMappingDto?>> GetLeagueJuiceForSeason(int leagueId, int season) {
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!User.IsInRole(AppRoles.Administrator) && !await repo.UserExistsInLeagueAsync(callerId!, leagueId))
+            return Forbid();
         var mapping = await repo.GetLeagueJuiceMappingAsync(leagueId, season);
         if (mapping == null) return Ok(null);
 
@@ -609,7 +618,12 @@ public class LeagueController(
     [HttpGet("exists/user-in-league/{userId}/{leagueId:int}")]
     [ProducesResponseType(typeof(bool), StatusCodes.Status200OK)]
     public async Task<ActionResult<bool>> UserExistsInLeague(string userId, int leagueId)
-        => Ok(await repo.UserExistsInLeagueAsync(userId, leagueId));
+    {
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!User.IsInRole(AppRoles.Administrator) && !string.Equals(callerId, userId, StringComparison.Ordinal))
+            return Forbid();
+        return Ok(await repo.UserExistsInLeagueAsync(userId, leagueId));
+    }
 
     // ---------- Adds for core entities ----------
     [HttpPost("league-user")]


### PR DESCRIPTION
## Summary

- `GET /{leagueId}` (GetLeagueInfo), `GET /{leagueId}/juice`, `GET /{leagueId}/juice/{season}`: now Forbid for any authenticated non-member — adds same member-or-admin guard as GetLeaguePicks
- `GET /exists/user-in-league/{userId}/{leagueId}`: now Forbid unless caller is querying their own userId or is admin (mirrors GetLeagueUserMappingsForUser pattern)
- 12 new tests: Forbid non-member, Ok member, Ok admin per endpoint

## Test plan

- [x] `dotnet test` → 362/362 pass (0 regressions)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)