### PR TITLE
fix(nfl): fall back to NflCurrentWeekService, not calendar year, when live scores are empty

### DIFF
--- a/Client.React/src/__tests__/nflAdapter.test.ts
+++ b/Client.React/src/__tests__/nflAdapter.test.ts
@@ -12,11 +12,12 @@ vi.mock('../api/league', () => ({
   doOddsExist: vi.fn(),
   spreadBatch: vi.fn(),
   addPicks: vi.fn(),
+  getNflCurrentWeek: vi.fn(),
 }));
 vi.mock('../api/jersey', () => ({ getAllJerseys: vi.fn() }));
 
 import { loadScoresWithRetry } from '../api/espn';
-import { getUserPicks, doOddsExist, spreadBatch } from '../api/league';
+import { getUserPicks, doOddsExist, spreadBatch, getNflCurrentWeek } from '../api/league';
 import { createSpreadResponse } from '../test/fixtures';
 
 const adapter = createNflAdapter();
@@ -95,6 +96,40 @@ describe('nflAdapter', () => {
       vi.mocked(loadScoresWithRetry).mockResolvedValue(makeScores('KC', 'BUF'));
       const year = await adapter.currentSeasonYear();
       expect(typeof year).toBe('number');
+    });
+
+    // frizat: ESPN's live "current" scoreboard has nothing in progress (off-season, between
+    // slates, etc.) — must fall back to NflCurrentWeekService's real resolved season/week via
+    // getNflCurrentWeek, not `new Date().getFullYear()` (today's real calendar year, which has
+    // no seeded data at all). Uses a fresh adapter instance — getCurrentWeek() caches for the
+    // adapter's lifetime, so reusing the shared module-level `adapter` here would leak state
+    // into/from other tests in this file.
+    it('currentSeasonYear falls back to the resolved current week, not the real calendar year', async () => {
+      vi.mocked(loadScoresWithRetry).mockResolvedValue(null);
+      vi.mocked(getNflCurrentWeek).mockResolvedValue({
+        weekId: 18, espnWeek: 18, season: 2025, isPostSeason: false,
+        weekLabel: 'Week 18', scoringFormat: 'Standard', spreadLockDatetime: '2026-01-04T18:00:00Z',
+      });
+
+      const freshAdapter = createNflAdapter();
+      const year = await freshAdapter.currentSeasonYear();
+
+      expect(year).toBe(2025);
+      expect(year).not.toBe(new Date().getFullYear());
+    });
+
+    it('loadCurrentGames falls back to the resolved current week when live scores are empty', async () => {
+      vi.mocked(loadScoresWithRetry).mockResolvedValue(null);
+      vi.mocked(getNflCurrentWeek).mockResolvedValue({
+        weekId: 18, espnWeek: 18, season: 2025, isPostSeason: false,
+        weekLabel: 'Week 18', scoringFormat: 'Standard', spreadLockDatetime: '2026-01-04T18:00:00Z',
+      });
+
+      const freshAdapter = createNflAdapter();
+      const result = await freshAdapter.loadCurrentGames(1, 'user1');
+
+      expect(result.season).toBe(2025);
+      expect(result.week).toBe(18);
     });
   });
 });

--- a/Client.React/src/api/league.ts
+++ b/Client.React/src/api/league.ts
@@ -6,7 +6,7 @@ import type {
   BatchSpreadResponse,
   NflPickDto,
 } from '../types/picks';
-import type { LeagueUserMappingDto, NflWeekDto } from '../types/league';
+import type { LeagueUserMappingDto, NflWeekDto, NflCurrentWeekDto } from '../types/league';
 import type {
   LeagueInfoDto,
   LeagueJuiceMappingDto,
@@ -58,6 +58,11 @@ export async function leagueExists(leagueName: string, season?: number) {
 export async function getNflWeeks(season: number) {
   const { data } = await http.get<NflWeekDto[]>(`/api/league/weeks/${season}`);
   return data ?? [];
+}
+
+export async function getNflCurrentWeek() {
+  const { data } = await http.get<NflCurrentWeekDto>('/api/league/current-week');
+  return data;
 }
 
 export async function getLeagueByName(leagueName: string) {

--- a/Client.React/src/services/nflAdapter.ts
+++ b/Client.React/src/services/nflAdapter.ts
@@ -1,5 +1,5 @@
 import { loadScoresWithRetry, getWeekScores, getLiveGames } from '../api/espn';
-import { getUserPicks, doOddsExist, spreadBatch, addPicks, getLeaguePicks } from '../api/league';
+import { getUserPicks, doOddsExist, spreadBatch, addPicks, getLeaguePicks, getNflCurrentWeek } from '../api/league';
 import { getAllJerseys } from '../api/jersey';
 import type { Competition, Event } from '../types/espn';
 import type { NflPickDto, PickType, SpreadResponse } from '../types/picks';
@@ -105,6 +105,20 @@ async function buildSituationMap(events: Event[]): Promise<Map<string, import('.
 }
 
 export function createNflAdapter(): SportAdapter {
+  // undefined = not yet fetched; null = backend couldn't resolve one (e.g. no season configs seeded)
+  let cachedCurrentWeek: Awaited<ReturnType<typeof getNflCurrentWeek>> | null | undefined = undefined;
+
+  // NflCurrentWeekService (backing this) already has a real off-season/pre-season fallback (most
+  // recent completed week, or upcoming Week 1) — mirrors cfbAdapter.ts's getCurrentSlate(). Used
+  // as the fallback when ESPN's live "current" scoreboard has nothing in progress, instead of
+  // `new Date().getFullYear()` — today's real calendar year, not a season with any actual data.
+  async function getCurrentWeek() {
+    if (cachedCurrentWeek === undefined) {
+      cachedCurrentWeek = await getNflCurrentWeek().catch(() => null);
+    }
+    return cachedCurrentWeek;
+  }
+
   return {
     sport: 'nfl',
     pollIntervalMs: 300_000,
@@ -132,7 +146,9 @@ export function createNflAdapter(): SportAdapter {
 
     async currentSeasonYear() {
       const data = await loadScoresWithRetry();
-      return data?.season?.year ?? new Date().getFullYear();
+      if (data?.season?.year) return data.season.year;
+      const current = await getCurrentWeek();
+      return current?.season ?? new Date().getFullYear();
     },
 
     // ─── Picks ──────────────────────────────────────────────────────────────
@@ -140,7 +156,9 @@ export function createNflAdapter(): SportAdapter {
     async loadCurrentGames(leagueId, userId) {
       const data = await loadScoresWithRetry();
       if (!data?.season || !data.week) {
-        return { season: new Date().getFullYear(), week: 1, isPostSeason: false, games: [], userPicks: [], hasOdds: false, requiredPicks: 4, maxWeek: 1, maxSeason: new Date().getFullYear() };
+        const current = await getCurrentWeek();
+        const season = current?.season ?? new Date().getFullYear();
+        return { season, week: current?.espnWeek ?? 1, isPostSeason: current?.isPostSeason ?? false, games: [], userPicks: [], hasOdds: false, requiredPicks: 4, maxWeek: 1, maxSeason: season };
       }
       const postSeason = isPostSeasonHelper(data);
       const weekNum = data.week.number;
@@ -182,7 +200,9 @@ export function createNflAdapter(): SportAdapter {
     async loadCurrentScores(leagueId, userId) {
       const data = await loadScoresWithRetry();
       if (!data?.season || !data.week) {
-        return { season: new Date().getFullYear(), week: 1, isPostSeason: false, games: [], allPicks: [], userPicks: [], hasOdds: false, hasActiveGames: false, requiredPicks: 4, maxWeek: 1, maxSeason: new Date().getFullYear() };
+        const current = await getCurrentWeek();
+        const season = current?.season ?? new Date().getFullYear();
+        return { season, week: current?.espnWeek ?? 1, isPostSeason: current?.isPostSeason ?? false, games: [], allPicks: [], userPicks: [], hasOdds: false, hasActiveGames: false, requiredPicks: 4, maxWeek: 1, maxSeason: season };
       }
       const postSeason = isPostSeasonHelper(data);
       const weekNum = data.week.number;

--- a/Client.React/src/types/league.ts
+++ b/Client.React/src/types/league.ts
@@ -71,3 +71,15 @@ export interface NflWeekDto {
   endDate: string;
   dateCreated: string;
 }
+
+// GET /api/league/current-week — mirrors CfbSlateDto's role for NFL: the season/week to treat
+// as "current," resolved server-side with a real off-season/pre-season fallback (NflCurrentWeekService).
+export interface NflCurrentWeekDto {
+  weekId: number;
+  espnWeek: number;
+  season: number;
+  isPostSeason: boolean;
+  weekLabel: string;
+  scoringFormat: string;
+  spreadLockDatetime: string;
+}

--- a/Server.UnitTests/NflCurrentWeekEndpointTests.cs
+++ b/Server.UnitTests/NflCurrentWeekEndpointTests.cs
@@ -1,0 +1,79 @@
+using FourPlayWebApp.Server.Controllers;
+using FourPlayWebApp.Server.Models.Identity;
+using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Server.Services.Repositories.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+/// <summary>
+/// GET /api/league/current-week exposes NflCurrentWeekService (already used internally by
+/// NflSpreadJob/EspnCacheService, with a real off-season/pre-season fallback) to the frontend —
+/// mirrors CfbPicksController.GetCurrentSlate's shape/role for CFB. Fixes nflAdapter.ts falling
+/// back to `new Date().getFullYear()` (today's real calendar year, not a season with any data)
+/// whenever ESPN's live "current" scoreboard has nothing in progress.
+/// </summary>
+public class NflCurrentWeekEndpointTests
+{
+    private static LeagueController BuildController(INflCurrentWeekService svc)
+    {
+        var repo = Substitute.For<ILeagueRepository>();
+        var store = Substitute.For<IUserStore<ApplicationUser>>();
+        var userManager = Substitute.For<UserManager<ApplicationUser>>(
+            store, null, null, null, null, null, null, null, null);
+
+        var controller = new LeagueController(
+            new MemoryCache(new MemoryCacheOptions()),
+            repo,
+            NullLogger<LeagueController>.Instance,
+            userManager,
+            Substitute.For<ISpreadCalculatorBuilder>(),
+            Substitute.For<IEspnCacheService>(),
+            Substitute.For<IInvitationService>());
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = TestPrincipalFactory.Build("user-1") }
+        };
+        return controller;
+    }
+
+    [Fact]
+    public async Task GetCurrentWeek_ReturnsWeekInfo_FromNflCurrentWeekService()
+    {
+        var svc = Substitute.For<INflCurrentWeekService>();
+        var info = new NflWeekInfo(6, 6, 2026, false, "Week 6", "Standard", new DateTime(2026, 10, 8, 18, 0, 0, DateTimeKind.Utc));
+        svc.GetCurrentWeekAsync().Returns(info);
+
+        var result = await BuildController(svc).GetCurrentWeek(svc);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var returned = Assert.IsType<NflWeekInfo>(ok.Value);
+        Assert.Equal(2026, returned.Season);
+        Assert.Equal(6, returned.WeekId);
+        Assert.False(returned.IsPostSeason);
+    }
+
+    [Fact]
+    public async Task GetCurrentWeek_ReturnsOffSeasonFallback_NotCallersConcern()
+    {
+        // NflCurrentWeekService already resolves off-season/pre-season fallbacks internally
+        // (most recent completed week, or upcoming Week 1) — the controller just passes it through
+        // unconditionally rather than re-implementing any of that logic.
+        var svc = Substitute.For<INflCurrentWeekService>();
+        var info = new NflWeekInfo(18, 18, 2025, false, "Week 18", "Standard", new DateTime(2026, 1, 4, 18, 0, 0, DateTimeKind.Utc));
+        svc.GetCurrentWeekAsync().Returns(info);
+
+        var result = await BuildController(svc).GetCurrentWeek(svc);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var returned = Assert.IsType<NflWeekInfo>(ok.Value);
+        Assert.Equal(2025, returned.Season);
+        Assert.Equal(18, returned.WeekId);
+    }
+}

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -35,6 +35,14 @@ public class LeagueController(
     ISpreadCalculatorBuilder spreadCalculatorBuilder,
     IEspnCacheService espnCacheService,
     IInvitationService invitationService) : ControllerBase {
+    // Mirrors CfbPicksController.GetCurrentSlate's role for CFB — exposes NflCurrentWeekService's
+    // existing off-season/pre-season fallback (already used internally by NflSpreadJob and
+    // EspnCacheService) to the frontend, so nflAdapter.ts no longer falls back to
+    // `new Date().getFullYear()` whenever ESPN's live "current" scoreboard has nothing in progress.
+    [HttpGet("current-week")]
+    public async Task<IActionResult> GetCurrentWeek([FromServices] INflCurrentWeekService svc) =>
+        Ok(await svc.GetCurrentWeekAsync());
+
     // ---------- League Info ----------
     [HttpGet("{leagueId:int}")]
     [ProducesResponseType(typeof(LeagueInfoDto), StatusCodes.Status200OK)]


### PR DESCRIPTION
## Summary
- \`nflAdapter.ts\`'s \`currentSeasonYear\`/\`loadCurrentGames\`/\`loadCurrentScores\` fell back to \`new Date().getFullYear()\` whenever ESPN's live "current" scoreboard had nothing in progress — today's real calendar year, which has no seeded picks/scores/leaderboard data at all.
- CFB's equivalent (\`cfbAdapter.ts\`'s \`getCurrentSlate\`) already falls back through real backend logic (\`CfbCurrentSlateService\`) that finds the season that actually has data. NFL had the same well-built logic already (\`NflCurrentWeekService\`: most recent completed week, or upcoming Week 1) but it was only used internally by \`NflSpreadJob\`/\`EspnCacheService\`, never exposed to the frontend — so the frontend's fallback bypassed it entirely.
- This is the confirmed root cause of the "NFL leaderboard/scores show nothing, CFB works fine" asymmetry reported from live testing.

## Fix
- Adds \`GET /api/league/current-week\` (mirrors \`CfbPicksController.GetCurrentSlate\`'s role for CFB) backed by the existing \`INflCurrentWeekService\`.
- \`nflAdapter.ts\`'s three fallback branches now call it instead of defaulting to the calendar year.

## Test plan
- [x] New backend tests: \`NflCurrentWeekEndpointTests.cs\`
- [x] New frontend tests: \`nflAdapter.test.ts\` — falls back to resolved season/week, not calendar year
- [x] \`dotnet test\` — 505/505 passing
- [x] \`npm run test -- --run\` — 274/274 passing
- [x] \`npm run typecheck\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)