### PR TITLE
feat(rules): show the full spread-lock schedule, sport-scoped, on Rules page

### DIFF
--- a/Client.React/src/__tests__/RulesPage.test.tsx
+++ b/Client.React/src/__tests__/RulesPage.test.tsx
@@ -2,15 +2,22 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 import { useSportContext } from '../services/sport';
-import { getNextSpreadJob } from '../services/spreadRelease';
+import { getNflSpreadLockSchedule } from '../api/league';
+import { getCfbSpreadLockSchedule } from '../api/cfb';
 import RulesPage from '../pages/RulesPage';
 
 vi.mock('../services/sport', () => ({
   useSportContext: vi.fn(() => ({ sport: 'NFL', isCfb: false, isNfl: true })),
 }));
 
-vi.mock('../services/spreadRelease', () => ({
-  getNextSpreadJob: vi.fn().mockResolvedValue(null),
+vi.mock('../api/league', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../api/league')>()),
+  getNflSpreadLockSchedule: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../api/cfb', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../api/cfb')>()),
+  getCfbSpreadLockSchedule: vi.fn().mockResolvedValue([]),
 }));
 
 function renderPage() {
@@ -153,50 +160,69 @@ describe('RulesPage — CFB playoff grid', () => {
 
 describe('RulesPage — spread lock section', () => {
   beforeEach(() => {
-    vi.mocked(getNextSpreadJob).mockReset();
+    vi.mocked(getNflSpreadLockSchedule).mockReset().mockResolvedValue([]);
+    vi.mocked(getCfbSpreadLockSchedule).mockReset().mockResolvedValue([]);
   });
 
   it('shows the "When spreads lock" section', () => {
     vi.mocked(useSportContext).mockReturnValue({ sport: 'NFL', isCfb: false, isNfl: true });
-    vi.mocked(getNextSpreadJob).mockResolvedValue(null);
     renderPage();
     expect(screen.getByText(/when spreads lock/i)).toBeInTheDocument();
   });
 
   it('explains the distinction between spread lock and pick lock', () => {
     vi.mocked(useSportContext).mockReturnValue({ sport: 'NFL', isCfb: false, isNfl: true });
-    vi.mocked(getNextSpreadJob).mockResolvedValue(null);
     renderPage();
     expect(screen.getByText(/freezes once for the whole week/i)).toBeInTheDocument();
   });
 
-  it('calls getNextSpreadJob with NFL for the NFL site', () => {
+  it('fetches the NFL schedule, not CFB, on the NFL site', () => {
     vi.mocked(useSportContext).mockReturnValue({ sport: 'NFL', isCfb: false, isNfl: true });
-    vi.mocked(getNextSpreadJob).mockResolvedValue(null);
     renderPage();
-    expect(getNextSpreadJob).toHaveBeenCalledWith('NFL');
+    expect(getNflSpreadLockSchedule).toHaveBeenCalled();
+    expect(getCfbSpreadLockSchedule).not.toHaveBeenCalled();
   });
 
-  it('calls getNextSpreadJob with CFB for the CFB site', () => {
+  it('fetches the CFB schedule, not NFL, on the CFB site', () => {
     vi.mocked(useSportContext).mockReturnValue({ sport: 'CFB', isCfb: true, isNfl: false });
-    vi.mocked(getNextSpreadJob).mockResolvedValue(null);
     renderPage();
-    expect(getNextSpreadJob).toHaveBeenCalledWith('CFB');
+    expect(getCfbSpreadLockSchedule).toHaveBeenCalled();
+    expect(getNflSpreadLockSchedule).not.toHaveBeenCalled();
   });
 
-  it('shows the next lock time once loaded', async () => {
+  it('shows every week with its lock time once loaded', async () => {
     vi.mocked(useSportContext).mockReturnValue({ sport: 'NFL', isCfb: false, isNfl: true });
-    vi.mocked(getNextSpreadJob).mockResolvedValue('2026-09-09T14:20:00Z');
+    vi.mocked(getNflSpreadLockSchedule).mockResolvedValue([
+      { weekLabel: 'Week 1', spreadLockDatetime: '2026-09-02T14:20:00Z' },
+      { weekLabel: 'Week 2', spreadLockDatetime: '2026-09-09T14:20:00Z' },
+    ]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByText(/next lock:/i)).toBeInTheDocument();
+      expect(screen.getByText('Week 1')).toBeInTheDocument();
+      expect(screen.getByText('Week 2')).toBeInTheDocument();
     });
   });
 
-  it('does not show "Next lock" text before the fetch resolves', () => {
+  it('does not render the schedule section before the fetch resolves', () => {
     vi.mocked(useSportContext).mockReturnValue({ sport: 'NFL', isCfb: false, isNfl: true });
-    vi.mocked(getNextSpreadJob).mockReturnValue(new Promise(() => {})); // never resolves
+    vi.mocked(getNflSpreadLockSchedule).mockReturnValue(new Promise(() => {})); // never resolves
     renderPage();
-    expect(screen.queryByText(/next lock:/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('Week 1')).not.toBeInTheDocument();
+  });
+
+  it('highlights the soonest week that has not locked yet', async () => {
+    vi.mocked(useSportContext).mockReturnValue({ sport: 'NFL', isCfb: false, isNfl: true });
+    vi.mocked(getNflSpreadLockSchedule).mockResolvedValue([
+      { weekLabel: 'Past Week', spreadLockDatetime: '2020-01-01T00:00:00Z' },
+      { weekLabel: 'Upcoming Week', spreadLockDatetime: '2099-01-01T00:00:00Z' },
+    ]);
+    renderPage();
+
+    const upcoming = await screen.findByText('Upcoming Week');
+    const past = screen.getByText('Past Week');
+    // MUI applies fontWeight via inline style on the Typography — 600 for the highlighted row,
+    // 400 for every other row.
+    expect(upcoming).toHaveStyle({ fontWeight: 600 });
+    expect(past).toHaveStyle({ fontWeight: 400 });
   });
 });

--- a/Client.React/src/api/cfb.ts
+++ b/Client.React/src/api/cfb.ts
@@ -1,4 +1,4 @@
-import type { CfbPickDto, CfbScoreDto, CfbSlateDto, CfbSpreadDto } from '../types/league';
+import type { CfbPickDto, CfbScoreDto, CfbSlateDto, CfbSpreadDto, SpreadLockWeekDto } from '../types/league';
 import type { CfbSeasonWeekConfigDto } from '../types/admin';
 
 const BASE = '/api/cfb';
@@ -6,6 +6,12 @@ const BASE = '/api/cfb';
 export async function getCfbCurrentSlate(): Promise<CfbSlateDto | null> {
   const res = await fetch(`${BASE}/current-slate`);
   if (!res.ok) return null;
+  return res.json();
+}
+
+export async function getCfbSpreadLockSchedule(): Promise<SpreadLockWeekDto[]> {
+  const res = await fetch(`${BASE}/spread-lock-schedule`);
+  if (!res.ok) return [];
   return res.json();
 }
 

--- a/Client.React/src/api/league.ts
+++ b/Client.React/src/api/league.ts
@@ -6,7 +6,7 @@ import type {
   BatchSpreadResponse,
   NflPickDto,
 } from '../types/picks';
-import type { LeagueUserMappingDto, NflWeekDto, NflCurrentWeekDto } from '../types/league';
+import type { LeagueUserMappingDto, NflWeekDto, NflCurrentWeekDto, SpreadLockWeekDto } from '../types/league';
 import type {
   LeagueInfoDto,
   LeagueJuiceMappingDto,
@@ -63,6 +63,11 @@ export async function getNflWeeks(season: number) {
 export async function getNflCurrentWeek() {
   const { data } = await http.get<NflCurrentWeekDto>('/api/league/current-week');
   return data;
+}
+
+export async function getNflSpreadLockSchedule() {
+  const { data } = await http.get<SpreadLockWeekDto[]>('/api/league/spread-lock-schedule');
+  return data ?? [];
 }
 
 export async function getLeagueByName(leagueName: string) {

--- a/Client.React/src/pages/RulesPage.tsx
+++ b/Client.React/src/pages/RulesPage.tsx
@@ -12,7 +12,9 @@ import {
 } from '@mui/material';
 import { getEspnRequiredPicks, getCfbRequiredPicks } from '../utils/gameHelpers';
 import { useSportContext } from '../services/sport';
-import { getNextSpreadJob } from '../services/spreadRelease';
+import { getNflSpreadLockSchedule } from '../api/league';
+import { getCfbSpreadLockSchedule } from '../api/cfb';
+import type { SpreadLockWeekDto } from '../types/league';
 import { toLocalDisplay } from '../utils/time';
 import PageHeader from '../components/PageHeader';
 
@@ -296,21 +298,64 @@ function formatLockTime(iso: string) {
   });
 }
 
-function SpreadLockInfo({ sport }: { sport: 'NFL' | 'CFB' }) {
-  // undefined = not loaded yet; null = loaded, no upcoming lock; string = ISO timestamp.
-  const [nextLock, setNextLock] = useState<string | null | undefined>(undefined);
+// Sport-scoped — NFL page shows only NFL lock times, CFB page shows only CFB's, never both at
+// once (matches every other sport-agnostic view in this app).
+function SpreadLockSchedule({ isCfb }: { isCfb: boolean }) {
+  // undefined = not loaded yet.
+  const [weeks, setWeeks] = useState<SpreadLockWeekDto[] | undefined>(undefined);
+  // Snapshotted once per mount (lazy initializer) rather than read during render — "upcoming"
+  // only needs to be roughly right for this page, not live-ticking.
+  const [now] = useState(() => Date.now());
 
   useEffect(() => {
     let cancelled = false;
-    setNextLock(undefined);
-    void getNextSpreadJob(sport).then((result) => {
-      if (!cancelled) setNextLock(result);
+    setWeeks(undefined);
+    const load = isCfb ? getCfbSpreadLockSchedule : getNflSpreadLockSchedule;
+    void load().then((result) => {
+      if (!cancelled) setWeeks(result);
     });
     return () => {
       cancelled = true;
     };
-  }, [sport]);
+  }, [isCfb]);
 
+  if (!weeks || weeks.length === 0) return null;
+
+  // Soonest week whose spread hasn't locked yet — the one to highlight as "upcoming."
+  const upcomingIndex = weeks.findIndex((w) => new Date(w.spreadLockDatetime).getTime() > now);
+
+  return (
+    <Paper variant="outlined" sx={{ borderRadius: 2, overflow: 'hidden', mt: 1.5, maxHeight: 320, overflowY: 'auto' }}>
+      {weeks.map((w, i) => (
+        <Box
+          key={w.weekLabel}
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            gap: 2,
+            px: 2,
+            py: 1,
+            bgcolor: i === upcomingIndex ? 'action.selected' : 'transparent',
+            '&:not(:last-child)': { borderBottom: '1px solid', borderColor: 'divider' },
+          }}
+        >
+          <Typography variant="body2" fontWeight={i === upcomingIndex ? 600 : 400}>
+            {w.weekLabel}
+          </Typography>
+          <Typography
+            variant="body2"
+            color={i === upcomingIndex ? 'text.primary' : 'text.secondary'}
+            fontWeight={i === upcomingIndex ? 600 : 400}
+          >
+            {formatLockTime(w.spreadLockDatetime)}
+          </Typography>
+        </Box>
+      ))}
+    </Paper>
+  );
+}
+
+function SpreadLockInfo({ isCfb }: { isCfb: boolean }) {
   return (
     <Box>
       <SectionLabel>When spreads lock</SectionLabel>
@@ -318,12 +363,6 @@ function SpreadLockInfo({ sport }: { sport: 'NFL' | 'CFB' }) {
         <RuleRow color="secondary">
           The teased line for each week freezes once, at a set time before that week&apos;s first
           game — it won&apos;t move again after that.
-          {nextLock != null && (
-            <>
-              {' '}
-              Next lock: <strong>{formatLockTime(nextLock)}</strong>.
-            </>
-          )}
         </RuleRow>
         <RuleRow color="info">
           This is different from when your <strong>picks</strong> lock, below. The spread freezes
@@ -331,6 +370,7 @@ function SpreadLockInfo({ sport }: { sport: 'NFL' | 'CFB' }) {
           game kicks off.
         </RuleRow>
       </Paper>
+      <SpreadLockSchedule isCfb={isCfb} />
     </Box>
   );
 }
@@ -419,7 +459,7 @@ export function RulesContent() {
       <Divider />
 
       {/* When Spreads Lock */}
-      <SpreadLockInfo sport={isCfb ? 'CFB' : 'NFL'} />
+      <SpreadLockInfo isCfb={isCfb} />
 
       <Divider />
 

--- a/Client.React/src/types/league.ts
+++ b/Client.React/src/types/league.ts
@@ -83,3 +83,11 @@ export interface NflCurrentWeekDto {
   scoringFormat: string;
   spreadLockDatetime: string;
 }
+
+// GET /api/league/spread-lock-schedule (NFL) / /api/cfb/spread-lock-schedule (CFB) — Rules page:
+// the full current season's spread-lock schedule, one row per in-scope week, shared shape for
+// both sports.
+export interface SpreadLockWeekDto {
+  weekLabel: string;
+  spreadLockDatetime: string;
+}

--- a/Server.UnitTests/SpreadLockScheduleEndpointTests.cs
+++ b/Server.UnitTests/SpreadLockScheduleEndpointTests.cs
@@ -1,0 +1,120 @@
+using FourPlayWebApp.Server.Controllers;
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Models.Identity;
+using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Server.Services.Repositories.Interfaces;
+using FourPlayWebApp.Shared.Models.Data.Dtos;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+/// <summary>
+/// Rules page needs the full season's spread-lock schedule, sport-scoped, for every logged-in
+/// user (not just admins) -- both endpoints resolve "current season" the same way the existing
+/// current-week/current-slate endpoints do, then return every in-scope week's lock time for that
+/// season, so the frontend doesn't need a separate round-trip just to learn which season to ask
+/// for.
+/// </summary>
+public class SpreadLockScheduleEndpointTests
+{
+    // ── NFL: LeagueController.GetSpreadLockSchedule ─────────────────────────
+
+    private static LeagueController BuildLeagueController(ILeagueRepository repo)
+    {
+        var store = Substitute.For<IUserStore<ApplicationUser>>();
+        var userManager = Substitute.For<UserManager<ApplicationUser>>(
+            store, null, null, null, null, null, null, null, null);
+
+        var controller = new LeagueController(
+            new MemoryCache(new MemoryCacheOptions()),
+            repo,
+            NullLogger<LeagueController>.Instance,
+            userManager,
+            Substitute.For<ISpreadCalculatorBuilder>(),
+            Substitute.For<IEspnCacheService>(),
+            Substitute.For<IInvitationService>());
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = TestPrincipalFactory.Build("user-1") }
+        };
+        return controller;
+    }
+
+    [Fact]
+    public async Task Nfl_GetSpreadLockSchedule_ReturnsOnlyCurrentSeasonsWeeks_OrderedByWeek()
+    {
+        var repo = Substitute.For<ILeagueRepository>();
+        var svc = Substitute.For<INflCurrentWeekService>();
+        svc.GetCurrentWeekAsync().Returns(new NflWeekInfo(3, 3, 2026, false, "Week 3", "Standard", DateTime.UtcNow));
+        repo.GetNflSeasonWeekConfigsAsync().Returns([
+            new NflSeasonWeekConfig { Season = 2026, WeekId = 2, WeekLabel = "Week 2", SpreadLockDatetime = new DateTime(2026, 9, 10, 18, 0, 0, DateTimeKind.Utc) },
+            new NflSeasonWeekConfig { Season = 2026, WeekId = 1, WeekLabel = "Week 1", SpreadLockDatetime = new DateTime(2026, 9, 3, 18, 0, 0, DateTimeKind.Utc) },
+            new NflSeasonWeekConfig { Season = 2025, WeekId = 1, WeekLabel = "Week 1", SpreadLockDatetime = new DateTime(2025, 9, 4, 18, 0, 0, DateTimeKind.Utc) },
+        ]);
+
+        var result = await BuildLeagueController(repo).GetSpreadLockSchedule(svc);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var weeks = Assert.IsAssignableFrom<IEnumerable<SpreadLockWeekDto>>(ok.Value).ToList();
+        Assert.Equal(2, weeks.Count);
+        Assert.Equal("Week 1", weeks[0].WeekLabel);
+        Assert.Equal("Week 2", weeks[1].WeekLabel);
+    }
+
+    // ── CFB: CfbPicksController.GetSpreadLockSchedule ───────────────────────
+
+    private static CfbPicksController BuildCfbController(ICfbRepository cfbRepo)
+    {
+        var repo = Substitute.For<ICfbPicksRepository>();
+        var leagueRepo = Substitute.For<ILeagueRepository>();
+        return new CfbPicksController(repo, cfbRepo, leagueRepo);
+    }
+
+    private static CfbSeasonWeekConfig MakeConfig(int ivWeek, string weekType, DateTime lock_, bool inScope = true) => new() {
+        Season = 2026, EspnWeekNumber = ivWeek, IvLeagueWeekNumber = ivWeek,
+        WeekType = weekType, ScoringFormat = "Standard", InScopeIvLeague = inScope,
+        SpreadLockDatetime = lock_,
+    };
+
+    [Fact]
+    public async Task Cfb_GetSpreadLockSchedule_ReturnsOnlyInScopeWeeks_OrderedByWeek()
+    {
+        var cfbRepo = Substitute.For<ICfbRepository>();
+        var svc = Substitute.For<ICfbCurrentSlateService>();
+        svc.GetCurrentSlateAsync().Returns(new CfbSlateInfo(
+            1, 2026, 1, "Week 1", "RegularSeason", new DateOnly(2026, 9, 1), new DateOnly(2026, 9, 7), null, DateTime.UtcNow));
+        cfbRepo.GetWeekConfigsForSeasonAsync(2026).Returns([
+            MakeConfig(0, "Regular Season", new DateTime(2026, 8, 27, 12, 0, 0, DateTimeKind.Utc), inScope: false),
+            MakeConfig(2, "Regular Season", new DateTime(2026, 9, 10, 13, 0, 0, DateTimeKind.Utc)),
+            MakeConfig(1, "Regular Season", new DateTime(2026, 9, 3, 12, 0, 0, DateTimeKind.Utc)),
+        ]);
+
+        var result = await BuildCfbController(cfbRepo).GetSpreadLockSchedule(svc);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var weeks = Assert.IsAssignableFrom<IEnumerable<SpreadLockWeekDto>>(ok.Value).ToList();
+        Assert.Equal(2, weeks.Count);
+        Assert.Equal("Week 1", weeks[0].WeekLabel);
+        Assert.Equal("Week 2", weeks[1].WeekLabel);
+    }
+
+    [Fact]
+    public async Task Cfb_GetSpreadLockSchedule_ReturnsEmpty_WhenNoCurrentSlateResolved()
+    {
+        var cfbRepo = Substitute.For<ICfbRepository>();
+        var svc = Substitute.For<ICfbCurrentSlateService>();
+        svc.GetCurrentSlateAsync().Returns((CfbSlateInfo?)null);
+
+        var result = await BuildCfbController(cfbRepo).GetSpreadLockSchedule(svc);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var weeks = Assert.IsAssignableFrom<IEnumerable<SpreadLockWeekDto>>(ok.Value);
+        Assert.Empty(weeks);
+    }
+}

--- a/Server/Controllers/CfbPicksController.cs
+++ b/Server/Controllers/CfbPicksController.cs
@@ -1,4 +1,5 @@
 using FourPlayWebApp.Server.Auth;
+using FourPlayWebApp.Server.Jobs;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Helpers;
@@ -19,6 +20,23 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
     public async Task<IActionResult> GetCurrentSlate([FromServices] ICfbCurrentSlateService svc) {
         var slate = await svc.GetCurrentSlateAsync();
         return slate is null ? NotFound() : Ok(slate);
+    }
+
+    // Rules page: the full current season's spread-lock schedule, every in-scope week — mirrors
+    // LeagueController.GetSpreadLockSchedule's role for NFL. Resolves "current season" via the
+    // same service GetCurrentSlate uses, so the frontend doesn't need a separate round-trip just
+    // to learn which season to ask for.
+    [HttpGet("spread-lock-schedule")]
+    public async Task<IActionResult> GetSpreadLockSchedule([FromServices] ICfbCurrentSlateService currentSlateService) {
+        var current = await currentSlateService.GetCurrentSlateAsync();
+        if (current is null) return Ok(Array.Empty<SpreadLockWeekDto>());
+
+        var configs = await cfbRepo.GetWeekConfigsForSeasonAsync(current.Season);
+        var schedule = configs
+            .Where(c => c.InScopeIvLeague)
+            .OrderBy(c => c.IvLeagueWeekNumber)
+            .Select(c => new SpreadLockWeekDto(CfbWeekLabelHelper.LabelFromConfig(c), c.SpreadLockDatetime));
+        return Ok(schedule);
     }
 
     [HttpGet("slates/{season}")]

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -43,6 +43,20 @@ public class LeagueController(
     public async Task<IActionResult> GetCurrentWeek([FromServices] INflCurrentWeekService svc) =>
         Ok(await svc.GetCurrentWeekAsync());
 
+    // Rules page: the full current season's spread-lock schedule, every week — resolves "current
+    // season" the same way GetCurrentWeek does, so the frontend doesn't need a separate round-trip
+    // just to learn which season to ask for.
+    [HttpGet("spread-lock-schedule")]
+    public async Task<IActionResult> GetSpreadLockSchedule([FromServices] INflCurrentWeekService currentWeekService) {
+        var current = await currentWeekService.GetCurrentWeekAsync();
+        var configs = await repo.GetNflSeasonWeekConfigsAsync();
+        var schedule = configs
+            .Where(c => c.Season == current.Season)
+            .OrderBy(c => c.WeekId)
+            .Select(c => new SpreadLockWeekDto(c.WeekLabel, c.SpreadLockDatetime));
+        return Ok(schedule);
+    }
+
     // ---------- League Info ----------
     [HttpGet("{leagueId:int}")]
     [ProducesResponseType(typeof(LeagueInfoDto), StatusCodes.Status200OK)]

--- a/Shared/Models/Data/Dtos/SpreadLockWeekDto.cs
+++ b/Shared/Models/Data/Dtos/SpreadLockWeekDto.cs
@@ -1,0 +1,5 @@
+namespace FourPlayWebApp.Shared.Models.Data.Dtos;
+
+// One row of a sport's full-season spread-lock schedule (Rules page) — shared shape for both
+// NFL and CFB, each sport's controller maps its own config entity into this.
+public record SpreadLockWeekDto(string WeekLabel, DateTime SpreadLockDatetime);


### PR DESCRIPTION
## Summary
Replaces the single "Next lock: <date>" line on the Rules page with a full per-week table showing every week's lock time for the current season — the soonest week that hasn't locked yet is highlighted. Sport-scoped like every other view in this app: NFL site shows only NFL lock times, CFB only CFB's, never both at once.

This replaces the earlier ask for a spread-lock-time view on the CFB Schedule admin page — that page turned out to be an internal ESPN-week mapping table, not what was actually wanted. This puts real lock-time visibility somewhere every logged-in user can see it, for both sports.

## Backend
- \`GET /api/league/spread-lock-schedule\` (NFL) and \`GET /api/cfb/spread-lock-schedule\` (CFB) — both resolve "current season" the same way the existing \`current-week\`/\`current-slate\` endpoints do (\`NflCurrentWeekService\` / \`ICfbCurrentSlateService\`), so the frontend doesn't need a separate round-trip just to learn which season to ask for.
- CFB filters to in-scope weeks only, reusing \`CfbWeekLabelHelper\` for labels.

## Test plan
- [x] New backend tests: \`SpreadLockScheduleEndpointTests.cs\`
- [x] Rewrote \`RulesPage.test.tsx\`'s spread-lock section tests for the new schedule table (sport-scoped fetch, renders every week, highlights the upcoming one)
- [x] \`dotnet test\` — 509/509 passing
- [x] \`npm run test -- --run\` — 277/277 passing
- [x] \`npm run test:e2e -- --project=chromium\` — 54/54 passing
- [x] \`npm run typecheck\` / \`npm run lint\` — clean
- [x] Verified visually against local demo stack, both NFL and CFB — schedule renders correctly, upcoming week bold/highlighted, sport-scoped (CFB shows CFB dates, NFL shows NFL dates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)