### PR TITLE
fix(demo): load ESPN fixtures as embedded resources, not a fragile relative path

### DIFF
--- a/Server.UnitTests/DemoCfbCacheServiceTests.cs
+++ b/Server.UnitTests/DemoCfbCacheServiceTests.cs
@@ -1,6 +1,4 @@
 using FourPlayWebApp.Server.Services;
-using Microsoft.AspNetCore.Hosting;
-using NSubstitute;
 using Xunit;
 
 namespace FourPlayWebApp.Server.UnitTests;
@@ -10,28 +8,18 @@ namespace FourPlayWebApp.Server.UnitTests;
 /// CFB Championship game (event 401800011, IU vs MIA), the same way DemoEspnCacheService serves
 /// sample_espn_nfl.json for NFL — not the always-null stub it was after CFB_DEMO_SITUATION was
 /// ripped out in PR #163.
+///
+/// No IWebHostEnvironment/working-directory setup needed here (unlike before) — the fixture is
+/// an embedded resource, not a loose file resolved via a relative path off ContentRootPath. That
+/// prior approach only worked locally by coincidence and silently returned null on Railway,
+/// where ContentRootPath points at the deployed app's own directory.
 /// </summary>
 public class DemoCfbCacheServiceTests
 {
-    // sample_espn_cfb.json lives at the repo root, alongside sample_espn_nfl.json — walk up from
-    // the test binary's output dir to find it, then point ContentRootPath one level below so
-    // DemoCfbCacheService's Path.Combine(ContentRootPath, "..", "sample_espn_cfb.json") resolves.
-    private static IWebHostEnvironment BuildEnvPointingAtRepoRoot()
-    {
-        var dir = AppContext.BaseDirectory;
-        while (dir is not null && !File.Exists(Path.Combine(dir, "sample_espn_cfb.json")))
-            dir = Path.GetDirectoryName(dir);
-        Assert.NotNull(dir); // fixture must exist at repo root
-
-        var env = Substitute.For<IWebHostEnvironment>();
-        env.ContentRootPath.Returns(Path.Combine(dir!, "Server"));
-        return env;
-    }
-
     [Fact]
     public async Task GetScoresAsync_ReturnsRealSituationData_ForChampionshipGame()
     {
-        var service = new DemoCfbCacheService(BuildEnvPointingAtRepoRoot());
+        var service = new DemoCfbCacheService();
 
         var scores = await service.GetScoresAsync();
 
@@ -46,7 +34,7 @@ public class DemoCfbCacheServiceTests
     [Fact]
     public async Task GetScoresAsync_ReturnsRealScoreAndTeams_ForChampionshipGame()
     {
-        var service = new DemoCfbCacheService(BuildEnvPointingAtRepoRoot());
+        var service = new DemoCfbCacheService();
 
         var scores = await service.GetScoresAsync();
 

--- a/Server.UnitTests/DemoEspnCacheServiceTests.cs
+++ b/Server.UnitTests/DemoEspnCacheServiceTests.cs
@@ -2,7 +2,6 @@ using FourPlayWebApp.Server.Data;
 using FourPlayWebApp.Server.Services;
 using FourPlayWebApp.Shared.Models;
 using FourPlayWebApp.Shared.Models.Data;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 using Xunit;
@@ -30,15 +29,26 @@ public class DemoEspnCacheServiceTests
         return factory;
     }
 
-    private static IWebHostEnvironment BuildFakeEnv()
+    // ── GetScoresAsync (fixture-backed) ─────────────────────────────────────
+
+    // frizat: regression test for the fixture silently failing to load on Railway.
+    // DemoFixtureLoader used to resolve sample_espn_nfl.json via
+    // Path.Combine(env.ContentRootPath, "..", fileName) — only correct locally by coincidence
+    // (dotnet run from Server/ puts the repo root one level up); on Railway, ContentRootPath is
+    // the deployed app's own directory, so ".." resolved to nothing and the fixture silently
+    // never loaded. No IWebHostEnvironment/working-directory setup needed here at all now — the
+    // fixture is an embedded resource, found by assembly-relative logical name regardless of
+    // where or how the process is actually running.
+    [Fact]
+    public async Task GetScoresAsync_LoadsFixture_RegardlessOfWorkingDirectoryOrContentRoot()
     {
-        var env = Substitute.For<IWebHostEnvironment>();
-        env.EnvironmentName.Returns("Development");
-        // Deliberately points nowhere — DemoFixtureLoader logs a warning and returns null when
-        // the fixture file doesn't exist, which is fine since these tests only exercise
-        // GetWeekScoresAsync (DB-backed), not GetScoresAsync (fixture-backed).
-        env.ContentRootPath.Returns("/nonexistent");
-        return env;
+        var sut = new DemoEspnCacheService(BuildFactory(BuildDb(nameof(GetScoresAsync_LoadsFixture_RegardlessOfWorkingDirectoryOrContentRoot))));
+
+        var scores = await sut.GetScoresAsync();
+
+        Assert.NotNull(scores);
+        Assert.NotNull(scores!.Events);
+        Assert.NotEmpty(scores.Events!);
     }
 
     // ── GetWeekScoresAsync ───────────────────────────────────────────────────
@@ -78,7 +88,7 @@ public class DemoEspnCacheServiceTests
         });
         await db.SaveChangesAsync();
 
-        var sut = new DemoEspnCacheService(BuildFakeEnv(), BuildFactory(db));
+        var sut = new DemoEspnCacheService(BuildFactory(db));
 
         var result = await sut.GetWeekScoresAsync(1, 2025, postSeason: true);
 
@@ -119,7 +129,7 @@ public class DemoEspnCacheServiceTests
         });
         await db.SaveChangesAsync();
 
-        var sut = new DemoEspnCacheService(BuildFakeEnv(), BuildFactory(db));
+        var sut = new DemoEspnCacheService(BuildFactory(db));
 
         // Week 5, regular season — nothing seeded for that combo.
         var result = await sut.GetWeekScoresAsync(5, 2025, postSeason: false);

--- a/Server/FourPlayWebApp.Server.csproj
+++ b/Server/FourPlayWebApp.Server.csproj
@@ -39,6 +39,19 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
 
+  <!-- DEMO_MODE fixtures live at the repo root, one level above this project. Embedded as
+       resources (not copy-to-output) so DemoFixtureLoader can find them by assembly-relative
+       logical name regardless of ContentRootPath or working directory; copy-to-output would
+       still break on Railway, where the deployed ContentRootPath differs from the local layout. -->
+  <ItemGroup>
+    <EmbeddedResource Include="..\sample_espn_nfl.json"><LogicalName>sample_espn_nfl.json</LogicalName></EmbeddedResource>
+    <EmbeddedResource Include="..\sample_espn_nfl_final.json"><LogicalName>sample_espn_nfl_final.json</LogicalName></EmbeddedResource>
+    <EmbeddedResource Include="..\sample_espn_nfl_halftime.json"><LogicalName>sample_espn_nfl_halftime.json</LogicalName></EmbeddedResource>
+    <EmbeddedResource Include="..\sample_espn_nfl_scheduled.json"><LogicalName>sample_espn_nfl_scheduled.json</LogicalName></EmbeddedResource>
+    <EmbeddedResource Include="..\sample_espn_nfl_in_progress.json"><LogicalName>sample_espn_nfl_in_progress.json</LogicalName></EmbeddedResource>
+    <EmbeddedResource Include="..\sample_espn_cfb.json"><LogicalName>sample_espn_cfb.json</LogicalName></EmbeddedResource>
+  </ItemGroup>
+
   <ItemGroup>
     <_ContentIncludedByDefault Remove="Areas\Identity\Pages\Account\Login.cshtml" />
     <_ContentIncludedByDefault Remove="Areas\Identity\Pages\Account\Manage\ChangePassword.cshtml" />

--- a/Server/Services/DemoCfbCacheService.cs
+++ b/Server/Services/DemoCfbCacheService.cs
@@ -6,15 +6,17 @@ namespace FourPlayWebApp.Server.Services;
 /// <summary>
 /// Demo-only implementation of ICfbCacheService that serves frozen ESPN data (including real
 /// down/distance/field-position) from sample_espn_cfb.json — mirrors DemoEspnCacheService's role
-/// for NFL. Only registered when DEMO_MODE=true. Never used in dev or prod.
+/// for NFL. Only registered when DEMO_MODE=true (the Railway "development" environment included —
+/// DEMO_MODE is an app-config flag, not tied to any particular environment name). Real (non-demo)
+/// prod never registers this class at all.
 /// </summary>
 public class DemoCfbCacheService : ICfbCacheService
 {
     private readonly EspnScores? _scores;
 
-    public DemoCfbCacheService(IWebHostEnvironment env)
+    public DemoCfbCacheService()
     {
-        _scores = DemoFixtureLoader.Load(env, "sample_espn_cfb.json");
+        _scores = DemoFixtureLoader.Load("sample_espn_cfb.json");
     }
 
     public event Action? ScoresChanged; // never fired — demo data is static

--- a/Server/Services/DemoEspnCacheService.cs
+++ b/Server/Services/DemoEspnCacheService.cs
@@ -8,18 +8,19 @@ namespace FourPlayWebApp.Server.Services;
 
 /// <summary>
 /// Demo-only implementation of IEspnCacheService that serves frozen ESPN data
-/// from sample_espn_nfl.json. Only registered when DEMO_MODE=true.
-/// Never used in dev or prod.
+/// from sample_espn_nfl.json. Only registered when DEMO_MODE=true (the Railway "development"
+/// environment included — DEMO_MODE is an app-config flag, not tied to any particular
+/// environment name). Real (non-demo) prod never registers this class at all.
 /// </summary>
 public class DemoEspnCacheService : IEspnCacheService
 {
     private readonly EspnScores? _scores;
     private readonly IDbContextFactory<ApplicationDbContext> _dbContextFactory;
 
-    public DemoEspnCacheService(IWebHostEnvironment env, IDbContextFactory<ApplicationDbContext> dbContextFactory)
+    public DemoEspnCacheService(IDbContextFactory<ApplicationDbContext> dbContextFactory)
     {
         _dbContextFactory = dbContextFactory;
-        _scores = DemoFixtureLoader.Load(env, "sample_espn_nfl.json", json =>
+        _scores = DemoFixtureLoader.Load("sample_espn_nfl.json", json =>
         {
             foreach (var map in NflTeamMappingHelpers.NflTeamAbbrMapping)
                 json = json.Replace($"\"{map.Key}\"", $"\"{map.Value}\"");

--- a/Server/Services/DemoFixtureLoader.cs
+++ b/Server/Services/DemoFixtureLoader.cs
@@ -5,22 +5,31 @@ using Serilog;
 namespace FourPlayWebApp.Server.Services;
 
 /// <summary>
-/// Shared "read a captured ESPN fixture from the repo root" logic for the demo-mode cache
-/// services (DemoEspnCacheService, DemoCfbCacheService) — kept as one implementation per
-/// CLAUDE.md's rule against hand-synced NFL/CFB forks, which has repeatedly drifted into bugs.
+/// Shared "read a captured ESPN fixture" logic for the demo-mode cache services
+/// (DemoEspnCacheService, DemoCfbCacheService) — kept as one implementation per CLAUDE.md's rule
+/// against hand-synced NFL/CFB forks, which has repeatedly drifted into bugs.
+///
+/// Fixtures are embedded resources (see FourPlayWebApp.Server.csproj), not loose files read via
+/// IWebHostEnvironment.ContentRootPath — a prior Path.Combine(ContentRootPath, "..", fileName)
+/// version only worked by coincidence locally (running `dotnet run` from Server/ puts the repo
+/// root exactly one level up); on Railway, ContentRootPath is the deployed app's own directory
+/// (e.g. /app), so ".." resolved to the container filesystem root and silently found nothing —
+/// DEMO_MODE's "live in-progress game" scenario (and, on NFL, the postseason weeks that only
+/// exist in this fixture) quietly never worked once deployed.
 /// </summary>
 internal static class DemoFixtureLoader
 {
-    public static EspnScores? Load(IWebHostEnvironment env, string fileName, Func<string, string>? transformJson = null)
+    public static EspnScores? Load(string fileName, Func<string, string>? transformJson = null)
     {
-        var path = Path.Combine(env.ContentRootPath, "..", fileName);
-        if (!File.Exists(path))
+        using var stream = typeof(DemoFixtureLoader).Assembly.GetManifestResourceStream(fileName);
+        if (stream is null)
         {
-            Log.Warning("DEMO_MODE: {FileName} not found at {Path}", fileName, path);
+            Log.Warning("DEMO_MODE: {FileName} not found as an embedded resource", fileName);
             return null;
         }
 
-        var json = File.ReadAllText(path);
+        using var reader = new StreamReader(stream);
+        var json = reader.ReadToEnd();
         if (transformJson is not null) json = transformJson(json);
         var scores = JsonSerializer.Deserialize<EspnScores>(json, EspnApiServiceJsonConverter.Settings);
         Log.Information("DEMO_MODE: Loaded {Count} events from {FileName}", scores?.Events?.Length ?? 0, fileName);


### PR DESCRIPTION
## Summary
- \`DemoFixtureLoader\` resolved \`sample_espn_*.json\` via \`Path.Combine(env.ContentRootPath, "..", fileName)\` — only correct locally by coincidence (running \`dotnet run\` from \`Server/\` happens to put the repo root exactly one level up). On Railway, \`ContentRootPath\` is the deployed app's own directory (e.g. \`/app\`), so \`".."\` resolved to the container filesystem root and silently found nothing — every Railway-hosted \`DEMO_MODE\` environment has been serving null from this fixture, always, undetected.
- Confirmed via live testing on dev: the demo "current" NFL/CFB scoreboard (backing the Scores page, and the postseason weeks that only exist in this fixture) never actually worked there — silently fell through to empty state. Distinct from (and downstream of) the season/week resolution bug fixed in #195.

## Fix
- Fixtures are now embedded resources (\`Server.csproj\`, explicit \`LogicalName\`), read via \`Assembly.GetManifestResourceStream\` — correct regardless of \`ContentRootPath\`, working directory, or deployment layout.
- \`DemoEspnCacheService\`/\`DemoCfbCacheService\` no longer need an \`IWebHostEnvironment\` dependency at all.

## Test plan
- [x] Rewrote \`DemoCfbCacheServiceTests\`/\`DemoEspnCacheServiceTests\` — no more artificial \`ContentRootPath\` setup needed
- [x] New regression test: \`GetScoresAsync_LoadsFixture_RegardlessOfWorkingDirectoryOrContentRoot\`
- [x] \`dotnet test\` — 506/506 passing
- [x] \`npm run test -- --run\` — 274/274 passing
- [x] **Verified against a real running local backend** (not just unit tests): fresh request logs \`DEMO_MODE: Loaded 1 events from sample_espn_nfl.json\` / \`sample_espn_cfb.json\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)