### PR TITLE
fix(admin): hide out-of-scope rows from CFB Schedule Config page

### DIFF
--- a/Client.React/src/__tests__/CfbSchedulePage.test.tsx
+++ b/Client.React/src/__tests__/CfbSchedulePage.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import CfbSchedulePage from '../pages/admin/CfbSchedulePage';
+import type { CfbSeasonWeekConfigDto } from '../types/admin';
+
+vi.mock('../api/cfb', () => ({ getCfbWeekConfigs: vi.fn() }));
+import { getCfbWeekConfigs } from '../api/cfb';
+
+const mockedGetCfbWeekConfigs = vi.mocked(getCfbWeekConfigs);
+
+function makeConfig(overrides: Partial<CfbSeasonWeekConfigDto> = {}): CfbSeasonWeekConfigDto {
+  return {
+    espnWeekNumber: 1,
+    ivLeagueWeekNumber: 1,
+    weekType: 'Regular Season',
+    scoringFormat: 'Standard',
+    inScopeIvLeague: true,
+    weekStartDate: '2026-09-01',
+    weekEndDate: '2026-09-07',
+    notes: null,
+    ...overrides,
+  };
+}
+
+// frizat: the out-of-scope sentinel rows (IvLeagueWeekNumber = 99 — ESPN weeks with no
+// corresponding pick'em slate, e.g. Week 0 openers, bye/dead weeks) are real, deliberate data the
+// backend needs, but they're internal scheduling detail, not something an admin needs to see —
+// confusing noise on this page, not a bug in the underlying data.
+describe('CfbSchedulePage', () => {
+  it('hides out-of-scope rows', async () => {
+    mockedGetCfbWeekConfigs.mockResolvedValue([
+      makeConfig({ espnWeekNumber: 0, ivLeagueWeekNumber: 99, inScopeIvLeague: false, notes: 'Thu 8/27 openers + Sat 8/29 slate' }),
+      makeConfig({ espnWeekNumber: 3, ivLeagueWeekNumber: 3, inScopeIvLeague: true }),
+    ]);
+
+    render(<CfbSchedulePage />);
+
+    await waitFor(() => expect(screen.getAllByText('3')).toHaveLength(2));
+    expect(screen.queryByText('99')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Thu 8\/27 openers/i)).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state when every row for the season is out of scope', async () => {
+    mockedGetCfbWeekConfigs.mockResolvedValue([
+      makeConfig({ espnWeekNumber: 0, ivLeagueWeekNumber: 99, inScopeIvLeague: false }),
+    ]);
+
+    render(<CfbSchedulePage />);
+
+    await waitFor(() => expect(screen.getByText(/no week configs found/i)).toBeInTheDocument());
+  });
+});

--- a/Client.React/src/pages/admin/CfbSchedulePage.tsx
+++ b/Client.React/src/pages/admin/CfbSchedulePage.tsx
@@ -11,7 +11,6 @@ import {
   TableCell,
   TableHead,
   TableRow,
-  Chip,
   Typography,
 } from '@mui/material';
 import PageHeader from '../../components/PageHeader';
@@ -25,6 +24,10 @@ export default function CfbSchedulePage() {
   const [season, setSeason] = useState(CURRENT_SEASON);
   const [configs, setConfigs] = useState<CfbSeasonWeekConfigDto[]>([]);
   const [loading, setLoading] = useState(false);
+  // Out-of-scope rows (e.g. ESPN Week 0 openers, bye/dead weeks) are a real, deliberate exclusion
+  // marker the app needs to know which games have no pick'em slate — but they're internal
+  // scheduling detail, not something an admin needs to see here.
+  const inScopeConfigs = configs.filter((c) => c.inScopeIvLeague);
 
   useEffect(() => {
     setLoading(true);
@@ -59,21 +62,20 @@ export default function CfbSchedulePage() {
                 <TableCell>Scoring Format</TableCell>
                 <TableCell>Start Date</TableCell>
                 <TableCell>End Date</TableCell>
-                <TableCell>In Scope</TableCell>
                 <TableCell>Notes</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
-              {configs.length === 0 && (
+              {inScopeConfigs.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={8}>
+                  <TableCell colSpan={7}>
                     <Typography color="text.secondary" variant="body2">
                       No week configs found for {season}
                     </Typography>
                   </TableCell>
                 </TableRow>
               )}
-              {configs.map((c) => (
+              {inScopeConfigs.map((c) => (
                 <TableRow key={c.espnWeekNumber}>
                   <TableCell>{c.espnWeekNumber}</TableCell>
                   <TableCell>{c.ivLeagueWeekNumber}</TableCell>
@@ -81,13 +83,6 @@ export default function CfbSchedulePage() {
                   <TableCell>{c.scoringFormat}</TableCell>
                   <TableCell>{c.weekStartDate}</TableCell>
                   <TableCell>{c.weekEndDate}</TableCell>
-                  <TableCell>
-                    <Chip
-                      label={c.inScopeIvLeague ? 'Yes' : 'No'}
-                      color={c.inScopeIvLeague ? 'success' : 'default'}
-                      size="small"
-                    />
-                  </TableCell>
                   <TableCell>{c.notes ?? '—'}</TableCell>
                 </TableRow>
               ))}


### PR DESCRIPTION
## Summary
Rows like \`IvLeagueWeekNumber=99\` (ESPN Week 0 openers, bye/dead weeks) are a real, deliberate exclusion marker the backend needs — they tell the app which ESPN weeks have no corresponding pick'em slate. But they're internal scheduling detail, not something an admin needs to see, and read as confusing noise on this page (\`99\` in the "IV Slate #" column with no context).

## Fix
- Filter to \`inScopeIvLeague === true\` rows only.
- Drop the "In Scope" column — redundant once every displayed row is in scope by definition.

## Test plan
- [x] New tests: \`CfbSchedulePage.test.tsx\` — hides out-of-scope rows, shows empty state when every row for a season is out of scope
- [x] \`npm run test -- --run\` — 276/276 passing
- [x] \`npm run test:e2e -- --project=chromium\` — 54/54 passing
- [x] \`npm run typecheck\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)