### PR TITLE
chore(schema): frizat-896 full DB schema audit — CFB FK gaps fixed, naming fix, findings documented

### DIFF
--- a/Server/Data/Configurations/CfbPicksConfiguration.cs
+++ b/Server/Data/Configurations/CfbPicksConfiguration.cs
@@ -1,3 +1,5 @@
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Shared.Models.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -19,5 +21,25 @@ public class CfbPicksConfiguration : IEntityTypeConfiguration<CfbPicks>
         entity.HasIndex(e => new { e.UserId, e.LeagueId, e.CfbSlateId, e.Season, e.Team, e.PickType }).IsUnique();
         entity.HasIndex(e => e.LeagueId);
         entity.HasIndex(e => e.CfbSlateId);
+
+        // UserId/LeagueId/CfbSlateId were previously unenforced "soft FKs" — no DB-level
+        // referential integrity at all, unlike NflPicks (frizat-896 schema audit). See
+        // CfbSpreadsConfiguration for the full CfbSlateId/Restrict rationale. UserId/LeagueId are
+        // the one delta from that: they mirror NflPicks' Cascade exactly, since deleting a user or
+        // a league is meant to take their picks with them.
+        entity.HasOne<ApplicationUser>()
+            .WithMany()
+            .HasForeignKey(e => e.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        entity.HasOne<LeagueInfo>()
+            .WithMany()
+            .HasForeignKey(e => e.LeagueId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        entity.HasOne<CfbSlates>()
+            .WithMany()
+            .HasForeignKey(e => e.CfbSlateId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/Server/Data/Configurations/CfbScoresConfiguration.cs
+++ b/Server/Data/Configurations/CfbScoresConfiguration.cs
@@ -1,3 +1,4 @@
+using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Shared.Models.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -17,5 +18,13 @@ public class CfbScoresConfiguration : IEntityTypeConfiguration<CfbScores>
         // upsert-by-EspnEventId the same way CfbSpreads' index backstops its upsert.
         entity.HasIndex(e => e.EspnEventId).IsUnique();
         entity.HasIndex(e => e.CfbSlateId);
+
+        // CfbSlateId was previously an unenforced "soft FK" — see CfbSpreadsConfiguration for the
+        // full rationale (frizat-896 schema audit). Restrict protects real final-score history from
+        // being silently orphaned by a bulk slate delete.
+        entity.HasOne<CfbSlates>()
+            .WithMany()
+            .HasForeignKey(e => e.CfbSlateId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/Server/Data/Configurations/CfbSpreadsConfiguration.cs
+++ b/Server/Data/Configurations/CfbSpreadsConfiguration.cs
@@ -1,3 +1,4 @@
+using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Shared.Models.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -15,5 +16,15 @@ public class CfbSpreadsConfiguration : IEntityTypeConfiguration<CfbSpreads>
 
         entity.HasIndex(e => e.EspnEventId).IsUnique();
         entity.HasIndex(e => e.CfbSlateId);
+
+        // CfbSlateId was previously an unenforced "soft FK" (indexed, joined against in queries,
+        // but no DB-level constraint) — frizat-896 schema audit. Restrict (not Cascade): CfbSlates
+        // rows are deleted in bulk by CfbSlateSeederJob's stale-slate cleanup with no check for
+        // whether real spread data already exists for them; Restrict turns a would-be silent
+        // orphan into a loud failure instead of quietly detaching real odds data from its slate.
+        entity.HasOne<CfbSlates>()
+            .WithMany()
+            .HasForeignKey(e => e.CfbSlateId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/Server/Data/Configurations/LeagueInfoConfiguration.cs
+++ b/Server/Data/Configurations/LeagueInfoConfiguration.cs
@@ -17,7 +17,7 @@ public class LeagueInfoConfiguration : IEntityTypeConfiguration<LeagueInfo>
             .HasDefaultValue(LeagueType.Nfl);
         entity.HasIndex(e => e.LeagueName).IsUnique();
 
-        entity.HasMany(e => e.LeagueUsers)
+        entity.HasMany(e => e.LeagueUserMappings)
             .WithOne(e => e.League)
             .HasForeignKey(e => e.LeagueId)
             .IsRequired();

--- a/Server/Data/Configurations/LeagueUserMappingConfiguration.cs
+++ b/Server/Data/Configurations/LeagueUserMappingConfiguration.cs
@@ -14,7 +14,7 @@ public class LeagueUserMappingConfiguration : IEntityTypeConfiguration<LeagueUse
             .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
         entity.HasOne(e => e.League)
-            .WithMany(l => l.LeagueUsers)
+            .WithMany(l => l.LeagueUserMappings)
             .HasForeignKey(e => e.LeagueId)
             .IsRequired();
 

--- a/Server/Migrations/20260810165726_AddCfbForeignKeysAndFixNavProperty.Designer.cs
+++ b/Server/Migrations/20260810165726_AddCfbForeignKeysAndFixNavProperty.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260810165726_AddCfbForeignKeysAndFixNavProperty")]
+    partial class AddCfbForeignKeysAndFixNavProperty
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/20260810165726_AddCfbForeignKeysAndFixNavProperty.cs
+++ b/Server/Migrations/20260810165726_AddCfbForeignKeysAndFixNavProperty.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCfbForeignKeysAndFixNavProperty : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddForeignKey(
+                name: "FK_CfbPicks_AspNetUsers_UserId",
+                table: "CfbPicks",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CfbPicks_CfbSlates_CfbSlateId",
+                table: "CfbPicks",
+                column: "CfbSlateId",
+                principalTable: "CfbSlates",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CfbPicks_LeagueInfo_LeagueId",
+                table: "CfbPicks",
+                column: "LeagueId",
+                principalTable: "LeagueInfo",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CfbScores_CfbSlates_CfbSlateId",
+                table: "CfbScores",
+                column: "CfbSlateId",
+                principalTable: "CfbSlates",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CfbSpreads_CfbSlates_CfbSlateId",
+                table: "CfbSpreads",
+                column: "CfbSlateId",
+                principalTable: "CfbSlates",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CfbPicks_AspNetUsers_UserId",
+                table: "CfbPicks");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CfbPicks_CfbSlates_CfbSlateId",
+                table: "CfbPicks");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CfbPicks_LeagueInfo_LeagueId",
+                table: "CfbPicks");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CfbScores_CfbSlates_CfbSlateId",
+                table: "CfbScores");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CfbSpreads_CfbSlates_CfbSlateId",
+                table: "CfbSpreads");
+        }
+    }
+}

--- a/Server/Models/Data/LeagueInfo.cs
+++ b/Server/Models/Data/LeagueInfo.cs
@@ -12,6 +12,9 @@ public class LeagueInfo {
     public LeagueType LeagueType { get; set; } = LeagueType.Nfl;
     public ICollection<LeagueJuiceMapping> LeagueJuiceMappings { get; set; } = new List<LeagueJuiceMapping>();
 
-    public ICollection<LeagueUserMapping> LeagueUsers { get; set; }
+    // Renamed from "LeagueUsers" (frizat-896 schema audit) — that name collided with the unrelated
+    // LeagueUsers entity/table (an orphaned write-only email allowlist, see audit notes on
+    // frizat-896), even though this collection is actually LeagueUserMapping rows.
+    public ICollection<LeagueUserMapping> LeagueUserMappings { get; set; }
     public ICollection<NflPicks> NflPicks { get; set; }
 }

--- a/Server/Services/Repositories/CfbRepository.cs
+++ b/Server/Services/Repositories/CfbRepository.cs
@@ -18,6 +18,12 @@ public class CfbRepository(IDbContextFactory<ApplicationDbContext> dbFactory) : 
         await db.SaveChangesAsync();
     }
 
+    // frizat-2lc: unlike DemoDataSeeder.SeedCfbSlatesAsync's equivalent re-seed path, this does not
+    // clean up dependent CfbSpreads/CfbScores/CfbPicks before deleting. CfbSlateSeederJob is the
+    // only caller and only invokes this when existing < configured slate count. As of frizat-896,
+    // CfbSlateId now carries a Restrict FK from those three tables, so a slate with real dependent
+    // data will now throw here (loud failure) instead of silently orphaning rows — but the
+    // underlying gap (no guard against deleting a slate that already has real data) is unfixed.
     public async Task DeleteSlatesAsync(IEnumerable<CfbSlates> slates) {
         await using var db = await dbFactory.CreateDbContextAsync();
         db.CfbSlates.RemoveRange(slates);

--- a/Server/Services/Repositories/LeagueRepository.cs
+++ b/Server/Services/Repositories/LeagueRepository.cs
@@ -47,7 +47,7 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
         await using var db = await dbContextFactory.CreateDbContextAsync();
         return await db.LeagueInfo.Where(x => x.Id == leagueId)
             .Include(li => li.LeagueJuiceMappings)
-            .Include(li => li.LeagueUsers)
+            .Include(li => li.LeagueUserMappings)
             .FirstAsync();
     }
 


### PR DESCRIPTION
## Summary

Full read-only schema audit for `frizat-896` (P2, under the `frizat-703` go-live epic), covering every table in `ApplicationDbContext` not already touched by the merged PR #180 (spread-scheduling tables — verified present on `dev`, not redone here).

### Fixed in this PR

1. **Missing FK constraints on CFB tables** (`CfbSpreadsConfiguration.cs`, `CfbScoresConfiguration.cs`, `CfbPicksConfiguration.cs`) — `CfbSpreads`, `CfbScores`, and `CfbPicks` all had `CfbSlateId` columns that were conceptually FKs (indexed, joined against) but carried **zero DB-level referential integrity**, unlike NFL's equivalent (`NflPicks.NflWeekId` has a real FK to `NflWeeks`). `CfbPicks.UserId`/`LeagueId` were in the same state. Verified zero orphaned rows against the live dev DB before adding constraints. `CfbSlateId` uses `Restrict` (not `Cascade`) deliberately — see finding below. `UserId`/`LeagueId` use `Cascade`, mirroring `NflPicksConfiguration` exactly.
2. **Misleading nav property renamed**: `LeagueInfo.LeagueUsers` (actually `ICollection<LeagueUserMapping>`) → `LeagueInfo.LeagueUserMappings`, across `LeagueInfo.cs`, `LeagueInfoConfiguration.cs`, `LeagueUserMappingConfiguration.cs`, `LeagueRepository.cs`. Pure rename — confirmed zero migration diff. Fixes confusion with the real (separately audited, see below) `LeagueUsers` entity/table.

Migration `20260810165726_AddCfbForeignKeysAndFixNavProperty` round-tripped (down/up) clean against the live dev DB; the new `Restrict` constraint was directly confirmed via `psql` to reject a delete, not just trusted from the migration.

### The 3 findings already logged in the bead — investigated and resolved

1. **`LeagueUsers` table "orphaned"** — **confirmed, but not simply dead.** It's write-only: `UserManagerJob.CreateBaseLeagueUser` writes a row for the admin email on every startup, `DemoDataSeeder` writes one per demo user, and `LeagueController.AddLeagueUser` (admin-only `POST /api/league/league-user`) can write one — but **nothing reads it for any actual decision**, and the frontend never calls that endpoint (grepped `Client.React/src` — zero references). Superseded by `LeagueUserMapping` + `AspNetUsers` as the original comment suspected. **Not dropped** — that's a product decision (data-loss risk) I'm flagging, not making.
2. **`NflPicks.NflWeek` + `NflWeekId` redundancy** — **confirmed redundant in value** (checked live data: zero rows where `NflWeek`/`Season` disagree with the `NflWeeks` row `NflWeekId` points to), **but they serve different structural roles**: `NflWeek` (raw int) is load-bearing everywhere — the unique index, `Equals`/`GetHashCode`, `GetRequiredPicks(week)`, every controller/DTO. `NflWeekId` exists solely to satisfy the FK constraint to `NflWeeks`; its nav property (`NflWeekInfo`) is never actually read anywhere (`grep` confirms zero `.Include(p => p.NflWeekInfo)` call sites). Removing either is a real, wider-blast-radius change than anything else in this PR — **flagged, not touched**.
3. **`NflPicks` unique index including `Pick`** — **investigated per the task's explicit instruction to run `/pick-rules` first, and concluded the original bead comment was wrong.** Traced the full flow: `PicksPage.tsx` calls `selectPick(game.id, game.homeTeam, 'Over')` — the *same* `Team` value used for a `Spread` pick on that team — and `picks.test.tsx`'s `'postseason allows selecting spread and over picks together'` test asserts exactly this UI flow. Postseason users are meant to hold both a Spread pick and an Over/Under pick on the same team in the same week; without `Pick` in the unique index, the second insert would collide with the first. **This constraint is correct, intentional behavior — closed, not touched**, per this repo's own standard that an incorrect "fix" to a working constraint is worse than leaving it alone.

### New findings from the full audit (not previously logged) — documented for a decision, not acted on

- **`CfbSlateSeederJob` / `CfbRepository.DeleteSlatesAsync` bulk-deletes stale `CfbSlates` rows with zero dependent-row cleanup** — unlike `DemoDataSeeder.SeedCfbSlatesAsync`'s identical reseed shape, which explicitly cleans up `CfbPicks`/`CfbScores`/`CfbSpreads` first. Before this PR, a mid-season fire of this path would have **silently orphaned real user picks**. The new `Restrict` FK now makes that fail loudly instead — real improvement — but the underlying job-logic gap is unfixed. Filed as **`frizat-2lc`** (P1), pointer comment left at `CfbRepository.cs`.
- **FK cascade-delete behavior is inconsistent around user deletion.** `LeagueInfo.OwnerUserId`, `NflPicks.UserId`, `LeagueUserMapping.UserId`, `RefreshTokens.UserId` (and now `CfbPicks.UserId`) all `CASCADE` from `AspNetUsers` — deleting a user silently cascades through their entire league ownership tree. But `Invitations`' 3 FKs (`InvitedByUserId`, `RegisteredUserId`, `LeagueId`) are `NO ACTION` — deleting a user or league with any invitation history throws an **unhandled FK violation** instead. Given this repo's explicit "never delete users without confirmation" policy, this inconsistency means the actual blast radius of a user deletion is unpredictable without checking invitation history first. Needs a product decision on the intended behavior, not a unilateral fix.
- **`Invitations.Email` is globally unique** (not scoped per league), and `InvitationService.CreateInvitationAsync` does a blind `Add` with no existing-row check — a second invite to the same email (same or different league) throws an unhandled `DbUpdateException`, uncaught in either `LeagueController` or `InvitationController`. With self-serve league creation newly shipped, this becomes reachable in ordinary usage once one email is relevant to more than one league. Needs a decision: scope the unique index per-league, or make invite creation an upsert.
- **`CfbRanking.CapturedAtUtc` is `DateTime`, not `DateTimeOffset`** — inconsistent with the rest of the schema and this repo's own prior "DateTimeOffset everywhere" push. Low urgency, cosmetic.
- **`LeagueJuiceMapping` (and `LeagueInfo.OwnerUserId`) have live `Update*Async` code paths but no `UpdatedAt`/`DateModified` audit column** — only `DateCreated`, set once at insert. Real per the bead's own "missing audit fields" DESIGN item, but adding it correctly means also touching the update call sites' behavior, which is more than a mechanical schema change — deferred rather than rushed in.

### Verification

- `dotnet test` — 493/493, 0 failures
- `npm run test -- --run` — 264/264
- `npm run typecheck` / `npm run lint` — clean
- `npm run test:e2e -- --project=chromium` — 54/54
- Demo backend (`DEMO_MODE=true`) started fresh against the migrated schema and seeded cleanly (5 users, all CFB slates/picks) with zero FK violations under the new constraints
- `npm run test:e2e:demo` — **not run to completion**: port 5174 (hardcoded in `playwright.config.ts`'s `demo-nfl`/`demo-cfb` projects) is held by a separate, already-running ~24h-old worktree session (`vercel-analytics`) on this shared host — killing another session's process was out of scope. Compensated with direct `psql`-level constraint verification (round-trip + a live `Restrict` rejection test), matching the same verification standard PR #180 itself used for its own DB-level constraints.
- `/simplify` — 4 parallel review agents (reuse, simplification, efficiency, altitude); reuse and efficiency clean; simplification flagged a redundant rationale comment (trimmed); altitude confirmed the FK fix is the right layer and correctly doesn't reach into the job-logic gap it's adjacent to (left as `frizat-2lc`), and suggested splitting the FK fix and the rename into separate commits (done — 2 commits on this branch).

### Follow-up beads filed

- `frizat-2lc` (P1) — `CfbSlateSeederJob` blind bulk-delete gap, described above.

Bead `frizat-896` updated with the full findings as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)