### PR TITLE
feat(frizat-mon9): league name → tappable Chip in AppLayout toolbar

### DIFF
--- a/Client.React/src/__tests__/AppLayout.test.tsx
+++ b/Client.React/src/__tests__/AppLayout.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * AppLayout league switcher chip tests (frizat-mon.9).
+ * Verifies the league name is a tappable chip that opens a menu of leagues
+ * and calls selectLeague when the user picks one.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import AppLayout from '../layouts/AppLayout';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+vi.mock('../services/auth',  () => ({ useAuth: () => ({ user: { userId: 'u1', name: 'Alice', claims: [] } }) }));
+vi.mock('../services/theme', () => ({ useThemeMode: () => ({ mode: 'light', toggleTheme: vi.fn() }) }));
+vi.mock('../services/toast', () => ({ useToast: () => ({ push: vi.fn() }) }));
+vi.mock('../utils/auth',     () => ({ isAdmin: () => false }));
+
+const selectLeague = vi.fn();
+
+const sessionState = {
+  currentLeague: 1 as number | null,
+  availableLeagues: [
+    { leagueId: 1, leagueName: 'Alpha League', leagueOwnerUserId: null, userId: 'u1', userName: 'Alice', leagueType: 0, dateCreated: '' },
+    { leagueId: 2, leagueName: 'Beta League',  leagueOwnerUserId: null, userId: 'u1', userName: 'Alice', leagueType: 0, dateCreated: '' },
+  ],
+  selectLeague,
+  reloadLeagues: vi.fn(),
+  clearSession: vi.fn(),
+  hasNflAccess: true,
+  hasCfbAccess: false,
+  leaguesLoaded: true,
+  isLeagueOwner: false,
+  ownedLeagues: [] as { id: number; leagueName: string; leagueType: string; ownerUserId: string; dateCreated: string }[],
+};
+vi.mock('../services/session', () => ({ useSession: () => sessionState }));
+vi.mock('../services/sport',   () => ({ useSportContext: () => ({ sport: 'NFL', isCfb: false, isNfl: true }) }));
+
+function renderLayout() {
+  return render(
+    <MemoryRouter>
+      <Routes>
+        <Route path="*" element={<AppLayout />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('AppLayout league switcher chip (frizat-mon.9)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the current league name as a clickable element in the toolbar', () => {
+    renderLayout();
+    expect(screen.getByRole('button', { name: /alpha league/i })).toBeInTheDocument();
+  });
+
+  it('clicking the league chip opens a menu listing available leagues', () => {
+    renderLayout();
+    fireEvent.click(screen.getByRole('button', { name: /alpha league/i }));
+    expect(screen.getByRole('menuitem', { name: 'Alpha League' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Beta League' })).toBeInTheDocument();
+  });
+
+  it('selecting a different league calls selectLeague with the correct leagueId', () => {
+    renderLayout();
+    fireEvent.click(screen.getByRole('button', { name: /alpha league/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Beta League' }));
+    expect(selectLeague).toHaveBeenCalledWith(2);
+  });
+
+  it('shows Select League when no current league is set', () => {
+    sessionState.currentLeague = null;
+    renderLayout();
+    expect(screen.getByRole('button', { name: /select league/i })).toBeInTheDocument();
+    sessionState.currentLeague = 1; // restore
+  });
+});

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -4,6 +4,7 @@ import {
   AppBar,
   Box,
   Button,
+  Chip,
   Collapse,
   Divider,
   Drawer,
@@ -20,6 +21,7 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import MenuIcon from '@mui/icons-material/Menu';
@@ -28,7 +30,6 @@ import AddToPhotosIcon from '@mui/icons-material/AddToPhotos';
 import ScoreboardIcon from '@mui/icons-material/Scoreboard';
 import LeaderboardIcon from '@mui/icons-material/Leaderboard';
 import MenuBookIcon from '@mui/icons-material/MenuBook';
-import SettingsIcon from '@mui/icons-material/Settings';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -124,12 +125,21 @@ export default function AppLayout() {
             IV League
           </Typography>
           <Stack direction="row" spacing={1} alignItems="center">
-            <Typography variant="body2" sx={{ opacity: 0.8 }}>
-              {leagueLabel}
-            </Typography>
-            <IconButton color="inherit" onClick={(e) => setMenuAnchor(e.currentTarget)}>
-              <SettingsIcon />
-            </IconButton>
+            <Chip
+              label={leagueLabel}
+              onClick={(e) => setMenuAnchor(e.currentTarget)}
+              onDelete={(e) => setMenuAnchor(e.currentTarget)}
+              deleteIcon={<ArrowDropDownIcon />}
+              variant="outlined"
+              size="small"
+              sx={{
+                color: 'inherit',
+                borderColor: 'rgba(255,255,255,0.4)',
+                maxWidth: 140,
+                '& .MuiChip-label': { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+                '&:hover': { borderColor: 'rgba(255,255,255,0.8)', bgcolor: 'rgba(255,255,255,0.08)' },
+              }}
+            />
             <IconButton color="inherit" onClick={toggleTheme} aria-label="toggle dark mode">
               {mode === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}
             </IconButton>
@@ -138,7 +148,7 @@ export default function AppLayout() {
             anchorEl={menuAnchor}
             open={Boolean(menuAnchor)}
             onClose={() => setMenuAnchor(null)}
-            PaperProps={{ sx: { minWidth: 220 } }}
+            slotProps={{ paper: { sx: { minWidth: 220 } } }}
           >
             <Typography variant="caption" sx={{ px: 2, py: 1, opacity: 0.7 }}>
               League Selection


### PR DESCRIPTION
## Summary
- Replaces the inert `<Typography>{leagueLabel}</Typography>` + SettingsIcon gear button with a single outlined `<Chip>` (league name + ▼ arrow) that opens the existing league/account menu in one tap
- Long league names truncate at 140px with ellipsis — safe for 390px iPhone viewport
- Fixes MUI v7 deprecation: `PaperProps` → `slotProps={{ paper: ... }}` on the Menu

## Tests (red → green)
- `renders the current league name as a clickable element in the toolbar`
- `clicking the league chip opens a menu listing available leagues`
- `selecting a different league calls selectLeague with the correct leagueId`
- `shows Select League when no current league is set`

## Test plan
- [x] 219/219 Vitest pass
- [x] `npm run typecheck` clean
- [x] No regressions in `sportAccess` tests

Closes frizat-mon.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)