### PR TITLE
fix(ci): move EF migrations out of app startup into a gated CI workflow

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -2,14 +2,15 @@ name: DB Migrate
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
     paths:
       - 'Server/Migrations/**'
       - 'Server/Data/**'
+  workflow_dispatch: {}
 
 jobs:
   migrate:
-    name: Run EF migrations (prod)
+    name: Run EF migrations (${{ github.ref_name }})
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,14 +20,25 @@ jobs:
         with:
           dotnet-version: '9.0.x'
 
-      - name: Install EF tools
-        run: dotnet tool install --global dotnet-ef
+      # A local tool manifest (.config/dotnet-tools.json) already declares dotnet-ef —
+      # `tool install --global` fights that manifest and leaves `dotnet ef` unresolvable
+      # ("Run 'dotnet tool restore'"). Restore the manifest's own version instead.
+      - name: Restore EF tool
+        run: dotnet tool restore
 
       - name: Restore
         run: dotnet restore
 
       - name: Migrate
+        env:
+          # main -> prod DB, dev -> dev DB. Each branch's own secret, resolved once here so a
+          # misconfigured/missing secret fails loudly instead of silently running against "".
+          CONN: ${{ github.ref_name == 'main' && secrets.NEON_PROD_CONNECTION_STRING || secrets.NEON_DEV_CONNECTION_STRING }}
         run: |
+          if [ -z "$CONN" ]; then
+            echo "::error::Connection string secret is empty for branch '${{ github.ref_name }}' — check NEON_PROD_CONNECTION_STRING/NEON_DEV_CONNECTION_STRING are set in repo secrets."
+            exit 1
+          fi
           dotnet ef database update \
             --project Server \
-            --connection "${{ secrets.NEON_PROD_CONNECTION_STRING }}"
+            --connection "$CONN"

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -33,12 +33,12 @@ jobs:
         env:
           # main -> prod DB, dev -> dev DB. Each branch's own secret, resolved once here so a
           # misconfigured/missing secret fails loudly instead of silently running against "".
-          CONN: ${{ github.ref_name == 'main' && secrets.NEON_PROD_CONNECTION_STRING || secrets.NEON_DEV_CONNECTION_STRING }}
+          # ApplicationDbContextFactory (Server/Data/) reads this exact env var directly — no
+          # app pipeline boot required, so no other config (JWT, email, ALLOWED_ORIGINS) is needed.
+          ConnectionStrings__POSTGRES_CONNECTION_STRING: ${{ github.ref_name == 'main' && secrets.NEON_PROD_CONNECTION_STRING || secrets.NEON_DEV_CONNECTION_STRING }}
         run: |
-          if [ -z "$CONN" ]; then
+          if [ -z "$ConnectionStrings__POSTGRES_CONNECTION_STRING" ]; then
             echo "::error::Connection string secret is empty for branch '${{ github.ref_name }}' — check NEON_PROD_CONNECTION_STRING/NEON_DEV_CONNECTION_STRING are set in repo secrets."
             exit 1
           fi
-          dotnet ef database update \
-            --project Server \
-            --connection "$CONN"
+          dotnet ef database update --project Server

--- a/Client.React/src/components/sports/GameCard.tsx
+++ b/Client.React/src/components/sports/GameCard.tsx
@@ -3,6 +3,7 @@ import CheckIcon from '@mui/icons-material/Check';
 import TeamHelmet from './TeamHelmet';
 import WeatherIcon from '../WeatherIcon';
 import { spreadLabel } from '../../utils/gameHelpers';
+import { toLocalDisplay } from '../../utils/time';
 
 export type PickState = 'none' | 'pending' | 'submitted';
 
@@ -51,7 +52,7 @@ export interface GameCardProps {
 }
 
 function formatShortDateTime(iso: string) {
-  return new Date(iso).toLocaleString([], {
+  return toLocalDisplay(iso, {
     weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
   });
 }

--- a/Client.React/src/pages/RulesPage.tsx
+++ b/Client.React/src/pages/RulesPage.tsx
@@ -13,6 +13,7 @@ import {
 import { getEspnRequiredPicks, getCfbRequiredPicks } from '../utils/gameHelpers';
 import { useSportContext } from '../services/sport';
 import { getNextSpreadJob } from '../services/spreadRelease';
+import { toLocalDisplay } from '../utils/time';
 import PageHeader from '../components/PageHeader';
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
@@ -284,7 +285,7 @@ function InfoCallout({ children }: { children: React.ReactNode }) {
 }
 
 function formatLockTime(iso: string) {
-  return new Date(iso).toLocaleString(undefined, {
+  return toLocalDisplay(iso, {
     weekday: 'long',
     month: 'short',
     day: 'numeric',

--- a/Server.UnitTests/CfbRankingCaptureJobTests.cs
+++ b/Server.UnitTests/CfbRankingCaptureJobTests.cs
@@ -17,15 +17,26 @@ public class CfbRankingCaptureJobTests
     private readonly ICfbLiveScoreFetcher _fetcher;
     private readonly ICfbRepository _repo;
     private readonly IJobExecutionContext _context;
+    private readonly TimeProvider _timeProvider;
+
+    // Fixed, controlled "now" — not tied to the real wall clock, so the EndDate-based skip filter
+    // is deterministic regardless of when the suite actually runs. Set before BuildSlate's default
+    // EndDate (2026-09-07) so existing "current" slates are still in scope by default.
+    private static readonly DateTimeOffset FakeNow = new(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private sealed class FakeTimeProvider(DateTimeOffset now) : TimeProvider {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
 
     public CfbRankingCaptureJobTests()
     {
         _fetcher = Substitute.For<ICfbLiveScoreFetcher>();
         _repo = Substitute.For<ICfbRepository>();
         _context = Substitute.For<IJobExecutionContext>();
+        _timeProvider = new FakeTimeProvider(FakeNow);
     }
 
-    private CfbRankingCaptureJob BuildJob() => new(_fetcher, _repo);
+    private CfbRankingCaptureJob BuildJob() => new(_fetcher, _repo, _timeProvider);
 
     private static CfbSlates BuildSlate(int slateId = 1) => new()
     {
@@ -109,6 +120,22 @@ public class CfbRankingCaptureJobTests
 
         await BuildJob().Execute(_context);
 
+        await _repo.DidNotReceive().AddRankingsAsync(Arg.Any<IEnumerable<CfbRanking>>());
+    }
+
+    [Fact]
+    public async Task Execute_SkipsSlateWhoseEndDateHasPassed_NoWastedFetch()
+    {
+        // CfbRankingExtractor only emits rows for StatusScheduled competitions, so a slate whose
+        // games are all already final is a guaranteed zero-yield ESPN call — skip it entirely
+        // rather than fetching and discarding.
+        var pastSlate = BuildSlate();
+        pastSlate.EndDate = DateOnly.FromDateTime(FakeNow.UtcDateTime.AddDays(-1));
+        _repo.GetSlatesForSeasonAsync(2026).Returns([pastSlate]);
+
+        await BuildJob().Execute(_context);
+
+        await _fetcher.DidNotReceive().FetchForSlateAsync(Arg.Any<CfbSlates>());
         await _repo.DidNotReceive().AddRankingsAsync(Arg.Any<IEnumerable<CfbRanking>>());
     }
 

--- a/Server/Controllers/JobManagerController.cs
+++ b/Server/Controllers/JobManagerController.cs
@@ -12,37 +12,12 @@ namespace FourPlayWebApp.Server.Controllers {
     public class JobManagerController(ISchedulerFactory schedulerFactory, IJobObserverService observer) : ControllerBase {
         [Authorize(Roles = "Administrator")]
         [HttpPost("run-spreads")]
-        public async Task<IActionResult> RunSpreads([FromQuery] bool force = false) {
-            try {
-                var scheduler = await schedulerFactory.GetScheduler();
-                var allJobs = await GetAllJobsStatusAsync();
-                // Each in-scope week now registers its own one-time "NFL Spreads {season} Wk{n}"
-                // job (frizat-pxy) — pick the SOONEST one, not an arbitrary match; a plain
-                // Contains("Spreads") FirstOrDefault would grab whichever week sorts first
-                // alphabetically ("Wk1" before "Wk10"), not the one actually coming up next.
-                var jobName = allJobs
-                    .Where(job => job.JobName.StartsWith("NFL Spreads ", StringComparison.OrdinalIgnoreCase) && job.NextRun is not null)
-                    .MinBy(job => job.NextRun);
-                if (jobName is null)
-                    return NotFound();
-                // force=true bypasses NflSpreadJob's lock-time write guard (SpreadLockGuard) —
-                // deliberately not the default; this endpoint is normally held to the same
-                // no-write-before-lock-time rule as the scheduler. Logged distinctly so an
-                // early write via this path is always auditable after the fact.
-                if (force) {
-                    var data = new JobDataMap { { "force", true } };
-                    await scheduler.TriggerJob(new JobKey(jobName.JobName), data);
-                    Log.Warning("Admin FORCED Spread Job {JobName} — bypassing lock-time guard", jobName.JobName);
-                } else {
-                    await scheduler.TriggerJob(new JobKey(jobName.JobName));
-                    Log.Information("Started Spread Job {JobName}", jobName.JobName);
-                }
-                return Ok(new {message = "Started Spread Job"});
-            }
-            catch (Exception e) {
-                return BadRequest(e.Message);
-            }
-        }
+        public Task<IActionResult> RunSpreads([FromQuery] bool force = false) =>
+            // Each in-scope week now registers its own one-time "NFL Spreads {season} Wk{n}"
+            // job (frizat-pxy) — TriggerSoonestSpreadJobAsync picks the SOONEST one, not an
+            // arbitrary match; a plain Contains("Spreads") FirstOrDefault would grab whichever
+            // week sorts first alphabetically ("Wk1" before "Wk10"), not the one coming up next.
+            TriggerSoonestSpreadJobAsync("NFL Spreads ", "Spread", force);
         [Authorize(Roles = "Administrator")]
         [HttpPost("run-scores")]
         public async Task<IActionResult> RunScores() {
@@ -89,34 +64,11 @@ namespace FourPlayWebApp.Server.Controllers {
         }
         [Authorize(Roles = "Administrator")]
         [HttpPost("run-cfb-spreads")]
-        public async Task<IActionResult> RunCfbSpreads([FromQuery] bool force = false) {
-            try {
-                var scheduler = await schedulerFactory.GetScheduler();
-                var allJobs = await GetAllJobsStatusAsync();
-                // The fixed "CFB Spread Job" JobKey this used to trigger no longer exists — CFB
-                // spreads now run via per-week "CFB Spreads {season} Wk{n}" triggers (frizat-9m0),
-                // same reasoning as RunSpreads above: pick the soonest one, not an arbitrary match.
-                var jobName = allJobs
-                    .Where(job => job.JobName.StartsWith("CFB Spreads ", StringComparison.OrdinalIgnoreCase) && job.NextRun is not null)
-                    .MinBy(job => job.NextRun);
-                if (jobName is null)
-                    return NotFound();
-                // See RunSpreads above — force=true bypasses CfbSpreadJob's lock-time write guard,
-                // same symmetric design as NFL.
-                if (force) {
-                    var data = new JobDataMap { { "force", true } };
-                    await scheduler.TriggerJob(new JobKey(jobName.JobName), data);
-                    Log.Warning("Admin FORCED CFB Spread Job {JobName} — bypassing lock-time guard", jobName.JobName);
-                } else {
-                    await scheduler.TriggerJob(new JobKey(jobName.JobName));
-                    Log.Information("Started CFB Spread Job {JobName}", jobName.JobName);
-                }
-                return Ok(new { message = "Started CFB Spread Job" });
-            }
-            catch (Exception e) {
-                return BadRequest(e.Message);
-            }
-        }
+        public Task<IActionResult> RunCfbSpreads([FromQuery] bool force = false) =>
+            // The fixed "CFB Spread Job" JobKey this used to trigger no longer exists — CFB
+            // spreads now run via per-week "CFB Spreads {season} Wk{n}" triggers (frizat-9m0),
+            // same reasoning as RunSpreads above: pick the soonest one, not an arbitrary match.
+            TriggerSoonestSpreadJobAsync("CFB Spreads ", "CFB Spread", force);
         [Authorize(Roles = "Administrator")]
         [HttpPost("run-cfb-scores")]
         public async Task<IActionResult> RunCfbScores() {
@@ -209,6 +161,34 @@ namespace FourPlayWebApp.Server.Controllers {
             return Ok(result);
         }
 
+
+        // Shared by RunSpreads/RunCfbSpreads: picks the soonest not-yet-fired per-week job whose
+        // name starts with jobNamePrefix and triggers it, optionally bypassing the sport's
+        // lock-time write guard (SpreadLockGuard) via force=true. force is deliberately not the
+        // default — logged distinctly so an early write via this path is always auditable.
+        private async Task<IActionResult> TriggerSoonestSpreadJobAsync(string jobNamePrefix, string sportLabel, bool force) {
+            try {
+                var scheduler = await schedulerFactory.GetScheduler();
+                var allJobs = await GetAllJobsStatusAsync();
+                var jobName = allJobs
+                    .Where(job => job.JobName.StartsWith(jobNamePrefix, StringComparison.OrdinalIgnoreCase) && job.NextRun is not null)
+                    .MinBy(job => job.NextRun);
+                if (jobName is null)
+                    return NotFound();
+                if (force) {
+                    var data = new JobDataMap { { "force", true } };
+                    await scheduler.TriggerJob(new JobKey(jobName.JobName), data);
+                    Log.Warning("Admin FORCED {SportLabel} Job {JobName} — bypassing lock-time guard", sportLabel, jobName.JobName);
+                } else {
+                    await scheduler.TriggerJob(new JobKey(jobName.JobName));
+                    Log.Information("Started {SportLabel} Job {JobName}", sportLabel, jobName.JobName);
+                }
+                return Ok(new { message = $"Started {sportLabel} Job" });
+            }
+            catch (Exception e) {
+                return BadRequest(e.Message);
+            }
+        }
 
         private static async Task<string> GetJobStatusAsync(IScheduler scheduler, JobKey jobKey) {
             var triggerState = await scheduler.GetTriggerState(new TriggerKey($"{jobKey.Name}-trigger"));

--- a/Server/Data/ApplicationDbContextFactory.cs
+++ b/Server/Data/ApplicationDbContextFactory.cs
@@ -1,0 +1,25 @@
+using FourPlayWebApp.Server.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace FourPlayWebApp.Server.Data;
+
+// dotnet ef has no lightweight way to get a DbContext for a top-level-statement Program.cs — by
+// default it boots the entire app pipeline (JWT config, email config, CORS validation, the
+// startup migration check) just to construct one. That's fragile for CI/migration-only runs
+// (needs a pile of unrelated dummy env vars, and would even trip the startup fail-fast check
+// this same PR adds). This factory is the standard EF Core answer: dotnet ef design-time tooling
+// prefers this over booting Program.cs when present, and it only needs a connection string.
+public class ApplicationDbContextFactory : IDesignTimeDbContextFactory<ApplicationDbContext>
+{
+    public ApplicationDbContext CreateDbContext(string[] args)
+    {
+        var raw = Environment.GetEnvironmentVariable("ConnectionStrings__POSTGRES_CONNECTION_STRING")
+            ?? throw new InvalidOperationException(
+                "ConnectionStrings__POSTGRES_CONNECTION_STRING must be set to run EF Core design-time commands (migrations, database update).");
+
+        var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
+        optionsBuilder.UseNpgsql(PostgresConnectionString.Normalize(raw));
+        return new ApplicationDbContext(optionsBuilder.Options);
+    }
+}

--- a/Server/Infrastructure/PostgresConnectionString.cs
+++ b/Server/Infrastructure/PostgresConnectionString.cs
@@ -1,0 +1,35 @@
+namespace FourPlayWebApp.Server.Infrastructure;
+
+internal static class PostgresConnectionString
+{
+    /// <summary>
+    /// Neon (and most managed Postgres providers) hand out postgres://-style URLs; Npgsql wants
+    /// Host=...;Port=...;... key=value form. Converts when needed, passes through unchanged
+    /// otherwise (e.g. local Docker Postgres already uses key=value).
+    /// </summary>
+    internal static string Normalize(string raw)
+    {
+        if (!raw.StartsWith("postgres://") && !raw.StartsWith("postgresql://"))
+            return raw;
+
+        var uri = new Uri(raw);
+        var userInfo = uri.UserInfo.Split(':');
+        var username = userInfo[0];
+        var password = userInfo.Length > 1 ? Uri.UnescapeDataString(userInfo[1]) : string.Empty;
+        var host = uri.Host;
+        var port = uri.Port > 0 ? uri.Port : 5432;
+        var database = uri.AbsolutePath.TrimStart('/');
+        var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
+        var sslMode = query["sslmode"] ?? "Prefer";
+        var npgsqlSsl = sslMode.ToLowerInvariant() switch {
+            "require"     => "Require",
+            "verify-ca"   => "VerifyCA",
+            "verify-full" => "VerifyFull",
+            "disable"     => "Disable",
+            _             => "Prefer"
+        };
+        // Only trust-cert for Require/Prefer — VerifyCA/VerifyFull must validate the chain
+        var trustCert = npgsqlSsl is "Require" or "Prefer" ? ";Trust Server Certificate=true" : string.Empty;
+        return $"Host={host};Port={port};Username={username};Password={password};Database={database};SSL Mode={npgsqlSsl}{trustCert}";
+    }
+}

--- a/Server/Jobs/CfbRankingCaptureJob.cs
+++ b/Server/Jobs/CfbRankingCaptureJob.cs
@@ -18,20 +18,25 @@ namespace FourPlayWebApp.Server.Jobs;
 // schedule-known and spread-locked). CfbRanking is append-only by design, so two captures over the
 // week is more complete history, not redundant noise.
 [DisallowConcurrentExecution]
-public class CfbRankingCaptureJob(ICfbLiveScoreFetcher fetcher, ICfbRepository repo) : IJob {
+public class CfbRankingCaptureJob(ICfbLiveScoreFetcher fetcher, ICfbRepository repo, TimeProvider timeProvider) : IJob {
     private const int Season = 2026;
 
     public async Task Execute(IJobExecutionContext context) {
         Log.Information("CfbRankingCaptureJob: capturing CFB rankings at {Time}", DateTime.UtcNow);
 
-        var slates = (await repo.GetSlatesForSeasonAsync(Season)).ToList();
-        if (slates.Count == 0) {
+        var allSlates = (await repo.GetSlatesForSeasonAsync(Season)).ToList();
+        if (allSlates.Count == 0) {
             Log.Warning("CfbRankingCaptureJob: no slates found for season {Season} — run CfbSlateSeederJob first", Season);
             return;
         }
 
-        // Each slate's scoreboard fetch is an independent ESPN call — no data dependency between
-        // them, so fetch all slates concurrently rather than serializing ~18 round-trips.
+        // CfbRankingExtractor only emits rows for StatusScheduled competitions, so a slate whose
+        // games are all already final is a guaranteed zero-yield ESPN call — skip it.
+        var today = DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime);
+        var slates = allSlates.Where(s => s.EndDate >= today).ToList();
+
+        // Each remaining slate's scoreboard fetch is an independent ESPN call — no data dependency
+        // between them, so fetch all slates concurrently rather than serializing the round-trips.
         var scoreboards = await Task.WhenAll(slates.Select(async slate =>
             (slate, scoreboard: await fetcher.FetchForSlateAsync(slate))));
 

--- a/Server/Jobs/CfbSpreadJob.cs
+++ b/Server/Jobs/CfbSpreadJob.cs
@@ -1,3 +1,4 @@
+using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models;
@@ -40,7 +41,7 @@ public class CfbSpreadJob(
         }
 
         var spreads = new List<CfbSpreads>();
-        var rankings = new List<Models.Data.CfbRanking>();
+        var rankings = new List<CfbRanking>();
 
         var scoreboard = await fetcher.FetchForSlateAsync(slate);
         if (scoreboard?.Events is not null) {
@@ -61,8 +62,8 @@ public class CfbSpreadJob(
 
     private async Task ProcessEventsForSpreads(
         List<CfbSpreads> spreads,
-        FourPlayWebApp.Server.Models.Data.CfbSlates slate,
-        IEnumerable<FourPlayWebApp.Shared.Models.Event> events) {
+        CfbSlates slate,
+        IEnumerable<Event> events) {
         var isCfp = CfbSlateHelpers.IsCfpSlate(slate.ScoringFormat);
 
         foreach (var evt in events) {

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -386,11 +386,28 @@ try
     using var scope = app.Services.CreateScope();
     var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
     var pending = db.Database.GetPendingMigrations().ToList();
-    if (pending.Count > 0)
-        Log.Information("Applying {Count} pending migration(s): {Names}", pending.Count, pending);
-    else
+
+    if (app.Environment.IsDevelopment()) {
+        // Local machine + demo stack: auto-apply for convenience, matches CLAUDE.md.
+        if (pending.Count > 0)
+            Log.Information("Applying {Count} pending migration(s): {Names}", pending.Count, pending);
+        else
+            Log.Information("Database is up to date, no migrations needed");
+        db.Database.Migrate();
+    } else if (pending.Count > 0) {
+        // Deployed environments (Railway dev/prod): migrations are applied by the "DB Migrate"
+        // GitHub Actions workflow (.github/workflows/migrate.yml) before this deploy is allowed
+        // to happen at all (Railway's checkSuites gate blocks the deploy on that job failing).
+        // Reaching pending migrations here means that gate was bypassed or the job never ran —
+        // fail loudly instead of silently serving traffic against a stale schema, which is
+        // exactly what happened silently for days before this check existed.
+        Log.Fatal("{Count} pending migration(s) not applied: {Names}. The DB Migrate workflow " +
+            "should have applied these before this deploy started — refusing to serve traffic " +
+            "against a stale schema.", pending.Count, pending);
+        throw new InvalidOperationException($"{pending.Count} pending migration(s) not applied: {string.Join(", ", pending)}");
+    } else {
         Log.Information("Database is up to date, no migrations needed");
-    db.Database.Migrate();
+    }
 }
 catch (Exception ex)
 {

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -33,32 +33,7 @@ var rawConnectionString = builder.Configuration.GetConnectionString("POSTGRES_CO
                           throw new InvalidOperationException("Connection string 'POSTGRES_CONNECTION_STRING' not found.");
 
 // Support both postgres:// URL format and Npgsql key=value format
-var connectionString = rawConnectionString.StartsWith("postgres://") || rawConnectionString.StartsWith("postgresql://")
-    ? ConvertPostgresUrl(rawConnectionString)
-    : rawConnectionString;
-
-static string ConvertPostgresUrl(string url)
-{
-    var uri = new Uri(url);
-    var userInfo = uri.UserInfo.Split(':');
-    var username = userInfo[0];
-    var password = userInfo.Length > 1 ? Uri.UnescapeDataString(userInfo[1]) : string.Empty;
-    var host = uri.Host;
-    var port = uri.Port > 0 ? uri.Port : 5432;
-    var database = uri.AbsolutePath.TrimStart('/');
-    var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
-    var sslMode = query["sslmode"] ?? "Prefer";
-    var npgsqlSsl = sslMode.ToLowerInvariant() switch {
-        "require"     => "Require",
-        "verify-ca"   => "VerifyCA",
-        "verify-full" => "VerifyFull",
-        "disable"     => "Disable",
-        _             => "Prefer"
-    };
-    // Only trust-cert for Require/Prefer — VerifyCA/VerifyFull must validate the chain
-    var trustCert = npgsqlSsl is "Require" or "Prefer" ? ";Trust Server Certificate=true" : string.Empty;
-    return $"Host={host};Port={port};Username={username};Password={password};Database={database};SSL Mode={npgsqlSsl}{trustCert}";
-}
+var connectionString = FourPlayWebApp.Server.Infrastructure.PostgresConnectionString.Normalize(rawConnectionString);
 builder.Services.AddOptions();
 builder.Services.AddControllersWithViews();
 #region Email

--- a/Server/Services/Repositories/LeagueRepository.cs
+++ b/Server/Services/Repositories/LeagueRepository.cs
@@ -120,14 +120,18 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
     // NFL Scores and Spreads methods
     public async Task UpsertAsync(IEnumerable<NflSpreads> spreads) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
+        var spreadList = spreads.ToList();
 
-        foreach (var spread in spreads) {
-            var existing = await db.NflSpreads.FirstOrDefaultAsync(s =>
-                s.Season == spread.Season &&
-                s.NflWeek == spread.NflWeek &&
-                s.HomeTeam == spread.HomeTeam);
+        // Batch the existing-row lookup into one query (mirrors CfbRepository.UpsertAsync) instead
+        // of a per-spread FirstOrDefaultAsync — avoids an N+1 round-trip on every spread fetch.
+        var seasons = spreadList.Select(s => s.Season).ToHashSet();
+        var weeks = spreadList.Select(s => s.NflWeek).ToHashSet();
+        var existingMap = await db.NflSpreads
+            .Where(s => seasons.Contains(s.Season) && weeks.Contains(s.NflWeek))
+            .ToDictionaryAsync(s => (s.Season, s.NflWeek, s.HomeTeam));
 
-            if (existing == null) {
+        foreach (var spread in spreadList) {
+            if (!existingMap.TryGetValue((spread.Season, spread.NflWeek, spread.HomeTeam), out var existing)) {
                 // Doesn't exist -> Insert new record
                 await db.NflSpreads.AddAsync(spread);
             }


### PR DESCRIPTION
## Summary
- Fixes `.github/workflows/migrate.yml`, which has failed on every run since May: the `NEON_PROD_CONNECTION_STRING`/`NEON_DEV_CONNECTION_STRING` secrets were never set, and `dotnet tool install --global dotnet-ef` conflicted with the repo's local tool manifest. Because Railway's `checkSuites` gate blocks deploys on a failing check run, this silently froze prod on a stale pre-#181 build for weeks — CFB kept working (its deploys never depended on this workflow succeeding), NFL/schema-dependent code did not.
- Adds `Server/Data/ApplicationDbContextFactory.cs` (`IDesignTimeDbContextFactory`) so `dotnet ef` can construct a `DbContext` from just a connection string, without booting the full app pipeline (JWT/email/CORS config) — the standard EF Core answer for top-level-statement `Program.cs` apps, and avoids a chicken-and-egg problem with the new fail-fast check below.
- `Server/Program.cs`: migrations are now applied by CI before a deploy is allowed to happen, not by the app itself. In `Development`, behavior is unchanged (auto-migrate on boot). In deployed environments, the app now fails loudly (`Log.Fatal` + throw) if it ever finds pending migrations at startup, instead of silently serving traffic against a stale schema — which is exactly what happened for weeks with the previous unconditional `Migrate()` call.
- Extracted `Server/Infrastructure/PostgresConnectionString.cs` (Neon `postgres://` → Npgsql key=value) out of `Program.cs`'s local function so both the real app and the new design-time factory share one implementation.
- Small `/simplify` pass on top: extracted a shared `TriggerSoonestSpreadJobAsync` helper for `JobManagerController`'s `RunSpreads`/`RunCfbSpreads` (previously near-duplicated), batched `LeagueRepository.UpsertAsync`'s existing-row lookup (N+1 → 1 query, mirroring `CfbRepository`'s pattern), skip already-final CFB slates in `CfbRankingCaptureJob` (guaranteed zero-yield ESPN calls), and reused the existing `toLocalDisplay` helper instead of ad-hoc `toLocaleString` calls in two components.

Verified end-to-end via `gh workflow run migrate.yml --ref chore/frizat-fix-migrate-workflow` against the real dev DB, and the 9 previously-pending migrations have already been applied directly to both dev and prod Postgres (Neon) to unblock right now while this PR lands.

## Test plan
- [x] `dotnet test` — 503/503 passing
- [x] `npm run test -- --run` — 269/269 passing
- [x] `npm run test:e2e -- --project=chromium` — 54/54 passing
- [x] `/simplify` run, fixes applied
- [x] `/code-review` run (8 finder angles + verify) — no confirmed bugs within this PR's actual diff; several confirmed bugs surfaced in already-merged `dev` code (PR #180's catch-up scheduler) are being reported separately as follow-up, not blocking this PR
- [x] `migrate.yml` verified working end-to-end via manual `workflow_dispatch` run against the real dev DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)