### PR TITLE
security: remove hardcoded secrets from launchSettings.json

### DIFF
--- a/Server/Properties/launchSettings.json
+++ b/Server/Properties/launchSettings.json
@@ -16,18 +16,18 @@
         "applicationUrl": "https://localhost:7209;http://localhost:5142",
         "environmentVariables": {
           "ASPNETCORE_ENVIRONMENT": "Development",
-          "ADMIN_PASSWORD": "qPEMIPJ578e5Ne!",
-          "POSTGRES_CONNECTION_STRING": "Server=10.0.1.5;Port=5432;User Id=root;Password=password;Database=fourplay;Include Error Detail=true",
-          "ConnectionStrings__POSTGRES_CONNECTION_STRING": "Server=10.0.1.5;Port=5432;User Id=root;Password=password;Database=fourplay;Include Error Detail=true",
-          "ADMIN_EMAIL": "fourplaywebbetty@gmail.com",
-          "ADMIN_USERNAME": "fourplaywebbetty",
-          "FOURPLAY_EMAIL_PASS": "zgde vpau zebb hwsp",
-          "FOURPLAY_EMAIL_USER": "fourplaywebbetty@gmail.com",
+          "ADMIN_PASSWORD": "",
+          "POSTGRES_CONNECTION_STRING": "",
+          "ConnectionStrings__POSTGRES_CONNECTION_STRING": "",
+          "ADMIN_EMAIL": "",
+          "ADMIN_USERNAME": "",
+          "FOURPLAY_EMAIL_PASS": "",
+          "FOURPLAY_EMAIL_USER": "",
           "Jwt__Audience": "FourPlayWebAppClient",
           "Jwt__ExpiresMinutes": "1000",
           "Jwt__Issuer": "FourPlayWebApp",
-          "Jwt__Key": "b7d0QyLWkxl8l4sQpEavhKxN2l3aZfS6kW8wqN4e0fY=",
-          "APP_URL": "https://fourplaywebapp.azurewebsites.net"
+          "Jwt__Key": "",
+          "APP_URL": ""
         }
       },
       "IIS Express": {


### PR DESCRIPTION
## Summary
`Server/Properties/launchSettings.json` has had real credentials committed in plaintext since the repo's initial commit — an admin password, a full Postgres connection string, a Gmail App Password, and the JWT signing key. Repo is public. Blanking all secret values (keeping keys, so the file still documents what's needed for a local IDE run profile).

**This is the "stop it going forward" half of the fix.** The credentials must also be rotated at the source (tracked separately) since a public-repo leak has to be treated as compromised regardless of this commit. Git history purge is being handled separately (full history rewrite, not a normal PR).

## Test plan
- N/A — JSON config values only, no app logic touched.

🤖 Generated with [Claude Code](https://claude.ai/code)