### PR TITLE
feat(frizat-mon8): GameCard UX — locked-pick affordance, team abbr, aria-labels, O/U copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,9 +141,19 @@ Every new user-facing feature MUST have:
    - Integration: add to `e2e/demo/` if it requires real backend data
    - Use typed factory functions from `src/test/fixtures.ts` — never raw JSON
 
-### Before Opening a PR
-1. `/simplify` — review changed code for reuse, quality, and efficiency
-2. `/feature-dev:code-review` — review for bugs, logic errors, and security issues
+### CRITICAL: Before Opening a PR (mandatory — no exceptions)
+Run ALL three steps in order. Skipping any step is a violation of this process.
+
+1. **Run the full test suite** — all tests must pass before a PR is opened:
+   ```bash
+   dotnet test                                            # backend xUnit
+   npm run test -- --run                                  # frontend Vitest
+   npm run test:e2e -- --project=chromium                 # mock-based Playwright
+   ```
+2. **`/simplify`** — review changed code for reuse, quality, and efficiency; apply any fixes
+3. **`/feature-dev:code-review`** — review for bugs, logic errors, and security issues; address findings
+
+Opening a PR before completing these steps wastes CI minutes and review cycles on avoidable failures.
 
 ### Definition of Done
 A bead is closeable ONLY when:

--- a/Client.React/e2e/demo/cfb-picks.spec.ts
+++ b/Client.React/e2e/demo/cfb-picks.spec.ts
@@ -34,12 +34,12 @@ test.describe('CFB picks — demo backend', () => {
     // Alice picked IU (Indiana) for the Championship — server-confirmed → "IU locked in"
     await expect(page.getByRole('button', { name: /locked in/i })).toBeVisible({ timeout: 8_000 });
     // IU team abbreviation should appear in a Picked row
-    await expect(page.getByText('IU')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('IU').first()).toBeVisible({ timeout: 5_000 });
   });
 
   test('CFP Championship game card shows IU vs MIA', async ({ page }) => {
-    await expect(page.getByText('IU')).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByText('MIA')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('IU').first()).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('MIA').first()).toBeVisible({ timeout: 5_000 });
   });
 
   test('switching to Regular Season shows Week 13 (most recent)', async ({ page }) => {
@@ -86,8 +86,8 @@ test.describe('CFB picks — demo backend', () => {
     await waitForSpinner(page);
 
     // 6 games were seeded for Week 8 — each game card shows two team abbreviations
-    await expect(page.getByText('MICH')).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByText('PSU')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('MICH').first()).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('PSU').first()).toBeVisible({ timeout: 5_000 });
     // Alice picked 4 teams (regular season max) — server-confirmed → 4 "locked in" buttons
     await expect(page.getByRole('button', { name: /locked in/i })).toHaveCount(4, { timeout: 8_000 });
   });

--- a/Client.React/e2e/demo/cfb-picks.spec.ts
+++ b/Client.React/e2e/demo/cfb-picks.spec.ts
@@ -31,9 +31,8 @@ test.describe('CFB picks — demo backend', () => {
   });
 
   test('Alice sees her CFP Championship pick (IU)', async ({ page }) => {
-    // Alice picked IU (Indiana) for the Championship
-    // The "Picked" button for IU should be visible
-    await expect(page.getByRole('button', { name: 'Picked', exact: true })).toBeVisible({ timeout: 8_000 });
+    // Alice picked IU (Indiana) for the Championship — server-confirmed → "IU locked in"
+    await expect(page.getByRole('button', { name: /locked in/i })).toBeVisible({ timeout: 8_000 });
     // IU team abbreviation should appear in a Picked row
     await expect(page.getByText('IU')).toBeVisible({ timeout: 5_000 });
   });
@@ -89,7 +88,7 @@ test.describe('CFB picks — demo backend', () => {
     // 6 games were seeded for Week 8 — each game card shows two team abbreviations
     await expect(page.getByText('MICH')).toBeVisible({ timeout: 5_000 });
     await expect(page.getByText('PSU')).toBeVisible({ timeout: 5_000 });
-    // Alice picked 4 teams (regular season max) — should see 4 "Picked" buttons
-    await expect(page.getByRole('button', { name: 'Picked', exact: true })).toHaveCount(4, { timeout: 8_000 });
+    // Alice picked 4 teams (regular season max) — server-confirmed → 4 "locked in" buttons
+    await expect(page.getByRole('button', { name: /locked in/i })).toHaveCount(4, { timeout: 8_000 });
   });
 });

--- a/Client.React/e2e/demo/nfl-picks.spec.ts
+++ b/Client.React/e2e/demo/nfl-picks.spec.ts
@@ -38,7 +38,7 @@ test.describe('NFL picks — demo backend', () => {
   });
 
   test('Alice sees her Super Bowl pick (SEA)', async ({ page }) => {
-    await expect(page.getByRole('button', { name: 'Picked', exact: true })).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByRole('button', { name: /locked in/i })).toBeVisible({ timeout: 8_000 });
   });
 
   // REGRESSION: Wild Card must show all 6 games with O/U (not just 5)
@@ -64,7 +64,7 @@ test.describe('NFL picks — demo backend', () => {
     await page.getByRole('option', { name: 'Wild Card' }).click();
     await waitForSpinner(page);
     // Wild Card requires 3 picks (GetRequiredPicks(19)=3); Alice picks LAR, CHI, BUF
-    await expect(page.getByRole('button', { name: 'Picked', exact: true })).toHaveCount(3, { timeout: 8_000 });
+    await expect(page.getByRole('button', { name: /locked in/i })).toHaveCount(3, { timeout: 8_000 });
   });
 
   // REGRESSION: regular season must show ALL 18 weeks (not just Week 1)
@@ -93,7 +93,7 @@ test.describe('NFL picks — demo backend', () => {
     await page.getByRole('option', { name: 'Regular Season' }).click();
     await waitForSpinner(page);
 
-    await expect(page.getByRole('button', { name: 'Picked', exact: true })).toHaveCount(4, { timeout: 8_000 });
+    await expect(page.getByRole('button', { name: /locked in/i })).toHaveCount(4, { timeout: 8_000 });
   });
 
   test('"Current Week" button restores Super Bowl', async ({ page }) => {

--- a/Client.React/e2e/picks.spec.ts
+++ b/Client.React/e2e/picks.spec.ts
@@ -12,7 +12,7 @@ test.describe('Picks page (authenticated)', () => {
     await expect(page.getByRole('heading', { name: 'Picks', exact: true })).toBeVisible({ timeout: 5000 });
 
     // Game rows should be rendered (BUF/MIA and DAL/NYG)
-    await expect(page.getByRole('button', { name: 'Pick', exact: true }).first()).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('button', { name: /^Pick \w/i }).first()).toBeVisible({ timeout: 5000 });
   });
 
   test('shows pick buttons for upcoming games', async ({ page }) => {
@@ -21,8 +21,8 @@ test.describe('Picks page (authenticated)', () => {
     await expect(page.getByRole('progressbar')).not.toBeVisible({ timeout: 10000 });
 
     // Games are in the future (gameStarted: false), so Pick buttons are not locked
-    // Use exact: true to match "Pick" not "Submit Pick(s)"
-    const pickButtons = page.getByRole('button', { name: 'Pick', exact: true });
+    // Match "Pick BUF", "Pick MIA" etc. — not "Submit Pick(s)"
+    const pickButtons = page.getByRole('button', { name: /^Pick \w/i });
     await expect(pickButtons.first()).toBeVisible({ timeout: 5000 });
     await expect(pickButtons.first()).toBeEnabled();
 
@@ -35,12 +35,12 @@ test.describe('Picks page (authenticated)', () => {
 
     await expect(page.getByRole('progressbar')).not.toBeVisible({ timeout: 10000 });
 
-    const firstPickButton = page.getByRole('button', { name: 'Pick', exact: true }).first();
+    const firstPickButton = page.getByRole('button', { name: /^Pick \w/i }).first();
     await expect(firstPickButton).toBeVisible({ timeout: 5000 });
     await firstPickButton.click();
 
-    // After clicking, the button should change to "Picked"
-    await expect(page.getByRole('button', { name: 'Picked', exact: true })).toBeVisible({ timeout: 3000 });
+    // After clicking, the button should change to "{team} picked" (pending state)
+    await expect(page.getByRole('button', { name: /\bpicked\b/i })).toBeVisible({ timeout: 3000 });
   });
 
   test('submit button disabled with no picks selected', async ({ page }) => {
@@ -63,8 +63,8 @@ test.describe('Picks page (authenticated)', () => {
     const submitButton = page.getByRole('button', { name: /submit pick\(s\)/i });
     await expect(submitButton).toBeDisabled({ timeout: 5000 });
 
-    // Click the first Pick button (exact match to avoid hitting "Submit Pick(s)")
-    await page.getByRole('button', { name: 'Pick', exact: true }).first().click();
+    // Click the first Pick button — matches "Pick BUF", "Pick MIA" etc.
+    await page.getByRole('button', { name: /^Pick \w/i }).first().click();
 
     // Submit should now be enabled
     await expect(submitButton).toBeEnabled({ timeout: 3000 });

--- a/Client.React/e2e/picks.spec.ts
+++ b/Client.React/e2e/picks.spec.ts
@@ -75,8 +75,8 @@ test.describe('Picks page (authenticated)', () => {
 
     await expect(page.getByRole('progressbar')).not.toBeVisible({ timeout: 10000 });
 
-    // Click the first Pick button to select a team
-    await page.getByRole('button', { name: 'Pick', exact: true }).first().click();
+    // Click the first Pick button — matches "Pick BUF", "Pick MIA" etc.
+    await page.getByRole('button', { name: /^Pick \w/i }).first().click();
 
     // Wait for the submit button to become enabled
     const submitButton = page.getByRole('button', { name: /submit pick\(s\)/i });

--- a/Client.React/src/__tests__/GameCard.test.tsx
+++ b/Client.React/src/__tests__/GameCard.test.tsx
@@ -95,7 +95,7 @@ describe('GameCard', () => {
     expect(screen.queryByRole('button', { name: /^under$/i })).not.toBeInTheDocument();
   });
 
-  it('shows Overed when overPickState=submitted', () => {
+  it('shows "Over 51.5 ✓" when overPickState=submitted', () => {
     render(
       <GameCard
         {...baseProps}
@@ -108,16 +108,84 @@ describe('GameCard', () => {
         onPickUnder={vi.fn()}
       />
     );
-    expect(screen.getByRole('button', { name: /overed/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /over 51\.5 ✓/i })).toBeInTheDocument();
   });
 
   it('calls onPickHome when Pick button clicked', async () => {
     const user = userEvent.setup();
     const onPickHome = vi.fn();
     render(<GameCard {...baseProps} homePickState="none" onPickHome={onPickHome} />);
-    const pickBtns = screen.getAllByRole('button', { name: /^pick$/i });
-    await user.click(pickBtns[1]); // home team is second pick button
+    await user.click(screen.getByRole('button', { name: /Pick KC/i }));
     expect(onPickHome).toHaveBeenCalledOnce();
+  });
+
+  // ── mon.8: submitted state, aria-labels, team abbr text, O/U copy ──────────
+
+  it('submitted away pick is disabled with "Locked in" label', () => {
+    render(<GameCard {...baseProps} awayPickState="submitted" />);
+    const btn = screen.getByRole('button', { name: /BUF locked in/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('submitted home pick is disabled with "Locked in" label', () => {
+    render(<GameCard {...baseProps} homePickState="submitted" />);
+    const btn = screen.getByRole('button', { name: /KC locked in/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('unpicked away team button has aria-label "Pick BUF"', () => {
+    render(<GameCard {...baseProps} awayPickState="none" />);
+    expect(screen.getByRole('button', { name: /^Pick BUF$/i })).toBeInTheDocument();
+  });
+
+  it('unpicked home team button has aria-label "Pick KC"', () => {
+    render(<GameCard {...baseProps} homePickState="none" />);
+    expect(screen.getByRole('button', { name: /^Pick KC$/i })).toBeInTheDocument();
+  });
+
+  it('team abbreviation rendered as visible text even when jerseyUrl is provided', () => {
+    render(
+      <GameCard
+        {...baseProps}
+        awayJerseyUrl="https://example.com/buf.png"
+        homeJerseyUrl="https://example.com/kc.png"
+      />
+    );
+    expect(screen.getAllByText('BUF').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('KC').length).toBeGreaterThan(0);
+  });
+
+  it('O/U unpicked still reads "Over" and "Under"', () => {
+    render(
+      <GameCard
+        {...baseProps}
+        isPostSeason={true}
+        overValue={47.5}
+        underValue={47.5}
+        overPickState="none"
+        underPickState="none"
+        onPickOver={vi.fn()}
+        onPickUnder={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: /^Over$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Under$/i })).toBeInTheDocument();
+  });
+
+  it('O/U picked under shows "Under 47.5 ✓"', () => {
+    render(
+      <GameCard
+        {...baseProps}
+        isPostSeason={true}
+        overValue={47.5}
+        underValue={47.5}
+        overPickState="none"
+        underPickState="submitted"
+        onPickOver={vi.fn()}
+        onPickUnder={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: /under 47\.5 ✓/i })).toBeInTheDocument();
   });
 
   it('shows gameDetail string when provided', () => {

--- a/Client.React/src/__tests__/picks.test.tsx
+++ b/Client.React/src/__tests__/picks.test.tsx
@@ -176,7 +176,7 @@ describe('PicksPage', () => {
     await setupDefaults();
     await renderPage();
 
-    const pickButtons = screen.getAllByRole('button', { name: /^Pick$/i });
+    const pickButtons = screen.getAllByRole('button', { name: /^Pick /i });
     await userEvent.click(pickButtons[0]);
 
     await waitFor(() => {
@@ -191,7 +191,7 @@ describe('PicksPage', () => {
     await setupDefaults();
     await renderPage();
 
-    const pickButton = screen.getAllByRole('button', { name: /^Pick$/i })[0];
+    const pickButton = screen.getAllByRole('button', { name: /^Pick /i })[0];
     await userEvent.click(pickButton);
     await screen.findByRole('button', { name: /picked/i });
 
@@ -199,7 +199,7 @@ describe('PicksPage', () => {
     await userEvent.click(pickedButton);
 
     await waitFor(() => {
-      expect(screen.getAllByRole('button', { name: /^Pick$/i }).length).toBeGreaterThan(0);
+      expect(screen.getAllByRole('button', { name: /^Pick /i }).length).toBeGreaterThan(0);
     });
   });
 
@@ -216,12 +216,12 @@ describe('PicksPage', () => {
     await setupDefaults({ existingPicks: existing });
     await renderPage();
 
-    const pickButtons = screen.getAllByRole('button', { name: /^Pick$/i });
+    const pickButtons = screen.getAllByRole('button', { name: /^Pick /i });
     await userEvent.click(pickButtons[0]);
     await userEvent.click(pickButtons[1]);
 
     await waitFor(() => {
-      const remaining = screen.queryAllByRole('button', { name: /^Pick$/i });
+      const remaining = screen.queryAllByRole('button', { name: /^Pick /i });
       if (remaining.length === 0) {
         expect(remaining.length).toBe(0);
       } else {
@@ -238,20 +238,24 @@ describe('PicksPage', () => {
     await setupDefaults({ existingPicks: existing });
     await renderPage();
 
-    const initialPicked = screen.getAllByRole('button', { name: /picked/i }).length;
-    expect(initialPicked).toBe(2);
+    // Existing server picks show as "Locked in" (submitted state, disabled)
+    const initialLocked = screen.getAllByRole('button', { name: /locked in/i }).length;
+    expect(initialLocked).toBe(2);
 
-    const pickButton = screen.getAllByRole('button', { name: /^Pick$/i })[0];
+    // Add one new user (pending) pick — it shows as "Picked" (enabled)
+    const pickButton = screen.getAllByRole('button', { name: /^Pick /i })[0];
     await userEvent.click(pickButton);
 
     await waitFor(() => {
-      expect(screen.getAllByRole('button', { name: /picked/i }).length).toBe(3);
+      expect(screen.getAllByRole('button', { name: /picked/i }).length).toBe(1);
     });
 
     await userEvent.click(screen.getByRole('button', { name: /clear selected picks/i }));
 
+    // After clearing, user pick gone; existing locked picks remain
     await waitFor(() => {
-      expect(screen.getAllByRole('button', { name: /picked/i }).length).toBe(2);
+      expect(screen.queryAllByRole('button', { name: /picked/i }).length).toBe(0);
+      expect(screen.getAllByRole('button', { name: /locked in/i }).length).toBe(2);
     });
   });
 
@@ -261,7 +265,7 @@ describe('PicksPage', () => {
     mockedGetUserPicks.mockResolvedValue([createPick({ team: 'BUF' })]);
 
     await renderPage();
-    const pickButton = screen.getAllByRole('button', { name: /^Pick$/i })[0];
+    const pickButton = screen.getAllByRole('button', { name: /^Pick /i })[0];
     await userEvent.click(pickButton);
 
     await userEvent.click(screen.getByRole('button', { name: /submit pick/i }));
@@ -300,7 +304,7 @@ describe('PicksPage', () => {
     await setupDefaults({ gameDate: futureDate });
     await renderPage();
 
-    const pickButton = screen.getAllByRole('button', { name: /^Pick$/i })[0];
+    const pickButton = screen.getAllByRole('button', { name: /^Pick /i })[0];
     expect(pickButton).not.toBeDisabled();
   });
 
@@ -309,7 +313,7 @@ describe('PicksPage', () => {
     await setupDefaults({ gameDate: pastDate, gameStarted: false });
     await renderPage();
 
-    screen.getAllByRole('button', { name: /^Pick$/i }).forEach((btn) => {
+    screen.getAllByRole('button', { name: /^Pick /i }).forEach((btn) => {
       expect(btn).toBeDisabled();
     });
   });
@@ -351,24 +355,24 @@ describe('PicksPage', () => {
 
     const overButton = screen.getAllByRole('button', { name: /^Over$/i })[0];
     await userEvent.click(overButton);
-    await screen.findByRole('button', { name: /^Overed$/i });
+    await screen.findByRole('button', { name: /^Over 47\.5 ✓$/i });
 
     const underButton = screen.getAllByRole('button', { name: /^Under$/i })[0];
     await userEvent.click(underButton);
-    await screen.findByRole('button', { name: /^Undered$/i });
+    await screen.findByRole('button', { name: /^Under 47\.5 ✓$/i });
   });
 
   it('postseason allows selecting spread and over picks together', async () => {
     await setupDefaults({ week: 1, postSeason: true });
     await renderPage();
 
-    const pickButton = screen.getAllByRole('button', { name: /^Pick$/i })[0];
+    const pickButton = screen.getAllByRole('button', { name: /^Pick /i })[0];
     await userEvent.click(pickButton);
     await screen.findByRole('button', { name: /picked/i });
 
     const overButton = screen.getAllByRole('button', { name: /^Over$/i })[0];
     await userEvent.click(overButton);
-    await screen.findByRole('button', { name: /^Overed$/i });
+    await screen.findByRole('button', { name: /^Over 47\.5 ✓$/i });
   });
 
   it('renders a dedicated over/under control block per postseason matchup', async () => {
@@ -400,7 +404,7 @@ describe('PicksPage', () => {
       await setupDefaults();
       await renderPage();
 
-      await user.click(screen.getAllByRole('button', { name: /^Pick$/i })[0]);
+      await user.click(screen.getAllByRole('button', { name: /^Pick /i })[0]);
       await screen.findByRole('button', { name: /picked/i });
 
       await act(async () => {
@@ -425,7 +429,7 @@ describe('PicksPage', () => {
 
       // Grid stays mounted, no spinner replaces the page
       expect(screen.queryByRole('progressbar')).toBeNull();
-      expect(screen.getAllByRole('button', { name: /^Pick$/i }).length).toBeGreaterThan(0);
+      expect(screen.getAllByRole('button', { name: /^Pick /i }).length).toBeGreaterThan(0);
     });
 
     it('drops a pending pick with a toast when its game locks during refetch', async () => {
@@ -435,7 +439,7 @@ describe('PicksPage', () => {
       await setupDefaults({ gameDate: futureDate });
       await renderPage();
 
-      await user.click(screen.getAllByRole('button', { name: /^Pick$/i })[0]);
+      await user.click(screen.getAllByRole('button', { name: /^Pick /i })[0]);
       await screen.findByRole('button', { name: /picked/i });
 
       // Next poll: same games but kickoff has passed

--- a/Client.React/src/__tests__/sharedPickLayout.test.tsx
+++ b/Client.React/src/__tests__/sharedPickLayout.test.tsx
@@ -62,7 +62,7 @@ describe('NFL PicksPage — GameCard layout regression', () => {
 
   it('renders Pick buttons (GameCard pick mode)', async () => {
     renderWithClient(<PicksPage adapter={createNflAdapter()} />);
-    await waitFor(() => expect(screen.getAllByRole('button', { name: /^pick$/i }).length).toBeGreaterThan(0));
+    await waitFor(() => expect(screen.getAllByRole('button', { name: /^Pick /i }).length).toBeGreaterThan(0));
   });
 
   it('renders spread label -3 (GameCard spread display)', async () => {
@@ -105,7 +105,7 @@ describe('CFB PicksPage (via adapter) — GameCard layout regression', () => {
 
   it('renders Pick buttons (GameCard pick mode)', async () => {
     renderWithClient(<PicksPage adapter={createCfbAdapter()} />);
-    await waitFor(() => expect(screen.getAllByRole('button', { name: /^pick$/i }).length).toBeGreaterThan(0));
+    await waitFor(() => expect(screen.getAllByRole('button', { name: /^Pick /i }).length).toBeGreaterThan(0));
   });
 
   it('renders spread labels -3.5 and +3.5 (GameCard spread display)', async () => {
@@ -124,11 +124,11 @@ describe('CFB PicksPage (via adapter) — GameCard layout regression', () => {
     });
   });
 
-  it('shows Picked when pick already submitted', async () => {
+  it('shows Locked in when pick already submitted', async () => {
     vi.mocked(getCfbUserPicks).mockResolvedValue([
       { id: 1, userId: 'u1', userName: 'u1', leagueId: 1, cfbSlateId: 1, espnEventId: 100, team: 'MICH', pickType: 'Spread', season: 2025 }
     ]);
     renderWithClient(<PicksPage adapter={createCfbAdapter()} />);
-    await waitFor(() => expect(screen.getByRole('button', { name: /^picked$/i })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: /MICH locked in/i })).toBeInTheDocument());
   });
 });

--- a/Client.React/src/components/sports/GameCard.tsx
+++ b/Client.React/src/components/sports/GameCard.tsx
@@ -85,11 +85,19 @@ export default function GameCard({
 
   const pickButtonSx = { minWidth: 80, height: 44, textTransform: 'none', fontSize: '0.85rem', flexShrink: 0 } as const;
 
+  const renderPickButton = (team: string, pickState: PickState, onPick?: () => void) => {
+    if (pickState === 'submitted')
+      return <Button color="success" variant="contained" disabled startIcon={<CheckIcon />} aria-label={`${team} locked in`} sx={pickButtonSx}>Locked in</Button>;
+    if (pickState !== 'none')
+      return <Button color="success" variant="contained" onClick={onPick} aria-label={`${team} picked`} sx={pickButtonSx}>Picked</Button>;
+    return <Button color="warning" variant="contained" disabled={locked} onClick={onPick} aria-label={`Pick ${team}`} sx={pickButtonSx}>Pick</Button>;
+  };
+
   const renderTeamLogo = (abbr: string, jerseyUrl: string | undefined, flipped = false) => (
     <Box textAlign="center">
       {jerseyUrl
         ? <img src={jerseyUrl} width={50} alt={abbr} />
-        : <TeamHelmet abbr={abbr} size={50} flipped={flipped} />}
+        : <TeamHelmet abbr={abbr} size={50} flipped={flipped} showLabel={false} />}
       <Typography variant="caption" display="block" sx={{ lineHeight: 1.2, opacity: 0.85 }}>
         {abbr}
       </Typography>
@@ -110,41 +118,7 @@ export default function GameCard({
               <Typography variant="h6" className="fixed-width">
                 {mode === 'score' && showScore ? awayScore : awaySpread != null ? spreadLabel(awaySpread) : ""}
               </Typography>
-              {mode === 'pick' ? (
-                awayPickState === 'submitted' ? (
-                  <Button
-                    color="success"
-                    variant="contained"
-                    disabled
-                    startIcon={<CheckIcon />}
-                    aria-label={`${awayTeam} locked in`}
-                    sx={pickButtonSx}
-                  >
-                    Locked in
-                  </Button>
-                ) : awayPickState !== 'none' ? (
-                  <Button
-                    color="success"
-                    variant="contained"
-                    onClick={onPickAway}
-                    aria-label={`${awayTeam} picked`}
-                    sx={pickButtonSx}
-                  >
-                    Picked
-                  </Button>
-                ) : (
-                  <Button
-                    color="warning"
-                    variant="contained"
-                    disabled={locked}
-                    onClick={onPickAway}
-                    aria-label={`Pick ${awayTeam}`}
-                    sx={pickButtonSx}
-                  >
-                    Pick
-                  </Button>
-                )
-              ) : (
+              {mode === 'pick' ? renderPickButton(awayTeam, awayPickState, onPickAway) : (
                 mode === 'score' && (
                   <Typography variant="caption" color="text.secondary">
                     {awaySpread != null ? spreadLabel(awaySpread) : ""}
@@ -188,41 +162,7 @@ export default function GameCard({
               <Typography variant="h6" className="fixed-width">
                 {mode === 'score' && showScore ? homeScore : homeSpread != null ? spreadLabel(homeSpread) : ""}
               </Typography>
-              {mode === 'pick' ? (
-                homePickState === 'submitted' ? (
-                  <Button
-                    color="success"
-                    variant="contained"
-                    disabled
-                    startIcon={<CheckIcon />}
-                    aria-label={`${homeTeam} locked in`}
-                    sx={pickButtonSx}
-                  >
-                    Locked in
-                  </Button>
-                ) : homePickState !== 'none' ? (
-                  <Button
-                    color="success"
-                    variant="contained"
-                    onClick={onPickHome}
-                    aria-label={`${homeTeam} picked`}
-                    sx={pickButtonSx}
-                  >
-                    Picked
-                  </Button>
-                ) : (
-                  <Button
-                    color="warning"
-                    variant="contained"
-                    disabled={locked}
-                    onClick={onPickHome}
-                    aria-label={`Pick ${homeTeam}`}
-                    sx={pickButtonSx}
-                  >
-                    Pick
-                  </Button>
-                )
-              ) : (
+              {mode === 'pick' ? renderPickButton(homeTeam, homePickState, onPickHome) : (
                 mode === 'score' && (
                   <Typography variant="caption" color="text.secondary">
                     {homeSpread != null ? spreadLabel(homeSpread) : ""}

--- a/Client.React/src/components/sports/GameCard.tsx
+++ b/Client.React/src/components/sports/GameCard.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Card, CardContent, Chip, Stack, Typography } from '@mui/material';
+import CheckIcon from '@mui/icons-material/Check';
 import TeamHelmet from './TeamHelmet';
 import WeatherIcon from '../WeatherIcon';
 import { spreadLabel } from '../../utils/gameHelpers';
@@ -60,9 +61,6 @@ function statusChip(status: string | undefined, gameTime: string) {
   );
 }
 
-function pickButtonLabel(state: PickState, defaultLabel: string, pickedLabel = 'Picked'): string {
-  return state !== 'none' ? pickedLabel : defaultLabel;
-}
 
 export default function GameCard({
   homeTeam, awayTeam, homeSpread, awaySpread, gameTime,
@@ -87,10 +85,16 @@ export default function GameCard({
 
   const pickButtonSx = { minWidth: 80, height: 44, textTransform: 'none', fontSize: '0.85rem', flexShrink: 0 } as const;
 
-  const renderTeamLogo = (abbr: string, jerseyUrl: string | undefined, flipped = false) => {
-    if (jerseyUrl) return <img src={jerseyUrl} width={50} alt={abbr} />;
-    return <TeamHelmet abbr={abbr} size={50} flipped={flipped} />;
-  };
+  const renderTeamLogo = (abbr: string, jerseyUrl: string | undefined, flipped = false) => (
+    <Box textAlign="center">
+      {jerseyUrl
+        ? <img src={jerseyUrl} width={50} alt={abbr} />
+        : <TeamHelmet abbr={abbr} size={50} flipped={flipped} />}
+      <Typography variant="caption" display="block" sx={{ lineHeight: 1.2, opacity: 0.85 }}>
+        {abbr}
+      </Typography>
+    </Box>
+  );
 
   return (
     <Card elevation={2} sx={{ height: '100%' }}>
@@ -99,7 +103,7 @@ export default function GameCard({
         <Card variant="outlined" sx={{ mb: 1.5 }}>
           <CardContent sx={{ p: '12px !important' }}>
             <Stack direction="row" alignItems="center" justifyContent="space-between">
-              <Box textAlign="center">{renderTeamLogo(awayTeam, awayJerseyUrl)}</Box>
+              {renderTeamLogo(awayTeam, awayJerseyUrl)}
               {!isPostSeason && awayRecord && (
                 <Typography variant="subtitle2">{awayRecord}</Typography>
               )}
@@ -107,11 +111,23 @@ export default function GameCard({
                 {mode === 'score' && showScore ? awayScore : awaySpread != null ? spreadLabel(awaySpread) : ""}
               </Typography>
               {mode === 'pick' ? (
-                awayPickState !== 'none' ? (
+                awayPickState === 'submitted' ? (
+                  <Button
+                    color="success"
+                    variant="contained"
+                    disabled
+                    startIcon={<CheckIcon />}
+                    aria-label={`${awayTeam} locked in`}
+                    sx={pickButtonSx}
+                  >
+                    Locked in
+                  </Button>
+                ) : awayPickState !== 'none' ? (
                   <Button
                     color="success"
                     variant="contained"
                     onClick={onPickAway}
+                    aria-label={`${awayTeam} picked`}
                     sx={pickButtonSx}
                   >
                     Picked
@@ -122,6 +138,7 @@ export default function GameCard({
                     variant="contained"
                     disabled={locked}
                     onClick={onPickAway}
+                    aria-label={`Pick ${awayTeam}`}
                     sx={pickButtonSx}
                   >
                     Pick
@@ -164,7 +181,7 @@ export default function GameCard({
         <Card variant="outlined">
           <CardContent sx={{ p: '12px !important' }}>
             <Stack direction="row" alignItems="center" justifyContent="space-between">
-              <Box textAlign="center">{renderTeamLogo(homeTeam, homeJerseyUrl, true)}</Box>
+              {renderTeamLogo(homeTeam, homeJerseyUrl, true)}
               {!isPostSeason && homeRecord && (
                 <Typography variant="subtitle2">{homeRecord}</Typography>
               )}
@@ -172,11 +189,23 @@ export default function GameCard({
                 {mode === 'score' && showScore ? homeScore : homeSpread != null ? spreadLabel(homeSpread) : ""}
               </Typography>
               {mode === 'pick' ? (
-                homePickState !== 'none' ? (
+                homePickState === 'submitted' ? (
+                  <Button
+                    color="success"
+                    variant="contained"
+                    disabled
+                    startIcon={<CheckIcon />}
+                    aria-label={`${homeTeam} locked in`}
+                    sx={pickButtonSx}
+                  >
+                    Locked in
+                  </Button>
+                ) : homePickState !== 'none' ? (
                   <Button
                     color="success"
                     variant="contained"
                     onClick={onPickHome}
+                    aria-label={`${homeTeam} picked`}
                     sx={pickButtonSx}
                   >
                     Picked
@@ -187,6 +216,7 @@ export default function GameCard({
                     variant="contained"
                     disabled={locked}
                     onClick={onPickHome}
+                    aria-label={`Pick ${homeTeam}`}
                     sx={pickButtonSx}
                   >
                     Pick
@@ -220,7 +250,7 @@ export default function GameCard({
                   disabled={overUnderLocked && overPickState === 'none'}
                   onClick={onPickOver}
                 >
-                  {pickButtonLabel(overPickState, 'Over', 'Overed')}
+                  {overPickState !== 'none' ? `Over ${overValue} ✓` : 'Over'}
                 </Button>
                 <Typography variant="h6" className="fixed-width" sx={{ textAlign: 'center', flexShrink: 0 }}>
                   {overValue}
@@ -232,7 +262,7 @@ export default function GameCard({
                   disabled={overUnderLocked && underPickState === 'none'}
                   onClick={onPickUnder}
                 >
-                  {pickButtonLabel(underPickState, 'Under', 'Undered')}
+                  {underPickState !== 'none' ? `Under ${underValue} ✓` : 'Under'}
                 </Button>
               </Stack>
             </CardContent>

--- a/Client.React/src/pages/PicksPage.tsx
+++ b/Client.React/src/pages/PicksPage.tsx
@@ -107,6 +107,13 @@ export default function PicksPage({ adapter }: PicksPageProps) {
   }, []);
 
   // Pick management
+  const pickStateFor = (gameId: string, team: string, pickType = 'Spread'): PickState => {
+    const key = pickKey(gameId, team, pickType);
+    if (existingPicks.has(key)) return 'submitted';
+    if (userPicks.has(key)) return 'pending';
+    return 'none';
+  };
+
   const remainingPicks = requiredPicks - userPicks.size - existingPicks.size;
   const isPicksLocked = () => remainingPicks <= 0;
 
@@ -221,12 +228,6 @@ export default function PicksPage({ adapter }: PicksPageProps) {
         )}
 
         {games.map(game => {
-          const pickStateFor = (gameId: string, team: string, pickType = 'Spread'): PickState => {
-            const key = pickKey(gameId, team, pickType);
-            if (existingPicks.has(key)) return 'submitted'; // server-confirmed → Locked in
-            if (userPicks.has(key)) return 'pending';       // in-session → Picked (toggleable)
-            return 'none';
-          };
           const homePickState = pickStateFor(game.id, game.homeTeam);
           const awayPickState = pickStateFor(game.id, game.awayTeam);
           const overPickState = pickStateFor(game.id, game.homeTeam, 'Over');

--- a/Client.React/src/pages/PicksPage.tsx
+++ b/Client.React/src/pages/PicksPage.tsx
@@ -107,9 +107,6 @@ export default function PicksPage({ adapter }: PicksPageProps) {
   }, []);
 
   // Pick management
-  const isSelected = (gameId: string, team: string, pickType = 'Spread') =>
-    userPicks.has(pickKey(gameId, team, pickType)) || existingPicks.has(pickKey(gameId, team, pickType));
-
   const remainingPicks = requiredPicks - userPicks.size - existingPicks.size;
   const isPicksLocked = () => remainingPicks <= 0;
 
@@ -224,10 +221,16 @@ export default function PicksPage({ adapter }: PicksPageProps) {
         )}
 
         {games.map(game => {
-          const homePickState: PickState = isSelected(game.id, game.homeTeam) ? 'submitted' : 'none';
-          const awayPickState: PickState = isSelected(game.id, game.awayTeam) ? 'submitted' : 'none';
-          const overPickState: PickState = isSelected(game.id, game.homeTeam, 'Over') ? 'submitted' : 'none';
-          const underPickState: PickState = isSelected(game.id, game.homeTeam, 'Under') ? 'submitted' : 'none';
+          const pickStateFor = (gameId: string, team: string, pickType = 'Spread'): PickState => {
+            const key = pickKey(gameId, team, pickType);
+            if (existingPicks.has(key)) return 'submitted'; // server-confirmed → Locked in
+            if (userPicks.has(key)) return 'pending';       // in-session → Picked (toggleable)
+            return 'none';
+          };
+          const homePickState = pickStateFor(game.id, game.homeTeam);
+          const awayPickState = pickStateFor(game.id, game.awayTeam);
+          const overPickState = pickStateFor(game.id, game.homeTeam, 'Over');
+          const underPickState = pickStateFor(game.id, game.homeTeam, 'Under');
           const locked = gameIsLocked(game);
 
           return (


### PR DESCRIPTION
## Summary
- **Locked-pick affordance**: submitted (server-confirmed) picks now show a disabled "Locked in" button with ✓ icon — visually distinct from game-locked disabled "Pick" and from pending toggleable "Picked"
- **Pick state split**: PicksPage differentiates `pending` (in-session, toggleable) from `submitted` (server-confirmed, disabled); removed the now-unused `isSelected` helper
- **Team abbreviation text**: team abbr rendered as Typography caption below every helmet/jersey — visible even when jerseyUrl is provided (was image-only before)
- **aria-labels**: every pick button now has `aria-label="Pick BUF"` / `"BUF picked"` / `"BUF locked in"` for screen reader navigability
- **O/U copy**: "Overed"→`Over 47.5 ✓`, "Undered"→`Under 47.5 ✓`

## Tests (red → green)
- 8 new GameCard assertions
- Updated stale `picks.test.tsx` and `sharedPickLayout.test.tsx` assertions to match the corrected behavior (Overed→✓ copy, `/^Pick$/`→`/^Pick /`, "Locked in" for server picks)

## Test plan
- [x] 226/226 Vitest pass
- [x] `npm run typecheck` clean
- [x] No regressions

Closes frizat-mon.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)