### PR TITLE
feat(frizat-mon10): slim CLAUDE.md + pick-rules and demo-stack skills

### DIFF
--- a/.claude/skills/demo-stack/SKILL.md
+++ b/.claude/skills/demo-stack/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: demo-stack
+description: Start, verify, and reset the local demo stack. Port conflicts, seed data, demo users, running integration e2e tests.
+---
+
+# Demo Stack
+
+The demo stack runs a `DEMO_MODE=true` backend with deterministic seed data. Playwright integration e2e tests run against it.
+
+## Starting the Stack
+
+```bash
+# Easiest — postgres + backend (port 5000) + frontend (port 5174):
+./scripts/start-demo.sh
+
+# Or manually:
+docker compose up -d    # Step 1: start Postgres on localhost:5432
+
+# Backend (from Server/):
+ConnectionStrings__POSTGRES_CONNECTION_STRING="Host=localhost;Port=5432;Username=fourplay;Password=fourplay_local;Database=fourplay_dev" \
+  DEMO_MODE="true" ASPNETCORE_ENVIRONMENT=Development \
+  dotnet run --no-launch-profile --urls http://localhost:5000
+
+# Frontend (from Client.React/):
+VITE_API_TARGET=http://localhost:5000 npm run dev -- --port 5174
+```
+
+## URLs
+
+| URL | Sport |
+|-----|-------|
+| `localhost:5174` | NFL |
+| `cfb.localhost:5174` | CFB |
+| `/admin/leagueManagement` | Admin (log in as `admin`) |
+
+## Demo Users
+
+| Username | Password | Role |
+|----------|----------|------|
+| alice | `DemoPass@123` | User |
+| bob | `DemoPass@123` | User |
+| carlos | `DemoPass@123` | User |
+| dana | `DemoPass@123` | User |
+| eve | `DemoPass@123` | User |
+| admin | `DemoPass@123` | Admin |
+
+## Seed Data
+
+Seed is deterministic and idempotent — re-running clears and re-seeds.
+
+- **NFL**: 2025 season, all 18 regular season weeks + Wild Card/Divisional/Conference/Super Bowl (NflWeeks 19–22). Week 18 games from frozen `sample_espn_nfl.json`. All weeks have spreads + scores + picks.
+- **CFB**: 2025 season, all 18 slates ("CFB Demo League"). All slates have spreads, scores, and picks.
+- Alice's NFL Week 18 picks: BUF, DAL, MIN, MIA
+- Alice's CFP Championship pick: IU (Indiana)
+
+Pick count invariants → see `/pick-rules`.
+
+## Running Integration E2E Tests
+
+```bash
+cd Client.React/
+npm run test:e2e:demo                           # all demo tests
+npm run test:e2e:demo -- --grep "CFB picks"     # target a specific area
+```
+
+Setup projects (`setup.nfl.ts`, `setup.cfb.ts`) log in as Alice and save cookies to `e2e/demo/.auth/`. Run `npm run test:e2e:demo` locally before pushing — don't push blind and wait for CI.
+
+## Troubleshooting
+
+**Port conflict on 5000**: `lsof -ti :5000 | xargs kill -9`
+
+**Vite starts before backend**: all `/api/*` requests return SPA HTML. Kill Vite, wait for backend, restart Vite.
+
+**Use single quotes for `ADMIN_PASSWORD`** — double quotes cause bash history expansion on `!`.
+
+**Local dev always uses Docker PostgreSQL** — never connect to Neon (dev or prod) directly.

--- a/.claude/skills/pick-rules/SKILL.md
+++ b/.claude/skills/pick-rules/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: pick-rules
+description: NFL/CFB pick count invariants, CFB slate mapping, seeder guards, test rot checklist. Invoke before changing any pick logic.
+---
+
+# Pick Rules & Invariants
+
+## NFL Pick Count — `GetRequiredPicks(nflWeek)` C# / `getEspnRequiredPicks(week, isPostSeason)` TS
+
+| NflWeek | ESPN Week | Label | Required Picks |
+|---------|-----------|-------|---------------|
+| 1–18 | 1–18 | Regular Season | 4 |
+| 19 | 1 | Wild Card | 3 |
+| 20 | 2 | Divisional | 3 |
+| 21 | 3 | Conference Championship | 2 |
+| 22 | 4 | Super Bowl | 1 |
+
+`NflScoresJob` stores ESPN week 5 (Super Bowl) as NflWeek 22 via `j == 5 ? 4 : j` hack. `GetRequiredPicks(23)` throws — week 23 does not exist (Pro Bowl is skipped). Use `PopulateScoresTestDataAsync(21)` in tests, not 22.
+
+## CFB Pick Count — `GetCfbRequiredPicks(slateNumber)` C# / `getCfbRequiredPicks(slateNumber)` TS
+
+18-slate system: slates 1–13 = regular season, 14 = Conf. Champs, 15–18 = CFP rounds.
+
+| SlateNumber | Label | Required Picks |
+|-------------|-------|---------------|
+| 1–14 | Regular Season Weeks 1–13 + Conf. Championships | 4 |
+| 15–16 | CFP First Round + Quarterfinals | 3 |
+| 17 | CFP Semifinals | 2 |
+| 18 | CFP Championship | 1 |
+
+## CFB Slate Numbering (ESPN Week → SlateNumber)
+
+| SlateNumber | ESPN Week | Label |
+|---|---|---|
+| 1–13 | 1–13 | Week 1 – Week 13 |
+| 14 | 14 | Conf. Championships |
+| 15 | 16 | CFP First Round |
+| 16 | 18 | CFP Quarterfinals |
+| 17 | 20 | CFP Semifinals |
+| 18 | 21 | CFP Championship |
+
+`cfbSlateNumberToWeek(n)` / `cfbWeekToSlateNumber(week, isPostSeason)` in `src/utils/gameHelpers.ts`.
+Slates ≤13 → `isPostSeason=false`; slates 14+ → `isPostSeason=true`, `week = slateNumber - 13`.
+
+## NFL Week Numbering
+
+Regular season weeks 1–18 map directly. Postseason: `getWeekFromEspnWeek(week, isPostSeason)` adds +18 offset (Wild Card=19, Divisional=20, Conference=21, Super Bowl=22).
+
+## Demo Stack Pick Count Invariants (5 users, CFB Demo League)
+
+| Slate(s) | Picks/user | Total picks |
+|----------|-----------|-------------|
+| 1–13 (regular season) | 4 each | 20/slate |
+| 14 (Conf. Championships) | 4 spread + O/U for Bob/Dana | 22 |
+| 15–16 (First Round, QF) | 3 spread + O/U for Bob/Dana | 17/slate |
+| 17 (Semifinals) | 2 spread + O/U for Bob/Dana | 12 |
+| 18 (Championship) | 1 spread + O/U for Bob/Dana | 7 |
+| **Total** | — | **335** |
+
+`DemoDataSeeder.ExpectedPickCount = 335` is the runtime guard — never fudge it.
+
+## Seeder Is Production-Critical
+
+`DemoDataSeeder` seeds the same DB that Playwright e2e tests run against.
+- Every pick count must match `GetCfbRequiredPicks`/`GetRequiredPicks`
+- After ANY pick logic change: re-verify seeder counts AND run `npm run test:e2e:demo`
+- `ExpectedPickCount` in `DemoDataSeeder.cs` is a guard — update it accurately, never fudge it
+
+## Test Rot Checklist (Before Shipping Any Pick Logic Change)
+
+1. Read the tables above — understand the correct rule FIRST
+2. Grep ALL test files for old expected values: `GameHelpersTests.cs`, `LeaderboardTests.cs`, `picks.test.tsx`, e2e specs
+3. Update stale assertions BEFORE fixing the implementation
+4. Confirm new tests are red before writing any implementation
+5. Run full suite: `dotnet test` + `npm run test -- --run` + `npm run test:e2e:demo`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,196 +1,124 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code when working with this repository.
 
-## What This App Is — Read This First
+## What This App Is
 
-**IV League** is a weekly pick'em pool for NFL and CFB. Users pick N teams against a **league-admin-configured teased spread** each week. You must get **ALL picks right** to win the week. Winners collect juice (money) from losers.
+**IV League** is a weekly pick'em pool for NFL and CFB. Users pick N teams against a **league-admin-configured teased spread** each week. ALL picks must be correct to win. Winners collect juice (money) from losers.
 
-The tease amount is **NOT hardcoded** — it is set per-league by admins via `LeagueJuiceMapping`:
-- `Juice` = tease pts added for regular season games ("Juice (Teaser)" in admin UI)
-- `JuiceDivisional` = tease pts for Wild Card + Divisional rounds
-- `JuiceConference` = tease pts for Conference Championship round
-- `WeeklyCost` = money per week at stake
+The tease amount is **NOT hardcoded** — set per-league via `LeagueJuiceMapping` (`Juice` / `JuiceDivisional` / `JuiceConference` / `WeeklyCost`).
 
-Admin pages are at `/admin/leagueManagement` — **only visible to `isAdmin(user)=true` users**. In the demo stack, log in as `admin` (not Alice/Bob/etc.) to access.
+Admin pages: `/admin/leagueManagement` — requires `isAdmin(user)=true`. Log in as `admin` in the demo stack.
 
-### Pick Count Rules — Core Invariants
+## CRITICAL: Pick Count Invariants
 
-**NFL** (`GetRequiredPicks(nflWeek)` C# / `getEspnRequiredPicks(week, isPostSeason)` TS):
+**Run `/pick-rules` before touching any pick logic.** Full NFL/CFB pick count tables, CFB slate numbering, seeder invariants, and test rot checklist live there.
 
-| NflWeek | ESPN Week | Label | Required Picks |
-|---------|-----------|-------|---------------|
-| 1–18 | 1–18 | Regular Season | 4 |
-| 19 | 1 | Wild Card | 3 |
-| 20 | 2 | Divisional | 3 |
-| 21 | 3 | Conference Championship | 2 |
-| 22 | 4 | Super Bowl (stored via wk5→4 hack in NflScoresJob) | 1 |
-
-**CFB** (`GetCfbRequiredPicks(slateNumber)` C# / `getCfbRequiredPicks(slateNumber)` TS):
-
-18-slate system: slates 1–13 = regular season, 14 = Conf. Champs, 15–18 = CFP rounds.
-
-| SlateNumber | Label | Required Picks |
-|-------------|-------|---------------|
-| 1–14 | Regular Season Weeks 1–13 + Conf. Championships | 4 |
-| 15–16 | CFP First Round + Quarterfinals | 3 |
-| 17 | CFP Semifinals | 2 |
-| 18 | CFP Championship | 1 |
-
-**Before changing ANY pick logic:** read the tables above, run the full test suite, verify counts in the DB.
+Short version: NFL regular season = 4 picks; postseason decreases 3→3→2→1. CFB slates 1–14 = 4, 15–16 = 3, 17 = 2, 18 = 1.
 
 ---
 
 ## Test Quality Standards
 
 ### Before Writing Any Test
-1. Understand the correct business rule FIRST — read the pick count tables above
+1. Understand the correct business rule FIRST — run `/pick-rules` if touching pick logic
 2. A test asserting the wrong value is WORSE than no test — false confidence hides bugs
 3. Tests must assert THE RULE, not the current (possibly broken) implementation
 
 ### The Seeder Is Production-Critical
-- `DemoDataSeeder` seeds the demo DB that Playwright e2e tests run against — same data, same invariants
-- Every pick count in the seeder must match `GetCfbRequiredPicks`/`GetRequiredPicks`
-- After ANY change to pick logic: re-verify seeder counts AND run `npm run test:e2e:demo`
-- `ExpectedPickCount` in `DemoDataSeeder.cs` is a guard — update it accurately, never fudge it
+`DemoDataSeeder` seeds the demo DB that Playwright e2e tests run against. After any pick logic change: re-verify seeder counts AND run `npm run test:e2e:demo`. Never fudge `ExpectedPickCount`.
 
 ### Test Rot Prevention
-- When fixing a bug in business logic, ALWAYS check if existing tests assert the buggy behavior
-- Search for test assertions that match old wrong values before shipping
-- When changing `GetRequiredPicks`/`GetEspnRequiredPicks`: read ALL test files that reference the function, update expected values first, then fix the implementation
-
-### Demo Stack Pick Count Invariants (5 users, CFB Demo League)
-| Slate(s) | Picks/user | Total picks |
-|----------|-----------|-------------|
-| 1–13 (regular season) | 4 each | 20/slate |
-| 14 (Conf. Championships) | 4 spread + O/U for Bob/Dana | 22 |
-| 15–16 (First Round, QF) | 3 spread + O/U for Bob/Dana | 17/slate |
-| 17 (Semifinals) | 2 spread + O/U for Bob/Dana | 12 |
-| 18 (Championship) | 1 spread + O/U for Bob/Dana | 7 |
-| **Total** | — | **335** |
+When fixing a bug: grep existing tests for old wrong values before shipping. When changing `GetRequiredPicks`/`GetCfbRequiredPicks`: read ALL test files that reference the function, update expected values first, then fix the implementation.
 
 ---
 
 ## CRITICAL: TDD Is the Primary Development Methodology
 - **Write failing tests FIRST, then implement** — no exceptions
 - Red → Green → Refactor is the only acceptable order
-- If you catch yourself writing code without a failing test, stop and write the test first
 
 ### What Requires a Test (mandatory checklist per feature)
-Every new or changed feature MUST have all of the following before the bead is closeable:
 
 | What changed | Required test |
 |---|---|
-| New backend controller endpoint | xUnit test in `Server.UnitTests/` covering: happy path, auth/ownership 403, and any error branch |
-| New frontend pure function / helper | Vitest unit test in `src/__tests__/` covering edge cases |
-| New page or significant UI component | At minimum: one e2e-mock Playwright test in `e2e/` (happy path + empty/error state) |
-| New nav link or conditional UI element | Unit test asserting visibility rules (shown/hidden based on role/state) |
-| New API route added to routes.ts helpers | Verify mock is wired — if missing, `isLeagueOwner` / session state silently falls back to defaults |
-| Security guard (ownership/admin check) | xUnit test: Forbid for unauthorized caller, Ok for authorized caller, Ok for admin |
-| Pick reveal / game kickoff logic | Unit test: scheduled=hidden, in_progress=visible, own picks always visible, ESPN null=fail-open |
+| New backend controller endpoint | xUnit test: happy path, auth/ownership 403, error branch |
+| New frontend pure function / helper | Vitest unit test covering edge cases |
+| New page or significant UI component | Mock-based Playwright test (happy path + empty/error state) |
+| New nav link or conditional UI element | Unit test asserting visibility rules (shown/hidden by role/state) |
+| New API route in routes.ts | Verify mock is wired — missing mock silently falls back to defaults |
+| Security guard (ownership/admin check) | xUnit: Forbid unauthorized, Ok authorized, Ok admin |
+| Pick reveal / game kickoff logic | Unit test: scheduled=hidden, in_progress=visible, ESPN null=fail-open |
 
 ### Common Test Gaps to Watch For
-- **Controller ownership guard** — every new `Forbid()` branch needs its own test; don't assume coverage from similar endpoints
-- **Session-derived flags** (`isLeagueOwner`, `ownedLeagues`, sport filter) — test in `session.test.tsx`, not just in e2e
-- **New page with no route in `routes.ts`** — will 404 silently in all existing e2e tests; add the mock
-- **Frontend pick reveal** — `revealPicksForStartedGames` is tested in `sportAdapter.test.ts`; if you change it, update those tests first
+- **Controller ownership guard** — every `Forbid()` branch needs its own test
+- **Session-derived flags** (`isLeagueOwner`, `ownedLeagues`, sport filter) — test in `session.test.tsx`
+- **New page with no route in `routes.ts`** — will 404 silently in all existing e2e tests
+- **Frontend pick reveal** — `revealPicksForStartedGames` tested in `sportAdapter.test.ts`; update those tests first
+
+---
 
 ## CRITICAL: Branch Rules
 - **NEVER push or commit directly to `main`** — all changes go through a PR
 - Branch flow: `feature/*` → PR → `dev` → PR → `main`
-- Always create a feature branch, open a PR to `dev` first
 
 ## Task Tracking
-- Use `bd` (beads) for all task tracking — `BEADS_DIR=~/.beads bd`
+- Use `bd` (beads) — `LD_LIBRARY_PATH=~/.local/lib BEADS_DIR=~/.beads ~/.local/bin/bd`
 - Binary lives at `~/.local/bin/bd`; requires `dolt` in PATH (`~/go/bin/dolt`)
+
+---
 
 ## Bead Standards
 
 ### Creating a Bead
-Every bead MUST include:
-- `--title` — clear, action-oriented title
-- `--type` — bug | feature | task | chore
-- `--priority` — P0 (critical) through P4 (nice-to-have)
-- `--description` — what the problem is and why it matters
-- `--design` — where in the codebase to look, proposed approach
-- `--acceptance` — structured with the sections below
-- `--external-ref` — GitHub issue number if one exists (e.g. `gh-44`)
-- `--deps` — any blocking beads
+Every bead MUST include: `--title`, `--type` (bug|feature|task|chore), `--priority` (P0–P4), `--description`, `--design`, `--acceptance` (Unit Tests red first / Functional Gates / Success Definition), `--external-ref` (GitHub issue), `--deps`.
 
-Acceptance criteria MUST contain:
-1. **Unit Tests (red first)** — specific failing test cases to write before any implementation
-2. **Functional Gates** — observable behaviors that must work
-3. **Success Definition** — one paragraph describing the done state unambiguously
-
-### Taking a Bead (starting work)
-Before writing any code:
-1. `bd show <id>` — read the full bead including design notes and acceptance
-2. Write ALL unit tests listed in acceptance first — they must be red (failing)
-3. Confirm `dotnet test` or `npm run test -- --run` shows the new tests failing
-4. Only then implement the fix/feature
-5. All tests must go green before marking complete
-6. Run the full test suite — 0 regressions allowed
-
-### New Feature Requirements
-Every new user-facing feature MUST have:
-1. **Unit tests first (TDD)**
-   - Backend logic: xUnit tests in `Server.UnitTests/`
-   - Frontend logic/components: Vitest tests in `Client.React/src/__tests__/`
-2. **Playwright e2e test** — at least one happy-path test
-   - Mock-based: use `mockAuth()` + `setupRoutes()` from `e2e/helpers/`
-   - Integration: add to `e2e/demo/` if it requires real backend data
-   - Use typed factory functions from `src/test/fixtures.ts` — never raw JSON
+### Taking a Bead
+1. `bd show <id>` — read design notes and acceptance
+2. Write ALL listed unit tests first — they must be red (failing)
+3. Confirm failing: `dotnet test` or `npm run test -- --run`
+4. Implement; all tests must go green; 0 regressions
 
 ### CRITICAL: Before Opening a PR (mandatory — no exceptions)
-Run ALL three steps in order. Skipping any step is a violation of this process.
+Run ALL three steps in order. Skipping any is a violation of this process.
 
-1. **Run the full test suite** — all tests must pass before a PR is opened:
+1. **Full test suite** — all must pass:
    ```bash
-   dotnet test                                            # backend xUnit
-   npm run test -- --run                                  # frontend Vitest
-   npm run test:e2e -- --project=chromium                 # mock-based Playwright
+   dotnet test && npm run test -- --run && npm run test:e2e -- --project=chromium
    ```
-2. **`/simplify`** — review changed code for reuse, quality, and efficiency; apply any fixes
-3. **`/feature-dev:code-review`** — review for bugs, logic errors, and security issues; address findings
-
-Opening a PR before completing these steps wastes CI minutes and review cycles on avoidable failures.
+2. **`/simplify`** — review for reuse, quality, efficiency; apply fixes
+3. **`/feature-dev:code-review`** — review for bugs, logic errors, security; address findings
 
 ### Definition of Done
-A bead is closeable ONLY when:
-- Full test suite passes: `dotnet test` + `npm run test -- --run` (208+ tests) + `npm run test:e2e -- --project=chromium` (47+ tests)
-- Every item in the **mandatory checklist** above is satisfied
-- `/simplify` and `/feature-dev:code-review` have been run and issues addressed
-- PR merged to `dev`, then PR merged to `main`
+Closeable ONLY when: full test suite passes · mandatory checklist satisfied · `/simplify` + `/code-review` run · PR merged to `dev` then `main`
 
 ---
 
 ## Commands
 
-### Backend (run from repo root or `Server/`)
+### Backend (from repo root or `Server/`)
 ```bash
-dotnet build                          # build
-dotnet test                           # run all xUnit tests
-dotnet test --filter "ClassName"      # run a single test class
+dotnet build
+dotnet test
+dotnet test --filter "ClassName"
 dotnet run --project Server --no-launch-profile --urls http://localhost:5000
 ```
 
-### Frontend (run from `Client.React/`)
+### Frontend (from `Client.React/`)
 ```bash
 npm run typecheck          # tsc -b (matches CI/Vercel strict mode)
-npm run lint               # ESLint
-npm run test -- --run      # Vitest (all tests, no watch)
-npm run test -- --run src/__tests__/GameCard.test.tsx   # single file
-npm run test:e2e -- --project=chromium                 # mock-based Playwright
-npm run test:e2e:demo                                  # integration tests (needs demo stack)
-npm run test:e2e:demo -- --grep "CFB picks"            # target a specific area
-npm run dev -- --port 5173             # Vite dev server
-npm run build                          # production build
+npm run lint
+npm run test -- --run
+npm run test -- --run src/__tests__/GameCard.test.tsx
+npm run test:e2e -- --project=chromium   # mock-based Playwright
+npm run dev -- --port 5173
+npm run build
 ```
 
 ### Demo Stack
+Run `/demo-stack` for full startup instructions, users, seed data, and troubleshooting.
 ```bash
-./scripts/start-demo.sh               # easiest: starts postgres + backend + frontend (port 5174)
-docker compose up -d                  # start Postgres only (localhost:5432)
+./scripts/start-demo.sh               # easiest: postgres + backend + frontend (port 5174)
+npm run test:e2e:demo                 # integration tests (from Client.React/)
 ```
 
 ---
@@ -206,109 +134,42 @@ docker compose up -d                  # start Postgres only (localhost:5432)
 - **Testing**: xUnit + NSubstitute (backend), Vitest + RTL (frontend), Playwright (e2e)
 
 ### Dual-Sport Architecture
-The app serves two sports from a single codebase. Sport is determined by subdomain:
-- `localhost:5173` / `ivleague.com` → NFL
-- `cfb.localhost:5173` / `cfb.ivleague.com` → CFB
+Sport is determined by subdomain: `localhost:5173` / `ivleague.com` → NFL; `cfb.localhost:5173` / `cfb.ivleague.com` → CFB.
+`useSportContext()` detects sport via `window.location.hostname.startsWith('cfb.')`. The session layer filters leagues by `leagueType` (0=NFL, 1=CFB).
 
-`useSportContext()` in `src/services/sport.tsx` detects the sport via `window.location.hostname.startsWith('cfb.')`. The session layer (`src/services/session.tsx`) then filters leagues by `leagueType` (0=NFL, 1=CFB). `AppLayout.tsx` shows a "No NFL/CFB access" message if the user has no leagues for the current sport.
+`PicksPage`, `ScoresPage`, and `LeaderboardPage` are sport-agnostic via an `adapter: SportAdapter` prop injected by `App.tsx`.
+- **NFL adapter** (`nflAdapter.ts`): polls ESPN `/api/espn/scores`, fetches spreads via `spreadBatch`
+- **CFB adapter** (`cfbAdapter.ts`): uses our own DB (`/api/cfb/*`), no ESPN live data
 
-#### SportAdapter Pattern
-`PicksPage`, `ScoresPage`, and `LeaderboardPage` receive an `adapter: SportAdapter` prop and are sport-agnostic. `App.tsx` injects `nflAdapter` or `cfbAdapter` based on `useSportContext().isCfb`.
-
-- **NFL adapter** (`src/services/nflAdapter.ts`): polls ESPN's `/api/espn/scores`, fetches spreads via `spreadBatch`, loads live game situations
-- **CFB adapter** (`src/services/cfbAdapter.ts`): uses our own DB (slates/spreads/scores/picks via `/api/cfb/*`), no ESPN live data
-
-Both adapters normalize to `GameView` / `LoadedWeek` / `LoadedScores` from `src/services/sportAdapter.ts`.
-
-#### CFB Slate Numbering
-CFB seasons use 18 slates. SlateNumbers 1–13 = regular season, 14 = Conf. Champs, 15–18 = CFP postseason.
-Driven by `CfbSeasonWeekConfig` DB table (one row per ESPN week); `CfbSlateSeederJob` reads it to create `CfbSlates`.
-
-| SlateNumber | ESPN Week | Label |
-|---|---|---|
-| 1–13 | 1–13 | Week 1 – Week 13 |
-| 14 | 14 | Conf. Championships |
-| 15 | 16 | CFP First Round |
-| 16 | 18 | CFP Quarterfinals |
-| 17 | 20 | CFP Semifinals |
-| 18 | 21 | CFP Championship |
-
-`cfbSlateNumberToWeek(n)` / `cfbWeekToSlateNumber(week, isPostSeason)` convert between them (`src/utils/gameHelpers.ts`).
-Boundary: slates ≤13 → `isPostSeason=false`; slates 14+ → `isPostSeason=true`, `week = slateNumber - 13`.
-
-#### NFL Week Numbering
-NFL stores weeks 1–18 as regular season and maps postseason rounds to weeks 1–4 (Wild Card, Divisional, Conference, Super Bowl). `getWeekFromEspnWeek(week, isPostSeason)` converts ESPN week numbers to the DB's `nflWeek` value (postseason weeks are offset by +18).
+CFB uses an 18-slate season. Slate/ESPN week mappings and pick counts → run `/pick-rules`.
 
 ### Backend Structure
-- **`Server/Controllers/`** — thin HTTP controllers; business logic lives in services
-- **`Server/Services/`** — `DemoDataSeeder`, `SpreadCalculatorService`, `LeaderboardService`, `EspnCacheService`, etc.
-- **`Server/Jobs/`** — Quartz.NET scheduled jobs: `NflScoresJob` / `NflSpreadJob` (pull from ESPN/odds API weekly), `CfbSlateSeederJob` / `CfbSpreadJob` / `CfbScoresJob` (CFB data), `UserManagerJob` (creates/confirms demo users), `MissingPicksJob`
-- **`Server/Data/ApplicationDbContext.cs`** — single EF Core context; key tables: `NflPicks`, `NflSpreads`, `NflScores`, `NflWeeks`, `CfbSlates`, `CfbSeasonWeekConfigs`, `CfbSpreads`, `CfbScores`, `CfbPicks`, `LeagueInfo`, `LeagueUserMapping`, `LeagueJuiceMapping`
-- **`Shared/`** — DTOs shared between backend and (historically) frontend
+- `Server/Controllers/` — thin HTTP controllers; business logic in services
+- `Server/Services/` — `DemoDataSeeder`, `SpreadCalculatorService`, `LeaderboardService`, `EspnCacheService`, etc.
+- `Server/Jobs/` — Quartz.NET: `NflScoresJob`, `NflSpreadJob`, `CfbSlateSeederJob`, `CfbSpreadJob`, `CfbScoresJob`, `MissingPicksJob`
+- `Server/Data/ApplicationDbContext.cs` — key tables: `NflPicks/Spreads/Scores/Weeks`, `CfbSlates/SeasonWeekConfigs/Spreads/Scores/Picks`, `LeagueInfo`, `LeagueJuiceMapping`
 
 ### Frontend Structure
-- **`src/pages/`** — route-level components (`PicksPage`, `ScoresPage`, `LeaderboardPage` are sport-agnostic via adapter)
-- **`src/components/`** — shared UI; key: `sports/GameCard.tsx` (pick/score card for both sports), `WeekYearSelector.tsx` (navigates weeks/seasons/season-type), `SpreadRelease.tsx` (countdown or "no odds" message)
-- **`src/services/`** — React context providers: `auth.tsx` (JWT + refresh), `session.tsx` (league selection + sport access), `sport.tsx` (subdomain detection), `sportAdapter.ts` (shared interface)
-- **`src/api/`** — typed async fetch functions grouped by domain (`league.ts`, `espn.ts`, `cfb.ts`, etc.)
-- **`src/utils/gameHelpers.ts`** — week conversions, ESPN status parsing, spread formatting
+- `src/pages/` — `PicksPage`, `ScoresPage`, `LeaderboardPage` (sport-agnostic via adapter)
+- `src/components/` — `sports/GameCard.tsx`, `WeekYearSelector.tsx`, `SpreadRelease.tsx`
+- `src/services/` — `auth.tsx`, `session.tsx`, `sport.tsx`, `sportAdapter.ts`
+- `src/api/` — typed fetch functions: `league.ts`, `espn.ts`, `cfb.ts`, etc.
+- `src/utils/gameHelpers.ts` — week conversions, ESPN status parsing, spread formatting
 
 ### Auth Flow
-JWT is stored in an HttpOnly cookie (`AuthToken`). The backend reads it via a custom `OnMessageReceived` Kestrel hook in `Program.cs`. Refresh tokens rotate on each use. `src/services/auth.tsx` calls `GET /api/auth/me` on load to hydrate the auth context.
+JWT in HttpOnly cookie (`AuthToken`), read via custom `OnMessageReceived` hook in `Program.cs`. Refresh tokens rotate on each use. `auth.tsx` calls `GET /api/auth/me` on load.
 
 ### Testing Architecture
-
-#### Mock-based Playwright (`e2e/` excluding `demo/`)
-Uses `page.route()` to intercept all `/api/*` calls. `mockAuth()` in `e2e/helpers/auth.ts` sets a fake JWT cookie and routes `/api/auth/me` to return `TEST_USER` or `ADMIN_USER`. All routes are centralized in `e2e/helpers/routes.ts`. Runs in CI against a Vite dev server (no real backend).
-
-#### Integration Playwright (`e2e/demo/`)
-Runs against a live `DEMO_MODE=true` backend at `localhost:5174` (NFL) and `cfb.localhost:5174` (CFB). Uses storage-state auth: `setup.nfl.ts` / `setup.cfb.ts` log in as Alice once and save cookies to `e2e/demo/.auth/`. Test projects (`demo-nfl`, `demo-cfb`) depend on the setup projects. Run with `npm run test:e2e:demo`.
-
-**Demo seed data** (deterministic, idempotent):
-- NFL: 2025 season, all 18 regular season weeks + Wild Card/Divisional/Conference/Super Bowl (weeks 19-22). Week 18 games from frozen `sample_espn_nfl.json`. All historical weeks have spreads + scores + picks.
-- CFB: 2025 season, all 19 slates (Week 1–14 + Conf. Championships + 4 CFP rounds), "CFB Demo League". All slates have spreads, scores, and picks.
-- Users: Alice, Bob, Carlos, Dana, Eve (password: `DemoPass@123`) + admin
-- Alice's NFL Week 18 picks: BUF, DAL, MIN, MIA; Alice's CFP Championship pick: IU
+- **Mock-based Playwright** (`e2e/` excl. `demo/`): `page.route()` intercepts all `/api/*`. `mockAuth()` + `setupRoutes()` from `e2e/helpers/`. Runs in CI against a Vite dev server.
+- **Integration Playwright** (`e2e/demo/`): live `DEMO_MODE=true` backend at `localhost:5174`. Alice's session saved to `e2e/demo/.auth/`. See `/demo-stack`.
 
 ---
 
 ## Dev Environment
 
-### Design Philosophy
-- **Mobile-first**: Primary audience is iOS users on ~390px viewport (iPhone). Touch targets ≥44px.
-- **Dark/light theme**: MUI theme toggle, respects system preference.
-- Admin pages are secondary UX — functional over beautiful.
+**Mobile-first**: primary audience is iOS (~390px viewport). Touch targets ≥44px. Dark/light MUI theme.
 
-### Running the Stack Locally
-
-**IMPORTANT: Local dev uses a local Docker PostgreSQL — never connect to Neon directly.**
-
-```bash
-docker compose up -d                                      # Step 0: start Postgres (localhost:5432)
-./scripts/start-demo.sh                                   # easiest full-stack start
-```
-
-Or manually:
-```bash
-# Backend (from Server/):
-ConnectionStrings__POSTGRES_CONNECTION_STRING="Host=localhost;Port=5432;Username=fourplay;Password=fourplay_local;Database=fourplay_dev" \
-  DEMO_MODE="true" ASPNETCORE_ENVIRONMENT=Development \
-  dotnet run --no-launch-profile --urls http://localhost:5000
-
-# Frontend (from Client.React/):
-VITE_API_TARGET=http://localhost:5000 npm run dev -- --port 5173
-```
-
-**Use single quotes for `ADMIN_PASSWORD`** — double quotes cause bash history expansion on `!`, garbling the password.
-
-**If Vite starts before the backend**: all `/api/*` requests return SPA HTML. Fix: kill Vite, restart after backend is up.
-
-**Port conflict**: `lsof -ti :5000 | xargs kill -9`
-
-### Database
-- EF Core migrations auto-apply at startup in Development (`db.Database.Migrate()`)
-- Quartz.NET scheduler tables (`quartz.qrtz_*`) are EF-managed
-- Prod: Neon PostgreSQL; connection string in `.env`
+**Database**: EF Core migrations auto-apply at startup in Development. **Local dev always uses Docker PostgreSQL — never connect to Neon directly.** Prod: connection string in `.env`.
 
 ### MUI / React Gotchas
 - `useMediaQuery(theme.breakpoints.down('md'))` returns `false` on first render — always pass `{ noSsr: true }` for drawer open/close logic
@@ -316,6 +177,4 @@ VITE_API_TARGET=http://localhost:5000 npm run dev -- --port 5173
 - All data tables need `<Box sx={{ overflowX: 'auto' }}>` wrapper for mobile scroll
 
 ### Chrome DevTools MCP
-- Used for live browser debugging via `mcp__plugin_chrome-devtools-mcp_chrome-devtools__*` tools
-- Browser emulates iPhone viewport (390×844) by default in this project
-- Check network requests with `list_network_requests` to diagnose API failures before reading code
+`mcp__plugin_chrome-devtools-mcp_chrome-devtools__*` tools. Browser emulates iPhone (390×844) by default. Use `list_network_requests` to diagnose API failures before reading code.


### PR DESCRIPTION
## Summary
- `CLAUDE.md` cut from 321 → 180 lines (44% reduction): pick count tables, CFB slate mapping, seeder invariants, demo stack details all moved to on-demand skills
- `.claude/skills/pick-rules/SKILL.md`: NFL/CFB pick count tables, CFB slate → ESPN week mapping, demo stack pick count invariants, seeder guard, test rot checklist
- `.claude/skills/demo-stack/SKILL.md`: startup commands, URLs, demo users/passwords, seed data summary, e2e test commands, troubleshooting
- Memory files de-duped: stale/wrong CFB tables removed from `project_app_domain.md`; reference to `CLAUDE.md` tables updated to `/pick-rules` in `feedback_test_quality.md`

## Test plan
- [ ] No code changes — docs/config only
- [ ] CLAUDE.md loads cleanly in session context (no lost invariants; tables referenced via skill pointers)
- [ ] `/pick-rules` skill is invocable and contains complete pick count tables
- [ ] `/demo-stack` skill is invocable and contains startup + troubleshooting info

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)