### PR TITLE
docs: drop ADMIN_ALERT_EMAIL from prod-live-test skill until frizat-703.2 ships

### DIFF
--- a/.claude/skills/prod-live-test/SKILL.md
+++ b/.claude/skills/prod-live-test/SKILL.md
@@ -38,7 +38,7 @@ Every ✗ gets its own bead; retest after fix. The test passes only when every r
 - [ ] Staging live at a stable URL, auto-deploying from `dev`, `DEMO_MODE=false`
 - [ ] Both hosts resolve: apex (NFL) and `cfb.` subdomain (CFB)
 - [ ] 2026 season config rows exist: `SELECT COUNT(*) FROM "NflSeasonWeekConfigs" WHERE "Season"=2026` → 22; CFB → 18
-- [ ] `ALLOWED_ORIGINS`, SMTP creds, odds API key, `ADMIN_ALERT_EMAIL` set in staging env
+- [ ] `ALLOWED_ORIGINS`, SMTP creds, odds API key set in staging env
 - [ ] 5 real test people recruited (real inboxes — Gmail aliases like `you+alice@gmail.com` work)
 
 ## Phase 1 — Infra smoke (any day, ~15 min)
@@ -103,7 +103,7 @@ Every ✗ gets its own bead; retest after fix. The test passes only when every r
 
 ## Phase 9 — Failure drills (staging only, after Phase 7)
 
-- [ ] Break the odds API key → trigger spread job → admin alert email arrives (job-alerting bead); restore key
+- [ ] Break the odds API key → trigger spread job → job fails cleanly (logged, no crash), no bad data written; restore key. (Admin alert email is out of scope until frizat-703.2 ships — add that assertion back once it exists.)
 - [ ] Restart the backend service mid-day → Quartz recovers, missed triggers fire per misfire policy, no duplicate score rows
 - [ ] Deploy a new build while a tester is mid-session → stale-build banner appears (frizat-066); session survives
 - [ ] Brief DB outage (pause Neon compute) → app shows error states, recovers without restart, session init doesn't hang


### PR DESCRIPTION
## Summary

`ADMIN_ALERT_EMAIL` doesn't exist anywhere in the codebase (only in this skill doc) — it's a forward-looking reference to job failure alerting (`frizat-703.2`), which is still open and paused. Phase 0's env-var check and Phase 9's failure drill both assumed it existed, making them un-passable as written for anyone running this test today.

- Phase 0: dropped `ADMIN_ALERT_EMAIL` from the env-var checklist item.
- Phase 9: the odds-key failure drill now checks the job fails cleanly (logged, no crash, no bad data written) instead of asserting an alert email arrives. That assertion can be restored once 703.2 ships.
- Removed the `frizat-703.4` → `frizat-703.2` bead dependency to match — job alerting isn't a hard blocker for running the live test now.

Doc-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)