### PR TITLE
fix: 3 P1 bugs from frizat-896 schema audit (frizat-5rp, frizat-9vm, frizat-2lc)

### DIFF
--- a/Server.UnitTests/AuthControllerTests.cs
+++ b/Server.UnitTests/AuthControllerTests.cs
@@ -615,4 +615,44 @@ public class AuthControllerTests
         Assert.Equal(dtoNotFound.Succeeded, dtoBadPass.Succeeded);
         Assert.Equal(dtoNotFound.Message, dtoBadPass.Message);
     }
+
+    // ── DeleteUser: predictable outcome on every dependent-data shape (frizat-5rp) ─────────
+    //
+    // frizat-896's schema audit found Invitations' 3 FKs off AspNetUsers/LeagueInfo were the only
+    // ones set to NO ACTION while every other table (LeagueInfo, NflPicks, CfbPicks,
+    // LeagueUserMapping, RefreshTokens) already CASCADEs — deleting a user with invitation history
+    // threw an unhandled DbUpdateException instead of completing. Resolved by making Invitations
+    // CASCADE too (consistent with everywhere else, and with CLAUDE.md's own description of
+    // delete-user as an already-accepted cascade-then-confirm operation). This test covers the
+    // other half of the bead's ask: DeleteUser must never let ANY DbUpdateException — from this
+    // now-fixed cause or a future one — bubble up as an unhandled 500.
+
+    [Fact]
+    public async Task DeleteUser_UserManagerThrowsDbUpdateException_ReturnsControlledError()
+    {
+        var userManager = BuildUserManager();
+        var user = BuildUser();
+        userManager.FindByIdAsync(user.Id).Returns(user);
+        userManager.DeleteAsync(user)
+            .Returns<Task<IdentityResult>>(_ => throw new DbUpdateException("FK violation", new Exception("inner")));
+
+        var result = await BuildController(userManager: userManager).DeleteUser(user.Id);
+
+        var objectResult = Assert.IsAssignableFrom<ObjectResult>(result.Result);
+        Assert.InRange(objectResult.StatusCode ?? 0, 400, 599);
+        Assert.IsType<string>(objectResult.Value);
+    }
+
+    [Fact]
+    public async Task DeleteUser_UserManagerSucceeds_ReturnsOk()
+    {
+        var userManager = BuildUserManager();
+        var user = BuildUser();
+        userManager.FindByIdAsync(user.Id).Returns(user);
+        userManager.DeleteAsync(user).Returns(IdentityResult.Success);
+
+        var result = await BuildController(userManager: userManager).DeleteUser(user.Id);
+
+        Assert.IsType<OkResult>(result.Result);
+    }
 }

--- a/Server.UnitTests/CfbRepositoryTests.cs
+++ b/Server.UnitTests/CfbRepositoryTests.cs
@@ -66,6 +66,43 @@ public class CfbRepositoryTests
         Assert.Equal(originalPostTime, saved.DateCreated);
     }
 
+    // frizat-2lc, moved down to the repository per /simplify's altitude review: guarding only in
+    // CfbSlateSeederJob protected that one caller, but left CfbRepository.DeleteSlatesAsync itself
+    // unguarded for any future caller. The guard now lives where the destructive RemoveRange
+    // actually happens, so it can't be bypassed by a caller that forgets to check first.
+    [Fact]
+    public async Task DeleteSlatesAsync_SlateHasDependentSpread_SkipsDeleteAndReturnsFalse()
+    {
+        var factory = new DbContextFactoryStub(nameof(DeleteSlatesAsync_SlateHasDependentSpread_SkipsDeleteAndReturnsFalse));
+        var seedDb = factory.CreateDbContext();
+        var slate = new CfbSlates { Id = 1, Season = 2026, SlateNumber = 3, Label = "Week 3", SlateType = "RegularSeason" };
+        seedDb.CfbSlates.Add(slate);
+        seedDb.CfbSpreads.Add(new CfbSpreads { CfbSlateId = 1, EspnEventId = 100, HomeTeam = "A", AwayTeam = "B" });
+        await seedDb.SaveChangesAsync();
+        var repo = new CfbRepository(factory);
+
+        var deleted = await repo.DeleteSlatesAsync([slate]);
+
+        Assert.False(deleted);
+        Assert.True(await factory.CreateDbContext().CfbSlates.AnyAsync(s => s.Id == 1));
+    }
+
+    [Fact]
+    public async Task DeleteSlatesAsync_NoDependentData_DeletesAndReturnsTrue()
+    {
+        var factory = new DbContextFactoryStub(nameof(DeleteSlatesAsync_NoDependentData_DeletesAndReturnsTrue));
+        var seedDb = factory.CreateDbContext();
+        var slate = new CfbSlates { Id = 1, Season = 2026, SlateNumber = 3, Label = "Week 3", SlateType = "RegularSeason" };
+        seedDb.CfbSlates.Add(slate);
+        await seedDb.SaveChangesAsync();
+        var repo = new CfbRepository(factory);
+
+        var deleted = await repo.DeleteSlatesAsync([slate]);
+
+        Assert.True(deleted);
+        Assert.False(await factory.CreateDbContext().CfbSlates.AnyAsync(s => s.Id == 1));
+    }
+
     [Fact]
     public async Task GetWeeksWithSpreadDataAsync_ReturnsSeasonSlateNumberPairsWithSpreads()
     {

--- a/Server.UnitTests/CfbSlateSeederJobTests.cs
+++ b/Server.UnitTests/CfbSlateSeederJobTests.cs
@@ -95,11 +95,33 @@ public class CfbSlateSeederJobTests
         var stale = MakeSlates(4).ToList();
         _repo.GetWeekConfigsForSeasonAsync(Season).Returns(Make2026Configs());
         _repo.GetSlatesForSeasonAsync(Season).Returns(stale);
+        _repo.DeleteSlatesAsync(Arg.Any<IEnumerable<CfbSlates>>()).Returns(true);
 
         await BuildJob().Execute(_context);
 
         await _repo.Received(1).DeleteSlatesAsync(Arg.Is<IEnumerable<CfbSlates>>(s => s.Count() == 4));
         await _repo.Received(1).AddSlatesAsync(Arg.Is<IEnumerable<CfbSlates>>(s => s.Count() == 18));
+    }
+
+    // frizat-2lc: CfbSlateSeederJob's reseed-delete path had no guard against wiping out slates
+    // that already carry real CfbSpreads/CfbScores/CfbPicks data (e.g. a corrective mid-season edit
+    // to CfbSeasonWeekConfigs bumping configs.Count past existing.Count). The fail-closed guard
+    // lives inside CfbRepository.DeleteSlatesAsync itself (see CfbRepositoryTests) so it protects
+    // every caller, not just this job — DeleteSlatesAsync returns false instead of deleting when
+    // dependent CfbSpreads/CfbScores/CfbPicks rows exist, and the job must skip the reseed entirely
+    // when that happens rather than risk real data loss or an unhandled FK violation.
+    [Fact]
+    public async Task Execute_WhenDeleteSlatesSkipsDueToDependentData_SkipsReseed()
+    {
+        var stale = MakeSlates(4).ToList();
+        _repo.GetWeekConfigsForSeasonAsync(Season).Returns(Make2026Configs());
+        _repo.GetSlatesForSeasonAsync(Season).Returns(stale);
+        _repo.DeleteSlatesAsync(Arg.Any<IEnumerable<CfbSlates>>()).Returns(false);
+
+        await BuildJob().Execute(_context);
+
+        await _repo.Received(1).DeleteSlatesAsync(Arg.Any<IEnumerable<CfbSlates>>());
+        await _repo.DidNotReceive().AddSlatesAsync(Arg.Any<IEnumerable<CfbSlates>>());
     }
 
     [Fact]

--- a/Server.UnitTests/InvitationServiceTests.cs
+++ b/Server.UnitTests/InvitationServiceTests.cs
@@ -83,5 +83,80 @@ namespace FourPlayWebApp.Server.UnitTests
                 Arg.Any<string>(),
                 Arg.Is<string>(body => body.Contains($"inviteCode={created.InvitationCode}")));
         }
+
+        // frizat-9vm: Invitations.Email was globally unique across the whole table, not scoped
+        // per league — inviting the same real-world email to two different leagues (routine once
+        // self-serve league creation shipped) threw an unhandled DbUpdateException. Scoped to
+        // (Email, LeagueId); CreateInvitationAsync is now an upsert instead of a blind insert.
+        [Fact]
+        public async Task CreateInvitationAsync_SameEmailTwoDifferentLeagues_BothSucceed()
+        {
+            var (service, _) = BuildService(nameof(CreateInvitationAsync_SameEmailTwoDifferentLeagues_BothSucceed));
+
+            var first = await service.CreateInvitationAsync("multi@example.com", "user123", leagueId: 1);
+            var second = await service.CreateInvitationAsync("multi@example.com", "user123", leagueId: 2);
+
+            Assert.NotEqual(first.Id, second.Id);
+            Assert.Equal(1, first.LeagueId);
+            Assert.Equal(2, second.LeagueId);
+        }
+
+        // frizat-9vm follow-up (code review): the [Index(Email, LeagueId)] unique constraint only
+        // fires when LeagueId is non-null (Postgres treats every NULL as distinct); a global,
+        // non-league-scoped invite (leagueId: null) relies entirely on the app-level upsert below
+        // to avoid duplicating, backed by a separate partial unique index (Email WHERE LeagueId IS
+        // NULL) at the DB level for the concurrent-request case this in-memory test can't exercise.
+        [Fact]
+        public async Task CreateInvitationAsync_ReinviteSameEmailNoLeague_RefreshesExistingRowInsteadOfDuplicating()
+        {
+            var (service, _) = BuildService(nameof(CreateInvitationAsync_ReinviteSameEmailNoLeague_RefreshesExistingRowInsteadOfDuplicating));
+            var first = await service.CreateInvitationAsync("global@example.com", "user123");
+
+            var second = await service.CreateInvitationAsync("global@example.com", "user123");
+
+            Assert.Equal(first.Id, second.Id);
+            Assert.Null(second.LeagueId);
+        }
+
+        [Fact]
+        public async Task CreateInvitationAsync_ReinviteSameEmailSameLeague_RefreshesExistingRowInsteadOfThrowing()
+        {
+            var (service, _) = BuildService(nameof(CreateInvitationAsync_ReinviteSameEmailSameLeague_RefreshesExistingRowInsteadOfThrowing));
+            var first = await service.CreateInvitationAsync("resend2@example.com", "user123", leagueId: 5);
+
+            var second = await service.CreateInvitationAsync("resend2@example.com", "user123", leagueId: 5);
+
+            Assert.Equal(first.Id, second.Id);
+            Assert.True(second.ExpiresAt >= first.ExpiresAt);
+        }
+
+        [Fact]
+        public async Task CreateInvitationAsync_ReinviteSameEmailSameLeague_ResendsEmail()
+        {
+            var (service, emailSender) = BuildService(nameof(CreateInvitationAsync_ReinviteSameEmailSameLeague_ResendsEmail));
+            var first = await service.CreateInvitationAsync("resend3@example.com", "user123", leagueId: 5, baseUrl: "https://ivleague.com");
+
+            await service.CreateInvitationAsync("resend3@example.com", "user123", leagueId: 5, baseUrl: "https://ivleague.com");
+
+            await emailSender.Received(2).SendEmailAsync(
+                "resend3@example.com",
+                Arg.Any<string>(),
+                Arg.Is<string>(body => body.Contains($"inviteCode={first.InvitationCode}")));
+        }
+
+        [Fact]
+        public async Task CreateInvitationAsync_ReinviteAlreadyUsedInvitation_DoesNotOverwriteRegistration()
+        {
+            var (service, emailSender) = BuildService(nameof(CreateInvitationAsync_ReinviteAlreadyUsedInvitation_DoesNotOverwriteRegistration));
+            var first = await service.CreateInvitationAsync("used@example.com", "user123", leagueId: 5);
+            await service.MarkInvitationAsUsedAsync(first.InvitationCode, "the-registered-user");
+
+            var second = await service.CreateInvitationAsync("used@example.com", "user123", leagueId: 5, baseUrl: "https://ivleague.com");
+
+            Assert.Equal(first.Id, second.Id);
+            Assert.True(second.IsUsed);
+            Assert.Equal("the-registered-user", second.RegisteredUserId);
+            await emailSender.DidNotReceiveWithAnyArgs().SendEmailAsync(default!, default!, default!);
+        }
     }
 }

--- a/Server/Controllers/AuthController.cs
+++ b/Server/Controllers/AuthController.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
@@ -224,7 +225,18 @@ public class AuthController(
         var user = await userManager.FindByIdAsync(userId);
         if (user == null)
             return NotFound();
-        var result = await userManager.DeleteAsync(user);
+
+        IdentityResult result;
+        try {
+            result = await userManager.DeleteAsync(user);
+        } catch (DbUpdateException ex) {
+            // frizat-5rp: every table referencing AspNetUsers/LeagueInfo now cascades on delete,
+            // so this shouldn't be reachable in normal operation — this is a safety net against
+            // any future FK left un-cascaded, so an admin gets a clear 500 instead of the raw
+            // exception, and the failure is at least logged with enough detail to diagnose.
+            logger.LogError(ex, "DeleteUser: unhandled DB error deleting user {UserId}", userId);
+            return StatusCode(500, "Failed to delete user due to a database error. See server logs for details.");
+        }
         if (result.Errors.Any())
             return BadRequest(string.Join(Environment.NewLine, result.Errors.Select(x => x.Description)));
         return Ok();

--- a/Server/Data/Configurations/InvitationConfiguration.cs
+++ b/Server/Data/Configurations/InvitationConfiguration.cs
@@ -1,0 +1,46 @@
+using FourPlayWebApp.Server.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FourPlayWebApp.Server.Data.Configurations;
+
+public class InvitationConfiguration : IEntityTypeConfiguration<Invitation>
+{
+    public void Configure(EntityTypeBuilder<Invitation> entity)
+    {
+        // frizat-5rp: all 3 FKs off AspNetUsers/LeagueInfo default to EF's convention for optional
+        // relationships (NO ACTION), the only tables in the schema not consistent with everything
+        // else referencing AspNetUsers/LeagueInfo (LeagueInfo, LeagueJuiceMapping,
+        // LeagueUserMapping, NflPicks, CfbPicks, RefreshTokens all CASCADE). That inconsistency
+        // made deleting a user/league with any invitation history throw an unhandled FK violation.
+        //
+        // InvitedByUserId is SetNull rather than Cascade, unlike the other two: the invitation row
+        // itself belongs to the RECIPIENT (and the league), not the inviter — deleting whoever sent
+        // the invite shouldn't destroy another, unrelated, still-active user's registration audit
+        // trail. RegisteredUserId/LeagueId cascading is safe because deleting either of THOSE really
+        // does mean "this invitation no longer has anything to refer to."
+        entity.HasOne(e => e.InvitedByUser)
+            .WithMany()
+            .HasForeignKey(e => e.InvitedByUserId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        entity.HasOne(e => e.RegisteredUser)
+            .WithMany()
+            .HasForeignKey(e => e.RegisteredUserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        entity.HasOne(e => e.League)
+            .WithMany()
+            .HasForeignKey(e => e.LeagueId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // frizat-9vm follow-up: the [Index(Email, LeagueId)] on the model only enforces uniqueness
+        // when LeagueId is non-null — Postgres treats every NULL as distinct, so two global
+        // (LeagueId == null) invites to the same email wouldn't collide against that index. This
+        // partial index closes that gap by enforcing Email uniqueness specifically among the
+        // LeagueId-null rows, matching what CreateInvitationAsync's upsert already assumes.
+        entity.HasIndex(e => e.Email)
+            .IsUnique()
+            .HasFilter("\"LeagueId\" IS NULL");
+    }
+}

--- a/Server/Jobs/CfbSlateSeederJob.cs
+++ b/Server/Jobs/CfbSlateSeederJob.cs
@@ -45,7 +45,14 @@ public class CfbSlateSeederJob(ICfbRepository repo) : IJob {
         }
 
         if (existing.Count > 0) {
-            await repo.DeleteSlatesAsync(existing);
+            // frizat-2lc: DeleteSlatesAsync fails closed and skips the delete if any of these
+            // slates already carry real dependent CfbSpreads/CfbScores/CfbPicks data — in that
+            // case, the whole reseed must be skipped too rather than adding new slates on top of
+            // stale ones that couldn't be removed.
+            if (!await repo.DeleteSlatesAsync(existing)) {
+                Log.Warning("CfbSlateSeederJob: {Count} stale slates for {Season} have dependent spread/score/pick data — skipping reseed", existing.Count, Season);
+                return;
+            }
             Log.Information("CfbSlateSeederJob: removed {Count} stale slates for {Season}", existing.Count, Season);
         }
 

--- a/Server/Migrations/20260810200334_FixInvitationScopingAndCascade.Designer.cs
+++ b/Server/Migrations/20260810200334_FixInvitationScopingAndCascade.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260810200334_FixInvitationScopingAndCascade")]
+    partial class FixInvitationScopingAndCascade
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -984,7 +987,7 @@ namespace FourPlayWebApp.Server.Migrations
             modelBuilder.Entity("FourPlayWebApp.Server.Models.Data.LeagueUserMapping", b =>
                 {
                     b.HasOne("FourPlayWebApp.Server.Models.Data.LeagueInfo", "League")
-                        .WithMany("LeagueUserMappings")
+                        .WithMany("LeagueUsers")
                         .HasForeignKey("LeagueId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
@@ -1062,45 +1065,6 @@ namespace FourPlayWebApp.Server.Migrations
                     b.Navigation("RegisteredUser");
                 });
 
-            modelBuilder.Entity("FourPlayWebApp.Shared.Models.Data.CfbPicks", b =>
-                {
-                    b.HasOne("FourPlayWebApp.Server.Models.Data.CfbSlates", null)
-                        .WithMany()
-                        .HasForeignKey("CfbSlateId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.HasOne("FourPlayWebApp.Server.Models.Data.LeagueInfo", null)
-                        .WithMany()
-                        .HasForeignKey("LeagueId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("FourPlayWebApp.Server.Models.Identity.ApplicationUser", null)
-                        .WithMany()
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-                });
-
-            modelBuilder.Entity("FourPlayWebApp.Shared.Models.Data.CfbScores", b =>
-                {
-                    b.HasOne("FourPlayWebApp.Server.Models.Data.CfbSlates", null)
-                        .WithMany()
-                        .HasForeignKey("CfbSlateId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-                });
-
-            modelBuilder.Entity("FourPlayWebApp.Shared.Models.Data.CfbSpreads", b =>
-                {
-                    b.HasOne("FourPlayWebApp.Server.Models.Data.CfbSlates", null)
-                        .WithMany()
-                        .HasForeignKey("CfbSlateId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-                });
-
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
                 {
                     b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
@@ -1156,7 +1120,7 @@ namespace FourPlayWebApp.Server.Migrations
                 {
                     b.Navigation("LeagueJuiceMappings");
 
-                    b.Navigation("LeagueUserMappings");
+                    b.Navigation("LeagueUsers");
 
                     b.Navigation("NflPicks");
                 });

--- a/Server/Migrations/20260810200334_FixInvitationScopingAndCascade.cs
+++ b/Server/Migrations/20260810200334_FixInvitationScopingAndCascade.cs
@@ -1,0 +1,118 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixInvitationScopingAndCascade : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Invitations_AspNetUsers_InvitedByUserId",
+                table: "Invitations");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Invitations_AspNetUsers_RegisteredUserId",
+                table: "Invitations");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Invitations_LeagueInfo_LeagueId",
+                table: "Invitations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Invitations_Email",
+                table: "Invitations");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invitations_Email",
+                table: "Invitations",
+                column: "Email",
+                unique: true,
+                filter: "\"LeagueId\" IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invitations_Email_LeagueId",
+                table: "Invitations",
+                columns: new[] { "Email", "LeagueId" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Invitations_AspNetUsers_InvitedByUserId",
+                table: "Invitations",
+                column: "InvitedByUserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Invitations_AspNetUsers_RegisteredUserId",
+                table: "Invitations",
+                column: "RegisteredUserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Invitations_LeagueInfo_LeagueId",
+                table: "Invitations",
+                column: "LeagueId",
+                principalTable: "LeagueInfo",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Invitations_AspNetUsers_InvitedByUserId",
+                table: "Invitations");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Invitations_AspNetUsers_RegisteredUserId",
+                table: "Invitations");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Invitations_LeagueInfo_LeagueId",
+                table: "Invitations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Invitations_Email",
+                table: "Invitations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Invitations_Email_LeagueId",
+                table: "Invitations");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invitations_Email",
+                table: "Invitations",
+                column: "Email",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Invitations_AspNetUsers_InvitedByUserId",
+                table: "Invitations",
+                column: "InvitedByUserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Invitations_AspNetUsers_RegisteredUserId",
+                table: "Invitations",
+                column: "RegisteredUserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Invitations_LeagueInfo_LeagueId",
+                table: "Invitations",
+                column: "LeagueId",
+                principalTable: "LeagueInfo",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/Server/Models/Invitation.cs
+++ b/Server/Models/Invitation.cs
@@ -5,7 +5,9 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace FourPlayWebApp.Server.Models;
-[Index(nameof(Email), IsUnique = true)]
+// frizat-9vm: scoped per league — the same email can legitimately be invited to several
+// different leagues; only a duplicate invite to the SAME league should be rejected/upserted.
+[Index(nameof(Email), nameof(LeagueId), IsUnique = true)]
 public class Invitation
 {
     [Key]

--- a/Server/Services/InvitationService.cs
+++ b/Server/Services/InvitationService.cs
@@ -26,25 +26,45 @@ public class InvitationService(IDbContextFactory<ApplicationDbContext> dbContext
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync();
 
-        var invitation = new Invitation
-        {
-            Email = email,
-            InvitedByUserId = invitedByUserId,
-            LeagueId = leagueId,
-            CreatedAt = DateTimeOffset.UtcNow,
-            ExpiresAt = DateTimeOffset.UtcNow.AddDays(7)
-        };
+        // frizat-9vm: Invitations is unique on (Email, LeagueId), not just Email — the same
+        // address can be invited to several different leagues. This is an upsert against that
+        // key rather than a blind insert, so re-inviting the same email to the same league
+        // refreshes/resends instead of throwing on the duplicate-key violation.
+        var existing = await dbContext.Invitations
+            .FirstOrDefaultAsync(i => i.Email == email && i.LeagueId == leagueId);
 
-        dbContext.Invitations.Add(invitation);
+        if (existing is not null && existing.IsUsed) {
+            // Already registered via this invite — nothing to refresh or resend, just hand back
+            // the existing record so the caller doesn't see this as a failure.
+            Log.Information("Invitation for {Email} to league {LeagueId} already used by {UserId} — no-op", email, leagueId, existing.RegisteredUserId);
+            return existing;
+        }
+
+        Invitation invitation;
+        if (existing is not null) {
+            invitation = existing;
+            invitation.InvitedByUserId = invitedByUserId;
+            invitation.ExpiresAt = DateTimeOffset.UtcNow.AddDays(7);
+            Log.Information("Invitation for {Email} to league {LeagueId} refreshed by {UserId}", email, leagueId, invitedByUserId);
+        } else {
+            invitation = new Invitation {
+                Email = email,
+                InvitedByUserId = invitedByUserId,
+                LeagueId = leagueId,
+                CreatedAt = DateTimeOffset.UtcNow,
+                ExpiresAt = DateTimeOffset.UtcNow.AddDays(7)
+            };
+            dbContext.Invitations.Add(invitation);
+            Log.Information("Invitation created for {Email} by {UserId}", email, invitedByUserId);
+        }
+
         await dbContext.SaveChangesAsync();
-
-        Log.Information("Invitation created for {Email} by {UserId}", email, invitedByUserId);
 
         if (!string.IsNullOrWhiteSpace(baseUrl)) {
             try {
                 await SendInvitationEmailAsync(invitation, baseUrl);
             } catch (Exception ex) {
-                // Invitation was created successfully; a failed email send must not undo it.
+                // Invitation was created/refreshed successfully; a failed email send must not undo it.
                 Log.Error(ex, "Failed to send invitation email to {Email}", email);
             }
         }

--- a/Server/Services/Repositories/CfbRepository.cs
+++ b/Server/Services/Repositories/CfbRepository.cs
@@ -18,16 +18,24 @@ public class CfbRepository(IDbContextFactory<ApplicationDbContext> dbFactory) : 
         await db.SaveChangesAsync();
     }
 
-    // frizat-2lc: unlike DemoDataSeeder.SeedCfbSlatesAsync's equivalent re-seed path, this does not
-    // clean up dependent CfbSpreads/CfbScores/CfbPicks before deleting. CfbSlateSeederJob is the
-    // only caller and only invokes this when existing < configured slate count. As of frizat-896,
-    // CfbSlateId now carries a Restrict FK from those three tables, so a slate with real dependent
-    // data will now throw here (loud failure) instead of silently orphaning rows — but the
-    // underlying gap (no guard against deleting a slate that already has real data) is unfixed.
-    public async Task DeleteSlatesAsync(IEnumerable<CfbSlates> slates) {
+    public async Task<bool> DeleteSlatesAsync(IEnumerable<CfbSlates> slates) {
         await using var db = await dbFactory.CreateDbContextAsync();
-        db.CfbSlates.RemoveRange(slates);
+        var slateList = slates.ToList();
+        var ids = slateList.Select(s => s.Id).ToHashSet();
+
+        // frizat-2lc: never bulk-delete slates that already carry real dependent data — guard
+        // lives here, not just in the one caller that exists today, so any future caller of
+        // DeleteSlatesAsync gets the same protection against real data loss / an unhandled FK
+        // violation (CfbSpreads/CfbScores/CfbPicks.CfbSlateId is Restrict, not Cascade).
+        var hasDependentData = ids.Count > 0 &&
+            (await db.CfbSpreads.AnyAsync(s => ids.Contains(s.CfbSlateId))
+             || await db.CfbScores.AnyAsync(s => ids.Contains(s.CfbSlateId))
+             || await db.CfbPicks.AnyAsync(p => ids.Contains(p.CfbSlateId)));
+        if (hasDependentData) return false;
+
+        db.CfbSlates.RemoveRange(slateList);
         await db.SaveChangesAsync();
+        return true;
     }
 
     public async Task<IEnumerable<CfbSlates>> GetSlatesForSeasonAsync(int season) {

--- a/Server/Services/Repositories/Interfaces/ICfbRepository.cs
+++ b/Server/Services/Repositories/Interfaces/ICfbRepository.cs
@@ -6,7 +6,9 @@ namespace FourPlayWebApp.Server.Services.Repositories.Interfaces;
 public interface ICfbRepository : ISpreadRepository<CfbSpreads> {
     Task<bool> SlatesExistForSeasonAsync(int season);
     Task AddSlatesAsync(IEnumerable<CfbSlates> slates);
-    Task DeleteSlatesAsync(IEnumerable<CfbSlates> slates);
+    // Returns false (and skips the delete) if any of the slates already carry dependent
+    // CfbSpreads/CfbScores/CfbPicks data — see CfbRepositoryTests for the guard behavior.
+    Task<bool> DeleteSlatesAsync(IEnumerable<CfbSlates> slates);
     Task<IEnumerable<CfbSlates>> GetSlatesForSeasonAsync(int season);
     Task<CfbSlates?> GetSlateByIdAsync(int slateId);
     Task UpsertCfbScoresAsync(IEnumerable<CfbScores> scores);


### PR DESCRIPTION
## Summary

Fixes the three P1 bugs the frizat-896 schema audit filed as follow-ups (PR #182), each of which its own DESIGN section said needed a product decision rather than a unilateral fix.

- **frizat-2lc** — `CfbSlateSeederJob` bulk-deleted stale `CfbSlates` rows with no check for dependent `CfbSpreads`/`CfbScores`/`CfbPicks` data. The guard now lives in `CfbRepository.DeleteSlatesAsync` itself (moved there per `/simplify`'s altitude review, so it protects any future caller too) — it returns `false` and skips the delete instead of destroying real data; the job skips the whole reseed when that happens.

- **frizat-9vm** — `Invitations.Email` was globally unique across the whole table, not scoped per league, so inviting the same email to two different leagues threw an unhandled `DbUpdateException`. Now scoped to `(Email, LeagueId)`, plus a partial unique index on `Email WHERE LeagueId IS NULL` (Postgres doesn't dedupe NULLs, so global/non-league-scoped invites needed their own constraint — caught in code review). `CreateInvitationAsync` is a real upsert: not found → insert, found+unused → refresh & resend, found+used → no-op instead of erroring.

- **frizat-5rp** — Invitations' 3 FKs off `AspNetUsers`/`LeagueInfo` were the only ones set to `NO ACTION` while every sibling table (`LeagueInfo`, `NflPicks`, `CfbPicks`, `LeagueUserMapping`, `RefreshTokens`) already cascades — deleting a user/league with any invitation history threw an unhandled FK violation. Resolved by making the behavior consistent with the rest of the schema, with one refinement from code review: `RegisteredUserId`/`LeagueId` cascade, but `InvitedByUserId` is `SetNull` instead — deleting whoever *sent* an invite shouldn't destroy an unrelated, still-active recipient's registration record. `AuthController.DeleteUser` also gained a `DbUpdateException` catch as a defense-in-depth safety net.

The cascade-vs-restrict direction for 5rp was confirmed with the repo owner before implementation, since it's exactly the kind of user-deletion-behavior change CLAUDE.md calls out as needing explicit confirmation.

## Test plan

- [x] `dotnet test` — 503 backend tests, all green (TDD red-first for all 3 fixes)
- [x] `npm run test -- --run` — 264 frontend tests, all green
- [x] `npm run test:e2e -- --project=chromium` — 54 mock e2e, all green
- [x] `npm run test:e2e:demo` — 46 demo-backend integration e2e, all green
- [x] Both migrations applied to the shared dev DB and round-trip verified (`dotnet ef database update` down/up), confirmed via direct `psql` inspection of the resulting indexes/FK actions
- [x] `/simplify` run on the full diff — 2 findings applied (collapsed a no-op branch to an early return; moved the frizat-2lc guard from the job into the repository), 1 finding intentionally deferred (a codebase-wide global exception handler is a legitimate but separately-scoped follow-up, not specific to this bead)
- [x] `/code-review`-equivalent review run — 2 real findings, both fixed (see frizat-9vm/5rp descriptions above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)