### PR TITLE
security: add gitleaks secret scanning (pre-commit + CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,17 @@ on:
     branches: [dev, main]
 
 jobs:
+  secret-scan:
+    name: Secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   backend:
     name: Backend build & test
     runs-on: ubuntu-latest

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,31 @@
+# Extends gitleaks' default ruleset. Added after a real incident (2026-08-05): a plaintext
+# admin password and a Gmail App Password sat in Server/Properties/launchSettings.json since
+# the repo's initial commit, undetected by gitleaks' default rules — those only catch
+# key-shaped/high-entropy secrets (JWTs, API keys), not human-typed passwords in a
+# `"SOME_KEY": "value"` pair.
+#
+# Scoped tightly to config/env-style files with UPPER_SNAKE_CASE keys (how the real leak
+# looked: ADMIN_PASSWORD, FOURPLAY_EMAIL_PASS, Jwt__Key) — NOT arbitrary C# source, where
+# lowercase test fixtures like `password = "wrong-password"` are normal and would otherwise
+# flood this with false positives on every test file.
+[extend]
+useDefault = true
+
+[[rules]]
+id = "generic-password-assignment"
+description = "UPPER_SNAKE_CASE password/secret key assigned a value in a config/env-style file"
+regex = '''\b[A-Z][A-Z0-9]*(_PASS(WORD)?|_SECRET)\b["']?\s*[:=]\s*["']?([^"'\s,}]{6,})["']?'''
+secretGroup = 3
+path = '''(launchSettings\.json|appsettings.*\.json|\.env.*|docker-compose.*\.ya?ml)$'''
+# .example/template files intentionally hold placeholder values (e.g. "Change-Me-..."), and
+# docker-compose.yml's local-only Postgres password ("fourplay_local") is a published,
+# non-sensitive default only ever reachable on localhost — not real leaked secrets.
+allowlist.paths = ['''\.example$''']
+allowlist.regexes = ['''fourplay_local''']
+
+[[rules]]
+id = "gmail-app-password"
+description = "Gmail App Password (16 lowercase letters in 4 space-separated groups of 4) in a config/env-style file"
+regex = '''\b[a-z]{4} [a-z]{4} [a-z]{4} [a-z]{4}\b'''
+path = '''(launchSettings\.json|appsettings.*\.json|\.env.*|docker-compose.*\.ya?ml)$'''
+allowlist.paths = ['''\.example$''']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,16 @@ repos:
       - id: no-commit-to-branch
         args: ['--branch', 'main', '--branch', 'dev']
 
+  # detect-private-key above only catches PEM-format keys — gitleaks catches generic secrets
+  # (passwords, JWT keys, API tokens, connection strings) that don't match a known key format.
+  # Added after a real incident: launchSettings.json had a plaintext admin password, DB
+  # connection string, Gmail App Password, and JWT signing key committed since the repo's
+  # initial commit, undetected by every hook above.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
   - repo: local
     hooks:
       - id: eslint


### PR DESCRIPTION
## Summary
Follow-up to today's secrets incident (real admin password, DB connection string, Gmail App Password, and JWT key committed in plaintext since the repo's initial commit — fixed in #172, history purged separately). The existing `detect-private-key` pre-commit hook only catches PEM-format keys; nothing in the pipeline would have caught what actually leaked.

- **Pre-commit**: adds the `gitleaks` hook, with a custom `.gitleaks.toml` extending the default ruleset — two rules scoped specifically to config/env-style files (`launchSettings.json`, `appsettings*.json`, `.env*`, `docker-compose*.yml`) for `*_PASSWORD`/`*_SECRET`-shaped keys and Gmail App Password shapes. Scoped by file path deliberately — an unscoped version flagged 32 false positives on normal test fixtures like `password = "wrong-password"`.
- **CI**: new "Secret scan" job (`gitleaks/gitleaks-action`) on every PR — catches anyone bypassing the pre-commit hook with `--no-verify`.

## Test plan
- [x] Reproduced the exact original 3 secrets in a scratch repo — caught by both a direct scan and the real pre-commit hook on a staged commit
- [x] Full scan of the current codebase (not just staged files) — zero false positives on tracked code; only gitignored files (`.env.backend`, e2e auth-state JSON) show up, which pre-commit never sees anyway
- [x] `.example` template files correctly excluded (they intentionally hold placeholder values)

🤖 Generated with [Claude Code](https://claude.ai/code)