### PR TITLE
fix(picks): scope kickoff guard to the pick's own season/week

### DIFF
--- a/Server.UnitTests/PicksTests.cs
+++ b/Server.UnitTests/PicksTests.cs
@@ -176,6 +176,42 @@ public class PicksTests
     }
 
     [Fact]
+    public async Task AddPicks_TeamNameCollisionInDifferentWeekSeason_DoesNotFalselyReject()
+    {
+        // Regression: the kickoff guard used to match a pick's team against ANY cached ESPN
+        // competition by abbreviation alone, ignoring season/week — so a historical pick for
+        // "BUF" in Week 5/2023 got wrongly rejected just because the CURRENTLY cached event
+        // happens to also involve BUF (in an unrelated Week 2/2024 game that already kicked
+        // off). Real-world case: restoring historical picks whose team happened to also be
+        // playing in the live/most-recent cached game.
+        var pastKickoff = DateTimeOffset.UtcNow.AddHours(-2);
+        const int historicalSeason = 2023;
+        const int historicalWeek = 5;
+
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetNflWeeksAsync(historicalSeason).Returns([new NflWeeks { Id = 99, NflWeek = historicalWeek, Season = historicalSeason }]);
+        repo.UserExistsInLeagueAsync(UserId, LeagueId).Returns(true);
+        repo.GetUserNflPicksAsync(UserId, LeagueId, historicalSeason, historicalWeek).Returns([]);
+        repo.AddNflPicksAsync(Arg.Any<IEnumerable<NflPicks>>()).Returns(Task.CompletedTask);
+
+        var espn = Substitute.For<IEspnCacheService>();
+        espn.GetScoresAsync().Returns(BuildScores(pastKickoff)); // cached: BUF vs MIA, Week 2/2024, already kicked off
+
+        var controller = BuildController(repo, espn, BuildPrincipal(UserId));
+        var picks = new[] { new NflPickDto {
+            LeagueId = LeagueId, UserId = UserId, Team = "BUF", Pick = PickType.Spread,
+            NflWeek = historicalWeek, Season = historicalSeason,
+        } };
+
+        // Act
+        var result = await controller.AddPicks(picks);
+
+        // Assert — BUF's Week 2/2024 kickoff is irrelevant to this Week 5/2023 pick
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal(1, ok.Value);
+    }
+
+    [Fact]
     public async Task AddPicks_WhenEspnCacheIsEmpty_AllowsPicks()
     {
         // Arrange — ESPN cache cold / unavailable; should not block picks

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -6,6 +6,7 @@ using FourPlayWebApp.Server.Models.Mappers;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Helpers;
+using FourPlayWebApp.Shared.Helpers.Extensions;
 using FourPlayWebApp.Shared.Models;
 using FourPlayWebApp.Shared.Models.Data;
 using FourPlayWebApp.Shared.Models.Data.Dtos;
@@ -409,12 +410,18 @@ public class LeagueController(
         }
         else
         {
-            var allCompetitions = espnScores.Events.SelectMany(e => e.Competitions).ToList();
             var now = DateTimeOffset.UtcNow;
             foreach (var pick in picksList)
             {
-                var competition = allCompetitions.FirstOrDefault(c =>
-                    c.Competitors.Any(comp => string.Equals(comp.Team?.Abbreviation, pick.Team, StringComparison.OrdinalIgnoreCase)));
+                // Scope the match to the SAME season/week as the pick — matching by team
+                // abbreviation alone let a historical pick get falsely rejected whenever that
+                // team also happened to appear in the currently-cached (unrelated) event.
+                var competition = espnScores.Events
+                    .Where(e => e.Season.Year == pick.Season &&
+                                GameHelpers.GetWeekFromEspnWeek(e.Week.Number, e.IsPostSeason()) == pick.NflWeek)
+                    .SelectMany(e => e.Competitions)
+                    .FirstOrDefault(c =>
+                        c.Competitors.Any(comp => string.Equals(comp.Team?.Abbreviation, pick.Team, StringComparison.OrdinalIgnoreCase)));
                 if (competition is not null && competition.Date <= now)
                     return BadRequest($"Pick rejected: {pick.Team}'s game has already kicked off.");
             }


### PR DESCRIPTION
## Summary
Found while restoring a real user's historical picks in production: `AddPicks`' kickoff guard matched a submitted pick's team against ANY competition in the current ESPN cache by team abbreviation alone, ignoring season/week entirely. A historical pick for a team that happened to also be in the currently-cached (unrelated) event got falsely rejected as "already kicked off" — even though it was for a completely different game, months apart.

Fixed by scoping the match to the pick's own (season, week) via the event's own `Season.Year`/`Week.Number` (converted through the existing `GameHelpers.GetWeekFromEspnWeek` + `IsPostSeason()`), so the guard only ever compares a pick against the actual game it's for.

## Test plan
- [x] New regression test (`AddPicks_TeamNameCollisionInDifferentWeekSeason_DoesNotFalselyReject`) — red first (reproduced the exact bug), green after the fix
- [x] Full backend suite: 435/435 passing
- [x] Existing kickoff-guard tests (`AddPicks_WhenGameKickoffHasPassed_ReturnsBadRequest`, `AddPicks_WhenGameKickoffIsInFuture_ReturnsOk`) still pass — same-week/season rejection behavior is unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)