### PR TITLE
feat(scores): migrate ScoresPage to React Query (frizat-ulm)

### DIFF
--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -1,10 +1,22 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ScoresPage from '../pages/ScoresPage';
 import { createNflAdapter } from '../services/nflAdapter';
+import { createCfbAdapter } from '../services/cfbAdapter';
 import { createPick, createScores, createSpreadResponse, createCompetition } from '../test/fixtures';
 import { vi } from 'vitest';
 import type { NflPickDto } from '../types/picks';
+
+// jsdom has no EventSource — ScoresPage opens one whenever hasActiveGames is true (SSE, primary
+// live-update path for NFL). Fallback polling (this file's actual focus) still needs it defined
+// so the effect doesn't throw and fall out of the tree.
+class MockEventSource {
+  onmessage: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  close() {}
+}
+vi.stubGlobal('EventSource', MockEventSource);
 
 const sessionState = {
   currentLeague: 1 as number | null,
@@ -19,21 +31,38 @@ const sessionState = {
 
 vi.mock('../services/session', () => ({ useSession: () => sessionState }));
 vi.mock('../services/auth', () => ({ useAuth: () => ({ user: { userId: '123', name: 'TestUser', claims: [] } }) }));
-vi.mock('../api/espn', () => ({ getScores: vi.fn(), loadScoresWithRetry: vi.fn(), getWeekScores: vi.fn(), getLiveGames: vi.fn() }));
+vi.mock('../api/espn', () => ({
+  getScores: vi.fn(), loadScoresWithRetry: vi.fn(), getWeekScores: vi.fn(), getLiveGames: vi.fn(),
+  loadCfbScoresWithRetry: vi.fn(), getCfbScoresForSlate: vi.fn(), getCfbLiveGames: vi.fn(),
+}));
 vi.mock('../api/league', () => ({
   doOddsExist: vi.fn(), getLeaguePicks: vi.fn(), spreadBatch: vi.fn(),
   addPicks: vi.fn(), getUserPicks: vi.fn(),
 }));
+vi.mock('../api/cfb', () => ({
+  getCfbCurrentSlate: vi.fn(), getCfbSlates: vi.fn(), getCfbSpreads: vi.fn(),
+  getCfbScores: vi.fn(), getCfbUserPicks: vi.fn(), getCfbAllPicks: vi.fn(),
+  addCfbPicks: vi.fn(), deleteCfbPicks: vi.fn(),
+}));
 vi.mock('../services/spreadRelease', () => ({ getNextSpreadJob: vi.fn().mockResolvedValue(null) }));
 
-import { loadScoresWithRetry, getLiveGames } from '../api/espn';
+import { loadScoresWithRetry, getLiveGames, getWeekScores, loadCfbScoresWithRetry, getCfbLiveGames } from '../api/espn';
 import { doOddsExist, getLeaguePicks, spreadBatch } from '../api/league';
+import { getCfbCurrentSlate, getCfbSlates, getCfbSpreads, getCfbScores, getCfbAllPicks } from '../api/cfb';
 
 const mockedLoadScoresWithRetry = vi.mocked(loadScoresWithRetry);
 const mockedGetLiveGames = vi.mocked(getLiveGames);
+const mockedGetWeekScores = vi.mocked(getWeekScores);
 const mockedDoOddsExist = vi.mocked(doOddsExist);
 const mockedGetLeaguePicks = vi.mocked(getLeaguePicks);
+const mockedGetCfbSlates = vi.mocked(getCfbSlates);
+const mockedGetCfbSpreads = vi.mocked(getCfbSpreads);
+const mockedGetCfbScores = vi.mocked(getCfbScores);
+const mockedGetCfbAllPicks = vi.mocked(getCfbAllPicks);
+const mockedLoadCfbScoresWithRetry = vi.mocked(loadCfbScoresWithRetry);
+const mockedGetCfbLiveGames = vi.mocked(getCfbLiveGames);
 const mockedSpreadBatch = vi.mocked(spreadBatch);
+const mockedGetCfbCurrentSlate = vi.mocked(getCfbCurrentSlate);
 
 // BUF home (24-10), spread -7: homeCovers = 24+(-7)=17 > 10 ✓ (BUF covers → green)
 // MIA away: !homeCovers → red; Over at 47.5: 24+10=34 < 47.5 → Under wins
@@ -67,8 +96,15 @@ const setupDefaults = async (options?: {
   mockedSpreadBatch.mockResolvedValue({ responses: SPREAD_RESPONSES });
 };
 
+const renderWithClient = (ui: React.ReactElement, client?: QueryClient) => {
+  const queryClient = client ?? new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  });
+  return { ...render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>), queryClient };
+};
+
 const renderPage = async () => {
-  const utils = render(<ScoresPage adapter={createNflAdapter()} />);
+  const utils = renderWithClient(<ScoresPage adapter={createNflAdapter()} />);
   await screen.findByText(/Scores/i);
   await waitFor(() => expect(screen.queryByRole('progressbar')).toBeNull());
   return utils;
@@ -83,13 +119,13 @@ describe('ScoresPage', () => {
   it('shows no league message when no league selected', async () => {
     sessionState.currentLeague = null;
     await setupDefaults();
-    render(<ScoresPage adapter={createNflAdapter()} />);
+    renderWithClient(<ScoresPage adapter={createNflAdapter()} />);
     await screen.findByText(/Please select a league/i);
   });
 
   it('shows odds not posted when odds missing', async () => {
     await setupDefaults({ oddsExist: false });
-    render(<ScoresPage adapter={createNflAdapter()} />);
+    renderWithClient(<ScoresPage adapter={createNflAdapter()} />);
     await screen.findByText(/Odds Not Posted/i);
   });
 
@@ -209,5 +245,158 @@ describe('ScoresPage', () => {
     await waitFor(() => {
       expect(screen.getByText(/haven.t made any picks/i)).toBeInTheDocument();
     });
+  });
+
+  // ── React Query migration (frizat-ulm) ──────────────────────────────────
+  describe('background poll refresh', () => {
+    const POLL_MS = 300_000;
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('shows stale scores during a background refetch, no spinner', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      // hasActiveGames must be true — an already-final fixture polls at 4x this interval,
+      // so advancing by POLL_MS alone would never trigger a refetch at all.
+      const liveComp = createCompetition({
+        homeTeam: 'BUF', awayTeam: 'MIA', homeScore: 24, awayScore: 10,
+        liveStatus: { name: 'status_in_progress', period: 2, displayClock: '5:00' },
+      });
+      mockedLoadScoresWithRetry.mockResolvedValue(createScores({
+        week: 2, postSeason: false,
+        events: [{ id: '1', season: { year: 2024, type: 2 }, week: { number: 2 }, date: new Date().toISOString(), competitions: [liveComp] }],
+      }));
+      mockedGetLiveGames.mockResolvedValue([]);
+      mockedDoOddsExist.mockResolvedValue(true);
+      mockedGetLeaguePicks.mockResolvedValue([]);
+      mockedSpreadBatch.mockResolvedValue({ responses: SPREAD_RESPONSES });
+      await renderPage();
+      expect(screen.getAllByText(/BUF/i).length).toBeGreaterThan(0);
+
+      // Hold the next fetch in-flight forever so we can observe mid-refetch UI
+      mockedLoadScoresWithRetry.mockImplementation(() => new Promise(() => {}));
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(POLL_MS);
+      });
+
+      // Stale data stays on screen, no spinner replaces the page
+      expect(screen.queryByRole('progressbar')).toBeNull();
+      expect(screen.getAllByText(/BUF/i).length).toBeGreaterThan(0);
+    });
+
+    it('selecting the literal current week from the dropdown (not the "Current Week" button) keeps polling active', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      // hasActiveGames must be true — proves polling only continues if weekState correctly
+      // routed back to the live query (isCurrentWeek), not a one-off historical fetch, which
+      // would disable refetchInterval entirely and silently freeze this in-progress game.
+      const liveComp = createCompetition({
+        homeTeam: 'BUF', awayTeam: 'MIA', homeScore: 24, awayScore: 10,
+        liveStatus: { name: 'status_in_progress', period: 2, displayClock: '5:00' },
+      });
+      mockedLoadScoresWithRetry.mockResolvedValue(createScores({
+        week: 2, postSeason: false,
+        events: [{ id: '1', season: { year: 2024, type: 2 }, week: { number: 2 }, date: new Date().toISOString(), competitions: [liveComp] }],
+      }));
+      mockedGetLiveGames.mockResolvedValue([]);
+      mockedDoOddsExist.mockResolvedValue(true);
+      mockedGetLeaguePicks.mockResolvedValue([]);
+      mockedSpreadBatch.mockResolvedValue({ responses: SPREAD_RESPONSES });
+      mockedGetWeekScores.mockResolvedValue(makeScores(5, false, true));
+      await renderPage();
+      expect(screen.getAllByText(/BUF/i).length).toBeGreaterThan(0);
+
+      // Navigate away to week 5 (a real historical fetch), then back to week 2 via the dropdown
+      // — week 2 is literally the current week's own identity (setupDefaults default), so
+      // returning to it must route back to weekState=null, not stay on the historical path.
+      await user.click(screen.getAllByRole('combobox')[1]);
+      await user.click(screen.getByRole('option', { name: /week 5/i }));
+      await waitFor(() => expect(screen.getAllByText(/DAL/i).length).toBeGreaterThan(0));
+
+      await user.click(screen.getAllByRole('combobox')[1]);
+      await user.click(screen.getByRole('option', { name: /week 2/i }));
+      await waitFor(() => expect(screen.getAllByText(/BUF/i).length).toBeGreaterThan(0));
+
+      // Clear AFTER the one-off settle call for "week 2" itself — nflAdapter's
+      // loadHistoricalScores also calls loadScoresWithRetry internally (its own frozen-week
+      // check), so a call here is unavoidable and NOT what proves polling stayed active. Only a
+      // FURTHER call, after advancing past the poll interval, proves that.
+      mockedLoadScoresWithRetry.mockClear();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(POLL_MS);
+      });
+      expect(mockedLoadScoresWithRetry).toHaveBeenCalled();
+    });
+  });
+
+  it('season selector keeps the current season navigable after viewing a historical season', async () => {
+    // Regression (mirrors the equivalent PicksPage test): navigating into a past season used to
+    // permanently shrink the selector's range to "minSeason..whatever season you're viewing" —
+    // loadHistoricalScores returns maxSeason: <the season being viewed>, so re-deriving the
+    // ceiling from the active query's data on every render collapses it instead of remembering
+    // the real ceiling from the last current-week load (currentWeekSnapshot).
+    await setupDefaults({ week: 2 }); // current week resolves to season 2024 (fixture default)
+    mockedGetWeekScores.mockResolvedValue(createScores({ week: 2, seasonYear: 2022, gameStarted: true }));
+    await renderPage();
+
+    await userEvent.click(screen.getAllByRole('combobox')[0]);
+    await userEvent.click(screen.getByRole('option', { name: '2022 Season' }));
+    await waitFor(() => expect(screen.getByText('2022 Season')).toBeInTheDocument());
+
+    // The current season (2024) must still be a selectable option — not dropped from the range.
+    await userEvent.click(screen.getAllByRole('combobox')[0]);
+    expect(screen.getByRole('option', { name: '2024 Season' })).toBeInTheDocument();
+  });
+
+  it('shows an error alert with a retry button when the scores query fails', async () => {
+    await setupDefaults();
+    mockedLoadScoresWithRetry.mockRejectedValue(new Error('network down'));
+    renderWithClient(<ScoresPage adapter={createNflAdapter()} />);
+
+    const retryButton = await screen.findByRole('button', { name: /retry/i });
+    expect(screen.getByText(/couldn.t load scores/i)).toBeInTheDocument();
+
+    // Recover on retry
+    mockedLoadScoresWithRetry.mockResolvedValue(makeScores(2, false, true));
+    await userEvent.click(retryButton);
+
+    await waitFor(() => expect(screen.getAllByText(/BUF/i).length).toBeGreaterThan(0));
+  });
+
+  it('keys the scores query by adapter.sport, so NFL and CFB never share a cache entry', async () => {
+    await setupDefaults();
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: Infinity } } });
+    const { rerender } = renderWithClient(<ScoresPage adapter={createNflAdapter()} />, client);
+    await screen.findByText(/Scores/i);
+    await waitFor(() => expect(screen.queryByRole('progressbar')).toBeNull());
+    expect(screen.getAllByText(/BUF/i).length).toBeGreaterThan(0);
+
+    // CFB gets its own real, resolved dataset with entirely different teams (MICH/PSU — CFB
+    // has no BUF/MIA). placeholderData: keepPreviousData legitimately shows NFL's stale BUF/MIA
+    // as a transient placeholder while CFB's own query is pending (that's the point of
+    // keepPreviousData — no spinner flash on navigation) — the real assertion for "separate
+    // cache entries" is that once CFB's OWN query settles, ITS data (MICH/PSU) is what renders,
+    // not that NFL's cache entry got clobbered or that a spinner necessarily appears.
+    const cfbSlate = { id: 1, season: 2025, slateNumber: 8, label: 'Week 8', slateType: 'RegularSeason', startDate: '2025-10-11', endDate: '2025-10-18' };
+    const cfbSpread = { id: 1, cfbSlateId: 1, espnEventId: 100, homeTeam: 'MICH', awayTeam: 'PSU', homeTeamSpread: -3.5, awayTeamSpread: 3.5, overUnder: 44.5, gameTime: '2025-10-11T20:00:00Z', dateCreated: '2025-10-09T14:00:00Z' };
+    mockedGetCfbCurrentSlate.mockResolvedValue(cfbSlate);
+    mockedGetCfbSlates.mockResolvedValue([cfbSlate]);
+    mockedGetCfbSpreads.mockResolvedValue([cfbSpread]);
+    mockedGetCfbScores.mockResolvedValue([]);
+    mockedGetCfbAllPicks.mockResolvedValue([]);
+    mockedLoadCfbScoresWithRetry.mockResolvedValue({ leagues: [], season: { year: 2025, type: 2 }, week: { number: 8 }, events: [] });
+    mockedGetCfbLiveGames.mockResolvedValue([]);
+
+    rerender(
+      <QueryClientProvider client={client}>
+        <ScoresPage adapter={createCfbAdapter()} />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(screen.getAllByText(/MICH/i).length).toBeGreaterThan(0));
+    expect(screen.queryByText(/BUF/i)).toBeNull();
   });
 });

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  Badge, Box, Button, CircularProgress, Grid,
+  Alert, Badge, Box, Button, CircularProgress, Grid,
   IconButton, Paper, Stack, Typography,
 } from '@mui/material';
 import PersonIcon from '@mui/icons-material/Person';
@@ -9,6 +9,7 @@ import GppBadIcon from '@mui/icons-material/GppBad';
 import GppMaybeIcon from '@mui/icons-material/GppMaybe';
 import ArrowCircleUpIcon from '@mui/icons-material/ArrowCircleUp';
 import ArrowCircleDownIcon from '@mui/icons-material/ArrowCircleDown';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import PageHeader from '../components/PageHeader';
 import WeekYearSelector from '../components/WeekYearSelector';
 import NoLeague from '../components/NoLeague';
@@ -20,7 +21,7 @@ import FieldPosition from '../components/FieldPosition';
 import { useSession } from '../services/session';
 import { useAuth } from '../services/auth';
 import { spreadLabel } from '../utils/gameHelpers';
-import type { SportAdapter, GameView, WeekState, LoadedScores } from '../services/sportAdapter';
+import type { SportAdapter, GameView, WeekState } from '../services/sportAdapter';
 
 // GameView.gameStatus is canonical GameStatusValue — use === directly, no string parsing
 
@@ -63,11 +64,16 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
   const { currentLeague, leaguesLoaded } = useSession();
   const { user } = useAuth();
 
-  const [loading, setLoading] = useState(true);
-  const [data, setData] = useState<LoadedScores | null>(null);
-  const [isCurrentWeek, setIsCurrentWeek] = useState(true);
-  const [maxWeek, setMaxWeek] = useState(adapter.weekSelectorConfig.maxRegularSeasonWeek);
-  const [maxSeason, setMaxSeason] = useState(new Date().getFullYear());
+  // null = live current week (polls in background); non-null = historical navigation
+  const [weekState, setWeekState] = useState<WeekState | null>(null);
+  // The real navigable ceiling and the real "current week" identity — captured only from a
+  // current-week load, mirroring PicksPage's currentBounds. loadHistoricalScores returns
+  // maxWeek/maxSeason/season/week set to whatever is being VIEWED, not "today" — re-deriving
+  // either from the active query's data would collapse the selector's ceiling, or make selecting
+  // your own current week from the dropdown look like a historical navigation.
+  const [currentWeekSnapshot, setCurrentWeekSnapshot] = useState<
+    (WeekState & { maxWeek: number; maxSeason: number }) | null
+  >(null);
   const [isPageVisible, setIsPageVisible] = useState(true);
   const [showMatrixView, setShowMatrixView] = useState(false);
   const [showOnlyMyPicks, setShowOnlyMyPicks] = useState(false);
@@ -76,84 +82,81 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
     userNames: string[]; userNamesOver: string[]; userNamesUnder: string[];
   } | null>(null);
 
-  const reload = useCallback(async () => {
-    if (!currentLeague || !user?.userId) { setLoading(false); return; }
-    setLoading(true);
-    try {
-      const result = await adapter.loadCurrentScores(currentLeague, user.userId);
-      const fp = (d: typeof result) => d.games.map(g => `${g.id}:${g.homeScore}:${g.awayScore}:${g.gameStatus}`).join('|');
-      setData(prev => prev && fp(prev) === fp(result) ? prev : result);
-      // Do NOT set isCurrentWeek=true here — polling races with handleWeekChange and would
-      // reset historical navigation. isCurrentWeek is managed by the callers.
-      setMaxWeek(result.maxWeek);
-      setMaxSeason(result.maxSeason);
-    } finally {
-      setLoading(false);
-    }
-  }, [currentLeague, user?.userId, adapter]);
+  const isCurrentWeek = weekState === null;
+  const enabled = leaguesLoaded && !!currentLeague && !!user?.userId;
 
-  const loadHistorical = useCallback(async (state: WeekState) => {
-    if (!currentLeague || !user?.userId) return;
-    setLoading(true);
-    try {
-      // If the selected week matches the current (frozen demo) week, use the current
-      // scores path so the in-progress state is shown instead of the real ESPN final.
-      // If the selected week matches the frozen demo week, use current path for consistency
-      const isSameAsCurrentWeek =
-        data != null &&
-        state.season === data.season &&
-        state.week === data.week &&
-        state.isPostSeason === data.isPostSeason;
-      if (isSameAsCurrentWeek) {
-        await reload();
-        setIsCurrentWeek(true);
-        return;
-      }
-      const result = await adapter.loadHistoricalScores(currentLeague, user.userId, state);
-      setData(result);
-    } finally {
-      setLoading(false);
-    }
-  }, [currentLeague, user?.userId, adapter, data, reload]);
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: [adapter.sport, 'scores', currentLeague, user?.userId, weekState],
+    queryFn: () => weekState
+      ? adapter.loadHistoricalScores(currentLeague!, user!.userId, weekState)
+      : adapter.loadCurrentScores(currentLeague!, user!.userId),
+    enabled,
+    refetchInterval: query => isCurrentWeek && isPageVisible && adapter.pollIntervalMs > 0
+      ? (query.state.data?.hasActiveGames ? adapter.pollIntervalMs : adapter.pollIntervalMs * 4)
+      : false,
+    placeholderData: keepPreviousData,
+  });
 
-  // Page visibility
+  useEffect(() => {
+    if (!isCurrentWeek || !data) return;
+    // data gets a new reference on every poll/SSE tick (scores/clock change), which would
+    // otherwise force this state — and everything derived from it below, including
+    // WeekYearSelector's props — to re-render on every tick even when nothing here actually
+    // changed. Bail out unless the fields this snapshot actually cares about moved.
+    setCurrentWeekSnapshot(prev =>
+      prev
+        && prev.season === data.season && prev.week === data.week && prev.isPostSeason === data.isPostSeason
+        && prev.maxWeek === data.maxWeek && prev.maxSeason === data.maxSeason
+        ? prev
+        : { season: data.season, week: data.week, isPostSeason: data.isPostSeason, maxWeek: data.maxWeek, maxSeason: data.maxSeason });
+  }, [isCurrentWeek, data]);
+
+  // Page visibility — pause polling for a hidden tab rather than burn cycles/battery on it.
   useEffect(() => {
     const h = () => setIsPageVisible(!document.hidden);
     document.addEventListener('visibilitychange', h);
     return () => document.removeEventListener('visibilitychange', h);
   }, []);
 
-  // Load + poll (fallback — SSE is primary when active games exist)
-  useEffect(() => {
-    if (!isCurrentWeek || !isPageVisible || !leaguesLoaded) return;
-    void reload();
-    if (adapter.pollIntervalMs <= 0) return;
-    const interval = setInterval(() => void reload(), data?.hasActiveGames ? adapter.pollIntervalMs : adapter.pollIntervalMs * 4);
-    return () => clearInterval(interval);
-  }, [reload, isCurrentWeek, isPageVisible, leaguesLoaded, data?.hasActiveGames, adapter.pollIntervalMs]);
-
-  // SSE — primary update mechanism when on current NFL week with active games
+  // SSE — primary update mechanism when on current NFL week with active games; polling above
+  // is the fallback (and the only mechanism at all for adapters with no sseUrl, e.g. CFB).
   useEffect(() => {
     if (!isCurrentWeek || !isPageVisible || !leaguesLoaded || !data?.hasActiveGames || !adapter.sseUrl) return;
     const es = new EventSource(adapter.sseUrl, { withCredentials: true });
-    es.onmessage = () => void reload();
+    es.onmessage = () => void refetch();
     es.onerror = () => es.close(); // fallback polling takes over
     return () => es.close();
-  }, [isCurrentWeek, isPageVisible, leaguesLoaded, data?.hasActiveGames, adapter.sseUrl, reload]);
+  }, [isCurrentWeek, isPageVisible, leaguesLoaded, data?.hasActiveGames, adapter.sseUrl, refetch]);
+
+  const maxWeek = currentWeekSnapshot?.maxWeek ?? adapter.weekSelectorConfig.maxRegularSeasonWeek;
+  const maxSeason = currentWeekSnapshot?.maxSeason ?? new Date().getFullYear();
+
+  // Selecting the week that IS the current week (from the dropdown, not the "Current Week"
+  // button) routes back to the live query instead of a one-off historical fetch — the historical
+  // path has no equivalent of hasActiveGames/SSE eligibility, so it would freeze live updates.
+  const routeToCurrentIfMatches = useCallback((candidate: WeekState): WeekState | null => {
+    if (currentWeekSnapshot
+      && candidate.season === currentWeekSnapshot.season
+      && candidate.week === currentWeekSnapshot.week
+      && candidate.isPostSeason === currentWeekSnapshot.isPostSeason) {
+      return null;
+    }
+    return candidate;
+  }, [currentWeekSnapshot]);
 
   const handleWeekChange = useCallback((week: number, meta?: { isPostSeason?: boolean }) => {
+    const season = data?.season ?? new Date().getFullYear();
     const isPostSeason = meta?.isPostSeason ?? data?.isPostSeason ?? false;
-    setIsCurrentWeek(false);
-    void loadHistorical({ season: data?.season ?? new Date().getFullYear(), week, isPostSeason });
-  }, [data?.isPostSeason, data?.season, loadHistorical]);
+    setWeekState(routeToCurrentIfMatches({ season, week, isPostSeason }));
+  }, [data?.season, data?.isPostSeason, routeToCurrentIfMatches]);
   const handleSeasonChange = useCallback((season: number) => {
-    setIsCurrentWeek(false);
-    void loadHistorical({ season, week: data?.week ?? 1, isPostSeason: data?.isPostSeason ?? false });
-  }, [data?.week, data?.isPostSeason, loadHistorical]);
+    const week = data?.week ?? 1;
+    const isPostSeason = data?.isPostSeason ?? false;
+    setWeekState(routeToCurrentIfMatches({ season, week, isPostSeason }));
+  }, [data?.week, data?.isPostSeason, routeToCurrentIfMatches]);
   const handleSeasonTypeChange = useCallback((_isPostSeason: boolean) => {
     // WeekYearSelector.handleSeasonTypeSelect also calls onWeekChange with the last week —
     // don't double-load here, let handleWeekChange handle it.
-    setIsCurrentWeek(false);
   }, []);
 
   // Pick query helpers
@@ -192,12 +195,25 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
 
   // ─── Guard states ─────────────────────────────────────────────────────────
 
-  if (loading) return (
+  // First load only — background refetches (polling, SSE) keep the grid mounted via
+  // placeholderData: keepPreviousData, so isLoading here only reflects a truly empty cache.
+  if (!leaguesLoaded || isLoading) return (
     <Box><PageHeader title="Scores" />
       <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}><CircularProgress /></Box>
     </Box>
   );
   if (!currentLeague) return <NoLeague />;
+  if (isError && !data) return (
+    <Box><PageHeader title="Scores" />
+      <Alert
+        severity="error"
+        sx={{ mt: 4 }}
+        action={<Button color="inherit" size="small" onClick={() => void refetch()}>Retry</Button>}
+      >
+        Couldn&apos;t load scores. Check your connection and try again.
+      </Alert>
+    </Box>
+  );
   if (!data?.hasOdds && isCurrentWeek) return <SpreadRelease sport={adapter.sport} />;
   if (!data) return null;
 
@@ -227,7 +243,7 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
         />
         {!isCurrentWeek && (
           <Box sx={{ display: 'flex', justifyContent: 'center', mt: -1, mb: 1 }}>
-            <Button size="small" variant="outlined" onClick={() => { setIsCurrentWeek(true); void reload(); }}>
+            <Button size="small" variant="outlined" onClick={() => setWeekState(null)}>
               Current Week
             </Button>
           </Box>


### PR DESCRIPTION
## Summary

Migrates `ScoresPage` from manual `useState`/`useEffect` polling to TanStack Query's `useQuery`, mirroring `PicksPage`'s already-merged migration.

- `queryKey: [adapter.sport, 'scores', leagueId, weekState]`, `placeholderData: keepPreviousData` — background refetches are invisible (no spinner replacing the grid).
- **Fixes a real bug along the way**: the old implementation set `loading = true` on *every* poll, including background ones — during a live game, the entire scores grid was replaced with a full-page spinner every 5 minutes. That's gone.
- New error+retry `Alert` on a first-load failure only (`isError && !data`) — a background refetch failure keeps showing stale data, consistent with the "background refetches are invisible" philosophy; it doesn't interrupt anyone mid-game over a transient network blip.
- SSE (`EventSource`) stays the primary live-update mechanism for NFL when games are active; polling is the fallback, gated on page visibility and the same "tight interval when active, 4x when not" cadence as before.
- Two subtle pre-existing behaviors, now both driven by one `currentWeekSnapshot` captured only from a current-week load (not re-derived from whatever's currently being viewed):
  - The week/season selector's ceiling doesn't shrink after navigating into a historical week.
  - Selecting the *literal current week* from the dropdown (not the "Current Week" button) routes back to the live/pollable query — the historical fetch path has no equivalent of `hasActiveGames`/SSE eligibility, so treating it as historical would silently freeze live updates for a game still in progress.

## Review notes

`/simplify` (4 parallel agents) found two real, in-scope issues and applied both: merged two always-co-written state variables (`currentBounds`/`currentWeekIdentity`) into one `currentWeekSnapshot`, and added value-equality dedup to its setter — without it, every poll/SSE tick during a live game allocated a fresh object and forced a re-render cascading through `WeekYearSelector`'s props even when nothing relevant had changed. Two other findings (extracting a shared hook with `PicksPage`, and a shared `QueryErrorAlert` component) were legitimate but require touching `PicksPage.tsx`, outside this diff's scope — left as follow-up candidates.

An independent code-reviewer pass traced all required behaviors against actual TanStack Query v5 runtime semantics and found the migration logic correct, with one real gap: no test coverage for the dropdown-vs-button current-week routing rule. Closed with 2 new tests — verified genuinely red (failed) against a deliberately broken version of the routing logic before confirming green against the real implementation.

## Test plan

- [x] `npm run test -- --run` — 269/269 (was 264; +2 net for this PR after accounting for the earlier merged PR's own additions)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:e2e -- --project=chromium` — 54/54 mock e2e
- [x] `npm run test:e2e:demo` — 46/46 demo-backend integration e2e, including live/in-progress score rendering (Super Bowl Q3 clock, field position, cover colors) and SSE-eligible current-week flows
- [x] Negative control: temporarily broke the dropdown-routing logic, confirmed the new test correctly failed, restored, confirmed green

🤖 Generated with [Claude Code](https://claude.com/claude-code)