### PR TITLE
feat(mon10+cfb): slim CLAUDE.md, extract skills, backend-driven CFB current slate

### DIFF
--- a/Client.React/src/__tests__/cfbAdapter.test.ts
+++ b/Client.React/src/__tests__/cfbAdapter.test.ts
@@ -4,6 +4,7 @@ import type { CfbSlateDto, CfbSpreadDto, CfbPickDto } from '../types/league';
 import type { EspnScores } from '../types/espn';
 
 vi.mock('../api/cfb', () => ({
+  getCfbCurrentSlate: vi.fn(),
   getCfbSlates: vi.fn(),
   getCfbSpreads: vi.fn(),
   getCfbScores: vi.fn(),
@@ -18,7 +19,7 @@ vi.mock('../api/espn', () => ({
   getLiveGames: vi.fn(),
 }));
 
-import { getCfbSlates, getCfbSpreads, getCfbScores, getCfbUserPicks } from '../api/cfb';
+import { getCfbCurrentSlate, getCfbSlates, getCfbSpreads, getCfbScores, getCfbUserPicks } from '../api/cfb';
 import { getCfbLiveScores, getLiveGames } from '../api/espn';
 
 const slate: CfbSlateDto = {
@@ -55,6 +56,7 @@ const adapter = createCfbAdapter();
 describe('cfbAdapter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getCfbCurrentSlate).mockResolvedValue(slate);
     vi.mocked(getLiveGames).mockResolvedValue([]);
     vi.mocked(getCfbScores).mockResolvedValue([]);
   });

--- a/Client.React/src/__tests__/sharedPickLayout.test.tsx
+++ b/Client.React/src/__tests__/sharedPickLayout.test.tsx
@@ -73,7 +73,7 @@ describe('NFL PicksPage — GameCard layout regression', () => {
 
 // ─── CFB regression ──────────────────────────────────────────────────────────
 vi.mock('../api/cfb', () => ({
-  getCfbSlates: vi.fn(), getCfbSpreads: vi.fn(), getCfbScores: vi.fn(),
+  getCfbCurrentSlate: vi.fn(), getCfbSlates: vi.fn(), getCfbSpreads: vi.fn(), getCfbScores: vi.fn(),
   getCfbUserPicks: vi.fn(), addCfbPicks: vi.fn(), deleteCfbPicks: vi.fn(),
 }));
 // Single espn mock covering both NFL and CFB needs
@@ -85,7 +85,7 @@ vi.mock('../api/espn', () => ({
   getLiveGames: vi.fn(),
 }));
 
-import { getCfbSlates, getCfbSpreads, getCfbScores, getCfbUserPicks } from '../api/cfb';
+import { getCfbCurrentSlate, getCfbSlates, getCfbSpreads, getCfbScores, getCfbUserPicks } from '../api/cfb';
 import { getCfbLiveScores, getLiveGames } from '../api/espn';
 
 const slate: CfbSlateDto = { id: 1, season: 2025, slateNumber: 8, label: 'Week 8', slateType: 'RegularSeason', startDate: '2025-10-11', endDate: '2025-10-18' };
@@ -94,6 +94,7 @@ const spread: CfbSpreadDto = { id: 1, cfbSlateId: 1, espnEventId: 100, homeTeam:
 describe('CFB PicksPage (via adapter) — GameCard layout regression', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getCfbCurrentSlate).mockResolvedValue(slate);
     vi.mocked(getCfbSlates).mockResolvedValue([slate]);
     vi.mocked(getCfbSpreads).mockResolvedValue([spread]);
     // ESPN returns scheduled game (future date → no score yet)

--- a/Client.React/src/api/cfb.ts
+++ b/Client.React/src/api/cfb.ts
@@ -3,6 +3,12 @@ import type { CfbSeasonWeekConfigDto } from '../types/admin';
 
 const BASE = '/api/cfb';
 
+export async function getCfbCurrentSlate(): Promise<CfbSlateDto | null> {
+  const res = await fetch(`${BASE}/current-slate`);
+  if (!res.ok) return null;
+  return res.json();
+}
+
 export async function getCfbSlates(season: number): Promise<CfbSlateDto[]> {
   const res = await fetch(`${BASE}/slates/${season}`);
   if (!res.ok) return [];

--- a/Client.React/src/services/cfbAdapter.ts
+++ b/Client.React/src/services/cfbAdapter.ts
@@ -1,4 +1,4 @@
-import { getCfbSlates, getCfbSpreads, getCfbScores, getCfbUserPicks, getCfbAllPicks, addCfbPicks, deleteCfbPicks } from '../api/cfb';
+import { getCfbCurrentSlate, getCfbSlates, getCfbSpreads, getCfbScores, getCfbUserPicks, getCfbAllPicks, addCfbPicks, deleteCfbPicks } from '../api/cfb';
 import { getCfbLiveScores, getLiveGames } from '../api/espn';
 import { cfbSlateNumberToWeek, cfbWeekToSlateNumber, getCfbWeekName, computeHomeCovers, computeOverWins, getCfbRequiredPicks } from '../utils/gameHelpers';
 import type { CfbSlateDto, CfbSpreadDto, CfbScoreDto, CfbPickDto } from '../types/league';
@@ -9,17 +9,12 @@ import { revealPicksForStartedGames } from './sportAdapter';
 
 /** Map CFB backend status strings to canonical GameStatusValue */
 
-// Production target season — adapter falls back to prior year if no slates exist yet.
+// Fallback season shown when no slates are available at all (empty DB / first-run edge case)
 const CFB_CONFIGURED_SEASON = 2026;
 // Earliest supported CFB season (controls the lower bound of the season dropdown).
 const CFB_FIRST_SEASON = 2025;
 const CFB_REGULAR_WEEKS = Array.from({ length: 13 }, (_, i) => i + 1); // weeks 1-13
 const CFB_POST_WEEKS = [1, 2, 3, 4, 5]; // Conf.Champs + CFP First Round/QF/SF/Championship
-
-function findActiveSlate(slates: CfbSlateDto[]): CfbSlateDto | null {
-  const now = new Date();
-  return slates.find(s => new Date(s.endDate) >= now) ?? slates[slates.length - 1] ?? null;
-}
 
 function slateToWeekState(slate: CfbSlateDto): WeekState {
   const { week, isPostSeason } = cfbSlateNumberToWeek(slate.slateNumber);
@@ -164,19 +159,20 @@ async function loadSlate(leagueId: number, _userId: string, slateId: number, sla
 }
 
 export function createCfbAdapter(): SportAdapter {
-  // Cache slates and the resolved season (may differ from CFB_CONFIGURED_SEASON in demo/off-season)
   let cachedSlates: CfbSlateDto[] = [];
-  let resolvedSeason: number = CFB_CONFIGURED_SEASON;
+  // undefined = not yet fetched; null = backend returned no slate
+  let cachedCurrentSlate: CfbSlateDto | null | undefined = undefined;
+
+  async function getCurrentSlate(): Promise<CfbSlateDto | null> {
+    if (cachedCurrentSlate === undefined)
+      cachedCurrentSlate = await getCfbCurrentSlate();
+    return cachedCurrentSlate;
+  }
 
   async function getSlates(): Promise<CfbSlateDto[]> {
     if (cachedSlates.length === 0) {
-      let slates = await getCfbSlates(CFB_CONFIGURED_SEASON);
-      if (slates.length === 0) {
-        // No data for configured year yet — fall back to prior year (demo / off-season)
-        slates = await getCfbSlates(CFB_CONFIGURED_SEASON - 1);
-        if (slates.length > 0) resolvedSeason = CFB_CONFIGURED_SEASON - 1;
-      }
-      cachedSlates = slates;
+      const current = await getCurrentSlate();
+      if (current) cachedSlates = await getCfbSlates(current.season);
     }
     return cachedSlates;
   }
@@ -206,23 +202,25 @@ export function createCfbAdapter(): SportAdapter {
     },
 
     async currentSeasonYear() {
-      await getSlates(); // ensure resolvedSeason is set
-      return resolvedSeason;
+      const current = await getCurrentSlate();
+      return current?.season ?? CFB_CONFIGURED_SEASON;
     },
 
     async loadCurrentGames(leagueId, userId) {
-      const slates = await getSlates();
-      const active = findActiveSlate(slates);
+      const active = await getCurrentSlate();
       if (!active) {
-        return { season: resolvedSeason, week: 1, isPostSeason: false, games: [], userPicks: [], hasOdds: false, requiredPicks: 0, maxWeek: 1, maxSeason: resolvedSeason };
+        return { season: CFB_CONFIGURED_SEASON, week: 1, isPostSeason: false, games: [], userPicks: [], hasOdds: false, requiredPicks: 0, maxWeek: 1, maxSeason: CFB_CONFIGURED_SEASON };
       }
+      const [slates, { games, userPicks }] = await Promise.all([
+        getSlates(),
+        loadSlate(leagueId, userId, active.id, active),
+      ]);
       const weekState = slateToWeekState(active);
-      const { games, userPicks } = await loadSlate(leagueId, userId, active.id, active);
       // maxWeek = max REGULAR season week with data (caps the regular season selector)
       const maxRegularSlate = slates
         .filter(s => s.slateType === 'RegularSeason')
         .reduce((max, s) => Math.max(max, s.slateNumber), 0);
-      return { ...weekState, games, userPicks, hasOdds: games.length > 0, requiredPicks: getCfbRequiredPicks(active.slateNumber), maxWeek: maxRegularSlate || 13, maxSeason: resolvedSeason };
+      return { ...weekState, games, userPicks, hasOdds: games.length > 0, requiredPicks: getCfbRequiredPicks(active.slateNumber), maxWeek: maxRegularSlate || 13, maxSeason: active.season };
     },
 
     async loadHistoricalGames(leagueId, userId, { season, week, isPostSeason }) {
@@ -260,15 +258,14 @@ export function createCfbAdapter(): SportAdapter {
     // ─── Scores ─────────────────────────────────────────────────────────────
 
     async loadCurrentScores(leagueId, userId) {
-      const slates = await getSlates();
-      const active = findActiveSlate(slates);
+      const active = await getCurrentSlate();
       if (!active) {
-        return { season: resolvedSeason, week: 1, isPostSeason: false, games: [], allPicks: [], userPicks: [], hasOdds: false, hasActiveGames: false, requiredPicks: 0, maxWeek: 1, maxSeason: resolvedSeason };
+        return { season: CFB_CONFIGURED_SEASON, week: 1, isPostSeason: false, games: [], allPicks: [], userPicks: [], hasOdds: false, hasActiveGames: false, requiredPicks: 0, maxWeek: 1, maxSeason: CFB_CONFIGURED_SEASON };
       }
       const weekState = slateToWeekState(active);
       const { games, allPicks, userPicks } = await loadScoresForSlate(leagueId, userId, active);
       const hasActiveGames = games.some(g => g.gameStatus === 'in_progress' || g.gameStatus === 'halftime');
-      return { ...weekState, games, allPicks, userPicks, hasOdds: games.length > 0, hasActiveGames, requiredPicks: getCfbRequiredPicks(active.slateNumber), maxWeek: weekState.week, maxSeason: resolvedSeason };
+      return { ...weekState, games, allPicks, userPicks, hasOdds: games.length > 0, hasActiveGames, requiredPicks: getCfbRequiredPicks(active.slateNumber), maxWeek: weekState.week, maxSeason: active.season };
     },
 
     async loadHistoricalScores(leagueId, userId, { season, week, isPostSeason }) {

--- a/Server/Controllers/CfbPicksController.cs
+++ b/Server/Controllers/CfbPicksController.cs
@@ -1,4 +1,5 @@
 using FourPlayWebApp.Server.Auth;
+using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models.Data;
 using FourPlayWebApp.Shared.Models.Data.Dtos;
@@ -12,6 +13,12 @@ namespace FourPlayWebApp.Server.Controllers;
 [Route("api/cfb")]
 [Authorize]
 public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo) : ControllerBase {
+    [HttpGet("current-slate")]
+    public async Task<IActionResult> GetCurrentSlate([FromServices] ICfbCurrentSlateService svc) {
+        var slate = await svc.GetCurrentSlateAsync();
+        return slate is null ? NotFound() : Ok(slate);
+    }
+
     [HttpGet("slates/{season}")]
     public async Task<IActionResult> GetSlates(int season) =>
         Ok(await cfbRepo.GetSlatesForSeasonAsync(season));

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -252,6 +252,7 @@ builder.Services.AddSingleton<ILeagueRepository, LeagueRepository>();
 builder.Services.AddScoped<ICfbRepository, CfbRepository>();
 builder.Services.AddScoped<ICfbPicksRepository, CfbPicksRepository>();
 builder.Services.AddSingleton<INflCurrentWeekService, NflCurrentWeekService>();
+builder.Services.AddScoped<ICfbCurrentSlateService, CfbCurrentSlateService>();
 // Register job observer for observability
 builder.Services.AddSingleton<IJobObserverService, JobObserverService>();
 

--- a/Server/Services/CfbCurrentSlateService.cs
+++ b/Server/Services/CfbCurrentSlateService.cs
@@ -10,8 +10,8 @@ public class CfbCurrentSlateService(ICfbRepository repo) : ICfbCurrentSlateServi
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
         var slates = (await repo.GetSlatesForSeasonAsync(ConfiguredSeason)).ToList();
 
-        // Pre-season: all slates haven't started yet — fall back to prior year
-        if (slates.Count > 0 && slates.All(s => s.StartDate > today))
+        // Empty or pre-season: no slates yet, or all are future — fall back to prior year
+        if (slates.All(s => s.StartDate > today))
             slates = (await repo.GetSlatesForSeasonAsync(ConfiguredSeason - 1)).ToList();
 
         if (slates.Count == 0) return null;

--- a/Server/Services/CfbCurrentSlateService.cs
+++ b/Server/Services/CfbCurrentSlateService.cs
@@ -1,0 +1,24 @@
+using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Server.Services.Repositories.Interfaces;
+
+namespace FourPlayWebApp.Server.Services;
+
+public class CfbCurrentSlateService(ICfbRepository repo) : ICfbCurrentSlateService {
+    private const int ConfiguredSeason = 2026;
+
+    public async Task<CfbSlateInfo?> GetCurrentSlateAsync() {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var slates = (await repo.GetSlatesForSeasonAsync(ConfiguredSeason)).ToList();
+
+        // Pre-season: all slates haven't started yet — fall back to prior year
+        if (slates.Count > 0 && slates.All(s => s.StartDate > today))
+            slates = (await repo.GetSlatesForSeasonAsync(ConfiguredSeason - 1)).ToList();
+
+        if (slates.Count == 0) return null;
+
+        // First slate whose end date hasn't passed = current; all past → show last (off-season)
+        var active = slates.FirstOrDefault(s => s.EndDate >= today) ?? slates[^1];
+        return new CfbSlateInfo(active.Id, active.Season, active.SlateNumber, active.Label,
+            active.SlateType, active.StartDate, active.EndDate, active.FirstGameUtc);
+    }
+}

--- a/Server/Services/Interfaces/ICfbCurrentSlateService.cs
+++ b/Server/Services/Interfaces/ICfbCurrentSlateService.cs
@@ -1,0 +1,8 @@
+namespace FourPlayWebApp.Server.Services.Interfaces;
+
+public record CfbSlateInfo(int Id, int Season, int SlateNumber, string Label, string SlateType,
+    DateOnly StartDate, DateOnly EndDate, DateTimeOffset? FirstGameUtc);
+
+public interface ICfbCurrentSlateService {
+    Task<CfbSlateInfo?> GetCurrentSlateAsync();
+}


### PR DESCRIPTION
## Summary

- **mon10**: Slimmed `CLAUDE.md` from ~320 → ~180 lines; extracted pick count tables and demo stack docs into `.claude/skills/pick-rules/` and `.claude/skills/demo-stack/` skills
- **CFB current slate**: Moved "what is the current CFB week?" from frontend to backend, mirroring how `NflCurrentWeekService` works for NFL

## CFB pre-season fix

`CfbSlateSeederJob` had created 2026 slates in the DB (season starts Sep 1). `cfbAdapter` was configured with `CFB_CONFIGURED_SEASON = 2026`, picked up those slates, found Week 1 as "active" (endDate Sep 7 > today), got empty spreads, and rendered `SpreadRelease` instead of the picks grid — breaking all 16 CFB demo tests.

**Root cause**: pre-season/off-season detection logic lived in the frontend (`cfbAdapter.ts`), where it didn't belong. NFL handles this on the backend via `NflCurrentWeekService`.

**Fix**: Added `CfbCurrentSlateService` (mirrors `NflCurrentWeekService` exactly):
- **In-season**: first slate with `EndDate >= today`
- **Off-season**: last completed slate (e.g. CFP Championship after January)
- **Pre-season**: all slates in configured year are future → fall back to prior year

Exposed as `GET /api/cfb/current-slate`. `cfbAdapter` now calls this and fetches all slates for the returned season (for navigation). Frontend decision logic removed entirely.

## Test plan

- [x] `dotnet test` — all backend unit tests pass
- [x] `npm run test -- --run` — all Vitest tests pass
- [x] `npm run test:e2e -- --project=chromium` — all mock-based Playwright tests pass
- [x] `npm run test:e2e:demo` — 45/45 demo integration tests pass (NFL 29 + CFB 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)