### PR TITLE
fix(rules): fix hard-to-see dot colors in dark mode

### DIFF
--- a/Client.React/src/pages/RulesPage.tsx
+++ b/Client.React/src/pages/RulesPage.tsx
@@ -50,7 +50,9 @@ function RuleRow({
           height: 24,
           borderRadius: '50%',
           bgcolor: `${color}.main`,
-          opacity: 0.15,
+          // A flat low opacity reads as a pale, visible dot on light backgrounds but nearly
+          // disappears against a dark card — bump it up specifically in dark mode.
+          opacity: (t) => (t.palette.mode === 'dark' ? 0.7 : 0.15),
           flexShrink: 0,
           mt: 0.25,
         }}


### PR DESCRIPTION
## Summary
\`RuleRow\`'s colored indicator dots used a flat \`opacity: 0.15\` regardless of theme mode — reads as a subtle pale dot on a light background, but nearly disappears against the dark card background in dark mode.

## Fix
Bumps opacity to 0.7 specifically in dark mode (theme-aware \`sx\` function, same pattern already used by \`InfoCallout\` in this file).

## Test plan
- [x] Visually confirmed against local demo stack — all 5 dot colors (blue/orange/red/green/amber) clearly visible in dark mode
- [x] \`npm run test -- --run\` — 272/272 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)