### PR TITLE
feat(edd): CFB SSE live score push

### DIFF
--- a/Client.React/src/__tests__/cfbAdapter.test.ts
+++ b/Client.React/src/__tests__/cfbAdapter.test.ts
@@ -145,11 +145,15 @@ describe('cfbAdapter', () => {
   });
 
   describe('config', () => {
-    it('pollIntervalMs is 60s (1-minute fallback polling)', () => {
-      expect(adapter.pollIntervalMs).toBe(60_000);
+    it('pollIntervalMs is 300s (SSE primary; poll is fallback)', () => {
+      expect(adapter.pollIntervalMs).toBe(300_000);
     });
     it('currentSeasonYear returns 2026', async () => {
       expect(await adapter.currentSeasonYear()).toBe(2026);
+    });
+    it('sseUrl points at CFB live-stream endpoint', () => {
+      expect(adapter.sseUrl).toBeDefined();
+      expect(adapter.sseUrl).toContain('/api/cfb/live-stream');
     });
     it('weekLabelFn returns CFP Championship for week 5 postseason', () => {
       const fn = adapter.weekSelectorConfig.weekLabelFn!;

--- a/Client.React/src/services/cfbAdapter.ts
+++ b/Client.React/src/services/cfbAdapter.ts
@@ -192,7 +192,8 @@ export function createCfbAdapter(): SportAdapter {
 
   return {
     sport: 'cfb',
-    pollIntervalMs: 60_000,
+    pollIntervalMs: 300_000,
+    sseUrl: `${import.meta.env.VITE_API_TARGET ?? ''}/api/cfb/live-stream`,
     weekSelectorConfig: {
       regularWeekOptions: CFB_REGULAR_WEEKS,
       postSeasonWeekOptions: CFB_POST_WEEKS,

--- a/Server.UnitTests/CfbScoreChangeNotifierTests.cs
+++ b/Server.UnitTests/CfbScoreChangeNotifierTests.cs
@@ -1,0 +1,75 @@
+using FourPlayWebApp.Server.Services;
+using FourPlayWebApp.Shared.Models.Data;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+public class CfbScoreChangeNotifierTests
+{
+    private static CfbScores MakeScore(int id, int home, int away, string status) =>
+        new() { EspnEventId = id, HomeTeamScore = home, AwayTeamScore = away, GameStatus = status };
+
+    [Fact]
+    public void NotifyIfChanged_FiresEvent_OnFirstCallWithScores()
+    {
+        var notifier = new CfbScoreChangeNotifier();
+        int fired = 0;
+        notifier.ScoresChanged += () => fired++;
+
+        notifier.NotifyIfChanged([MakeScore(1, 0, 0, "StatusInProgress")]);
+
+        Assert.Equal(1, fired);
+    }
+
+    [Fact]
+    public void NotifyIfChanged_DoesNotFire_WhenListIsEmpty()
+    {
+        var notifier = new CfbScoreChangeNotifier();
+        int fired = 0;
+        notifier.ScoresChanged += () => fired++;
+
+        notifier.NotifyIfChanged([]);
+
+        Assert.Equal(0, fired);
+    }
+
+    [Fact]
+    public void NotifyIfChanged_FiresAgain_WhenScoresChange()
+    {
+        var notifier = new CfbScoreChangeNotifier();
+        int fired = 0;
+        notifier.ScoresChanged += () => fired++;
+
+        notifier.NotifyIfChanged([MakeScore(1, 0, 0, "StatusInProgress")]);
+        notifier.NotifyIfChanged([MakeScore(1, 21, 14, "StatusFinal")]);
+
+        Assert.Equal(2, fired);
+    }
+
+    [Fact]
+    public void NotifyIfChanged_DoesNotFire_WhenScoresIdentical()
+    {
+        var notifier = new CfbScoreChangeNotifier();
+        int fired = 0;
+        notifier.ScoresChanged += () => fired++;
+
+        var scores = new List<CfbScores> { MakeScore(1, 21, 14, "StatusFinal") };
+
+        notifier.NotifyIfChanged(scores);
+        notifier.NotifyIfChanged(scores);
+
+        Assert.Equal(1, fired);
+    }
+
+    [Fact]
+    public void NotifyIfChanged_FiresOnce_WhenSameScoresPassedAsNewList()
+    {
+        var notifier = new CfbScoreChangeNotifier();
+        int fired = 0;
+        notifier.ScoresChanged += () => fired++;
+
+        notifier.NotifyIfChanged([MakeScore(1, 21, 14, "StatusFinal")]);
+        notifier.NotifyIfChanged([MakeScore(1, 21, 14, "StatusFinal")]);
+
+        Assert.Equal(1, fired);
+    }
+}

--- a/Server.UnitTests/CfbScoresJobTests.cs
+++ b/Server.UnitTests/CfbScoresJobTests.cs
@@ -14,16 +14,18 @@ public class CfbScoresJobTests
 {
     private readonly ICfbApiService _cfbApi;
     private readonly ICfbRepository _repo;
+    private readonly ICfbScoreChangeNotifier _notifier;
     private readonly IJobExecutionContext _context;
 
     public CfbScoresJobTests()
     {
         _cfbApi = Substitute.For<ICfbApiService>();
         _repo = Substitute.For<ICfbRepository>();
+        _notifier = Substitute.For<ICfbScoreChangeNotifier>();
         _context = Substitute.For<IJobExecutionContext>();
     }
 
-    private CfbScoresJob BuildJob() => new(_cfbApi, _repo);
+    private CfbScoresJob BuildJob() => new(_cfbApi, _repo, _notifier);
 
     private static CfbSlates BuildSlate() => new()
     {
@@ -262,5 +264,32 @@ public class CfbScoresJobTests
         await BuildJob().Execute(_context);
 
         await _repo.DidNotReceive().UpsertCfbScoresAsync(Arg.Any<IEnumerable<CfbScores>>());
+    }
+
+    // ── SSE notifier tests ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_CallsNotifier_WhenScoresUpserted()
+    {
+        _repo.GetSlatesForSeasonAsync(Arg.Any<int>()).Returns([BuildSlate()]);
+        _cfbApi.GetScoresByDateAsync(new DateOnly(2025, 12, 19))
+            .Returns(BuildScoreboard(status: TypeName.StatusFinal));
+        _cfbApi.GetScoresByDateAsync(new DateOnly(2025, 12, 20)).Returns((EspnScores?)null);
+
+        await BuildJob().Execute(_context);
+
+        _notifier.Received(1).NotifyIfChanged(Arg.Any<IEnumerable<CfbScores>>());
+    }
+
+    [Fact]
+    public async Task Execute_DoesNotCallNotifier_WhenNoScoresFinal()
+    {
+        _repo.GetSlatesForSeasonAsync(Arg.Any<int>()).Returns([BuildSlate()]);
+        _cfbApi.GetScoresByDateAsync(Arg.Any<DateOnly>())
+            .Returns(BuildScoreboard(status: TypeName.StatusScheduled));
+
+        await BuildJob().Execute(_context);
+
+        _notifier.DidNotReceive().NotifyIfChanged(Arg.Any<IEnumerable<CfbScores>>());
     }
 }

--- a/Server/Controllers/CfbPicksController.cs
+++ b/Server/Controllers/CfbPicksController.cs
@@ -6,6 +6,7 @@ using FourPlayWebApp.Shared.Models.Data.Dtos;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
+using FourPlayWebApp.Server.Infrastructure;
 
 namespace FourPlayWebApp.Server.Controllers;
 
@@ -90,6 +91,13 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
         await repo.DeletePicksAsync(leagueId, cfbSlateId, CurrentUserId);
         return Ok();
     }
+
+    [HttpGet("live-stream")]
+    public Task LiveStream([FromServices] ICfbScoreChangeNotifier notifier, CancellationToken ct) =>
+        SseHelper.StreamAsync(Response,
+            h => notifier.ScoresChanged += h,
+            h => notifier.ScoresChanged -= h,
+            ct);
 
     [HttpGet("week-configs/{season:int}")]
     [Authorize(Roles = AppRoles.Administrator)]

--- a/Server/Controllers/EspnController.cs
+++ b/Server/Controllers/EspnController.cs
@@ -1,4 +1,4 @@
-using System.Threading.Channels;
+using FourPlayWebApp.Server.Infrastructure;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Shared.Models;
 using FourPlayWebApp.Shared.Models.Data.Dtos;
@@ -56,35 +56,11 @@ public class EspnController(IEspnApiService espnApiService, IEspnCacheService es
         return Ok(games);
     }
     [HttpGet("live-stream")]
-    public async Task LiveStream(CancellationToken ct) {
-        Response.Headers["Content-Type"] = "text/event-stream";
-        Response.Headers["Cache-Control"] = "no-cache";
-        Response.Headers["X-Accel-Buffering"] = "no";
-
-        var channel = Channel.CreateBounded<string>(new BoundedChannelOptions(10) {
-            FullMode = BoundedChannelFullMode.DropOldest,
-        });
-
-        void OnChanged() => channel.Writer.TryWrite("data: scores-updated\n\n");
-
-        espnCacheService.ScoresChanged += OnChanged;
-        try {
-            using var heartbeat = new PeriodicTimer(TimeSpan.FromSeconds(28));
-            _ = Task.Run(async () => {
-                while (await heartbeat.WaitForNextTickAsync(ct))
-                    channel.Writer.TryWrite(": heartbeat\n\n");
-            }, ct);
-
-            await foreach (var msg in channel.Reader.ReadAllAsync(ct)) {
-                await Response.WriteAsync(msg, ct);
-                await Response.Body.FlushAsync(ct);
-            }
-        } catch (OperationCanceledException) {
-            // client disconnected — normal
-        } finally {
-            espnCacheService.ScoresChanged -= OnChanged;
-        }
-    }
+    public Task LiveStream(CancellationToken ct) =>
+        SseHelper.StreamAsync(Response,
+            h => espnCacheService.ScoresChanged += h,
+            h => espnCacheService.ScoresChanged -= h,
+            ct);
 
 /*
     [HttpGet("odds/events/{eventId:int}")]

--- a/Server/Infrastructure/SseHelper.cs
+++ b/Server/Infrastructure/SseHelper.cs
@@ -1,0 +1,40 @@
+using System.Threading.Channels;
+using Microsoft.AspNetCore.Http;
+
+namespace FourPlayWebApp.Server.Infrastructure;
+
+public static class SseHelper {
+    public static async Task StreamAsync(
+        HttpResponse response,
+        Action<Action> subscribe,
+        Action<Action> unsubscribe,
+        CancellationToken ct) {
+
+        response.Headers["Content-Type"] = "text/event-stream";
+        response.Headers["Cache-Control"] = "no-cache";
+        response.Headers["X-Accel-Buffering"] = "no";
+
+        var channel = Channel.CreateBounded<string>(new BoundedChannelOptions(10) {
+            FullMode = BoundedChannelFullMode.DropOldest,
+        });
+
+        void OnChanged() => channel.Writer.TryWrite("data: scores-updated\n\n");
+
+        subscribe(OnChanged);
+        try {
+            using var heartbeat = new PeriodicTimer(TimeSpan.FromSeconds(28));
+            _ = Task.Run(async () => {
+                while (await heartbeat.WaitForNextTickAsync(ct))
+                    channel.Writer.TryWrite(": heartbeat\n\n");
+            }, ct);
+
+            await foreach (var msg in channel.Reader.ReadAllAsync(ct)) {
+                await response.WriteAsync(msg, ct);
+                await response.Body.FlushAsync(ct);
+            }
+        } catch (OperationCanceledException) {
+        } finally {
+            unsubscribe(OnChanged);
+        }
+    }
+}

--- a/Server/Jobs/CfbScoresJob.cs
+++ b/Server/Jobs/CfbScoresJob.cs
@@ -9,7 +9,7 @@ using Serilog;
 namespace FourPlayWebApp.Server.Jobs;
 
 [DisallowConcurrentExecution]
-public class CfbScoresJob(ICfbApiService cfbApi, ICfbRepository repo) : IJob {
+public class CfbScoresJob(ICfbApiService cfbApi, ICfbRepository repo, ICfbScoreChangeNotifier notifier) : IJob {
     private const int Season = 2026;
 
     public async Task Execute(IJobExecutionContext context) {
@@ -58,6 +58,7 @@ public class CfbScoresJob(ICfbApiService cfbApi, ICfbRepository repo) : IJob {
 
         if (scores.Count > 0) {
             await repo.UpsertCfbScoresAsync(scores);
+            notifier.NotifyIfChanged(scores);
             Log.Information("CfbScoresJob: upserted {Count} CFB scores", scores.Count);
         }
         Log.Information("CfbScoresJob: complete at {Time}", DateTime.UtcNow);

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -253,6 +253,7 @@ builder.Services.AddScoped<ICfbRepository, CfbRepository>();
 builder.Services.AddScoped<ICfbPicksRepository, CfbPicksRepository>();
 builder.Services.AddSingleton<INflCurrentWeekService, NflCurrentWeekService>();
 builder.Services.AddScoped<ICfbCurrentSlateService, CfbCurrentSlateService>();
+builder.Services.AddSingleton<ICfbScoreChangeNotifier, CfbScoreChangeNotifier>();
 // Register job observer for observability
 builder.Services.AddSingleton<IJobObserverService, JobObserverService>();
 

--- a/Server/Services/CfbScoreChangeNotifier.cs
+++ b/Server/Services/CfbScoreChangeNotifier.cs
@@ -1,0 +1,27 @@
+using FourPlayWebApp.Shared.Models.Data;
+using FourPlayWebApp.Server.Services.Interfaces;
+
+namespace FourPlayWebApp.Server.Services;
+
+public class CfbScoreChangeNotifier : ICfbScoreChangeNotifier {
+    private readonly object _lock = new();
+    private string? _lastFingerprint;
+
+    public event Action? ScoresChanged;
+
+    public void NotifyIfChanged(IEnumerable<CfbScores> scores) {
+        var list = scores.ToList();
+        if (list.Count == 0) return;
+
+        var fp = string.Join("|", list
+            .OrderBy(s => s.EspnEventId)
+            .Select(s => $"{s.EspnEventId}:{s.HomeTeamScore}:{s.AwayTeamScore}:{s.GameStatus}"));
+
+        bool changed;
+        lock (_lock) {
+            changed = fp != _lastFingerprint;
+            if (changed) _lastFingerprint = fp;
+        }
+        if (changed) ScoresChanged?.Invoke();
+    }
+}

--- a/Server/Services/Interfaces/ICfbScoreChangeNotifier.cs
+++ b/Server/Services/Interfaces/ICfbScoreChangeNotifier.cs
@@ -1,0 +1,8 @@
+using FourPlayWebApp.Shared.Models.Data;
+
+namespace FourPlayWebApp.Server.Services.Interfaces;
+
+public interface ICfbScoreChangeNotifier {
+    event Action? ScoresChanged;
+    void NotifyIfChanged(IEnumerable<CfbScores> scores);
+}


### PR DESCRIPTION
## Summary
- Add `ICfbScoreChangeNotifier` singleton — fingerprint-based dedup fires `ScoresChanged` only when scores actually change
- `CfbScoresJob` calls `notifier.NotifyIfChanged(scores)` after each upsert
- `CfbPicksController.LiveStream` endpoint streams SSE via shared `SseHelper`
- `SseHelper` extracted from `EspnController` to eliminate 30-line duplication between NFL and CFB streaming
- `cfbAdapter.sseUrl` wired to `/api/cfb/live-stream`; `pollIntervalMs` raised 60s → 300s (SSE is now primary)
- `_lastFingerprint` protected by lock per code-review finding (thread-safe singleton)

## Test plan
- [x] `CfbScoreChangeNotifierTests` — 5 unit tests (dedup, empty-list guard, fires on change)
- [x] `CfbScoresJobTests` — 2 SSE tests (calls notifier on upsert, skips when no final games)
- [x] `cfbAdapter.test.ts` — sseUrl + pollIntervalMs tests
- [x] `dotnet test` — 372 passed
- [x] `npm run test -- --run` — 227 passed
- [x] `npm run test:e2e -- --project=chromium` — 50 passed
- [x] `npm run test:e2e:demo` — 45/45 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)