### PR TITLE
fix(build): copy DEMO_MODE fixture JSONs into the Docker build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN dotnet restore Server/FourPlayWebApp.Server.csproj
 # Copy source and publish
 COPY Shared/ Shared/
 COPY Server/ Server/
+# DEMO_MODE fixtures embedded by Server.csproj (EmbeddedResource Include="..\sample_espn_*.json")
+# live at the repo root, one level above Server/ -- must be copied into the build context here too.
+COPY sample_espn_nfl.json sample_espn_nfl_final.json sample_espn_nfl_halftime.json \
+    sample_espn_nfl_scheduled.json sample_espn_nfl_in_progress.json sample_espn_cfb.json ./
 RUN dotnet publish Server/FourPlayWebApp.Server.csproj \
     -c Release \
     -o /app/publish \


### PR DESCRIPTION
## Summary
PR #196 made \`DemoFixtureLoader\` read \`sample_espn_*.json\` as embedded resources, fixing the fixtures silently failing to load at runtime on Railway. But the Dockerfile only ever \`COPY\`s \`Shared/\` and \`Server/\` into the build context — never the repo-root fixture files — so the embedded-resource *build* itself now fails:

\`\`\`
CSC : error CS1566: Error reading resource 'sample_espn_nfl.json' -- 'Could not find file '/src/sample_espn_nfl.json'.'
\`\`\`

This actually broke dev's Railway deployment (confirmed via the failed deployment's build logs) — #196 merged clean on GitHub Actions (whose CI does a plain \`dotnet build\`/\`dotnet test\` from the repo root, where the fixture files are already present) but failed on Railway's Docker build specifically, which only copies the two subdirectories.

## Fix
Add the same fixture files to the Dockerfile's \`COPY\` step, alongside \`Shared/\`/\`Server/\`.

## Test plan
- [x] Local Docker build (\`docker build --pull --no-cache\`) — confirmed the fixture COPY step succeeds and the exact \`CS1566\` error is gone
- [ ] Railway dev deployment succeeds (verify after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)