### PR TITLE
fix(test): eliminate PeriodicRefreshCache flaky test

### DIFF
--- a/Server.UnitTests/PeriodicRefreshCacheTests.cs
+++ b/Server.UnitTests/PeriodicRefreshCacheTests.cs
@@ -73,19 +73,24 @@ public class PeriodicRefreshCacheTests
     [Fact]
     public async Task RefreshLoop_SurvivesFetchException_AndKeepsPriorValue()
     {
+        // No Changed event fires here (fetch always throws), so there's nothing to hook the way
+        // WaitForChangedAsync does above — signal directly from inside the fetch delegate instead
+        // of gambling on a fixed Task.Delay window (the previous version raced the background
+        // loop's actual scheduling under CI load and could fail even with correct behavior).
+        var fetchRan = new TaskCompletionSource();
         int callCount = 0;
         await using var cache = new PeriodicRefreshCache<string>(
             fetch: () => {
                 Interlocked.Increment(ref callCount);
+                fetchRan.TrySetResult();
                 throw new InvalidOperationException("simulated fetch failure");
             },
             fingerprint: v => v,
             interval: TimeSpan.FromMinutes(5),
             initialDelay: TimeSpan.FromMilliseconds(50));
 
-        // No Changed subscriber to wait on (fetch always throws) — give the background loop a
-        // generous window to run and confirm it didn't crash or corrupt state.
-        await Task.Delay(500);
+        var completed = await Task.WhenAny(fetchRan.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.True(completed == fetchRan.Task, "Timed out waiting for the fetch to be called.");
 
         Assert.True(callCount >= 1);
         Assert.Null(cache.Current);


### PR DESCRIPTION
## Summary
- \`RefreshLoop_SurvivesFetchException_AndKeepsPriorValue\` was waiting a fixed \`Task.Delay(500)\` and hoping the background refresh loop had run by then — flaked under CI load (observed on PR #172's \`backend\` job). This file already documents the fix pattern for exactly this class of bug (\`WaitForChangedAsync\`), but this one test never got it since it has no \`Changed\` event to hook.
- Fixed by signaling a \`TaskCompletionSource\` directly from inside the fetch delegate, so the test waits exactly as long as needed instead of guessing a wall-clock window.
- Verified with 15 back-to-back local runs post-fix; full backend suite (434/434) green.

## Test plan
- [x] \`dotnet test --filter "FullyQualifiedName~PeriodicRefreshCacheTests"\` — 15/15 consecutive local runs, 0 failures
- [x] \`dotnet test --filter "Category!=Contract"\` — 434/434 passing

🤖 Generated with [Claude Code](https://claude.ai/code)