### PR TITLE
ci(build): add a real Docker build check to catch Railway-only failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Backend/frontend jobs below run `dotnet build`/`npm run build` directly from the repo root,
+  # which never exercises the Dockerfile's own COPY/build-context rules -- so a change that's
+  # only wrong from the Docker build's point of view (e.g. a file referenced by a project file
+  # that the Dockerfile never copies into its build context) passes every other check here and
+  # only fails once Railway actually builds and deploys it. Confirmed the hard way: PR #196 added
+  # an EmbeddedResource the Dockerfile didn't COPY, passed this whole workflow, then failed on
+  # Railway. This job runs the exact same `docker build` Railway does, so that class of failure
+  # shows up as a normal PR check instead of a live deploy failure.
+  docker-build:
+    name: Docker build (Railway parity)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image
+        run: docker build -f Dockerfile .
+
   backend:
     name: Backend build & test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Every existing backend/frontend CI job runs \`dotnet build\`/\`npm run build\` directly from the repo root — never through the Dockerfile Railway actually uses to build/deploy. So a change that's only wrong from Docker's point of view passes every check here and only fails once Railway builds and deploys it live.

Confirmed the hard way today: PR #196 added an \`EmbeddedResource\` the Dockerfile didn't \`COPY\` into its build context, passed this entire workflow, then failed on Railway with \`Could not find file '/src/sample_espn_nfl.json'\` — a live deploy failure instead of a normal PR check.

## Fix
New \`docker-build\` job that runs the exact same \`docker build -f Dockerfile .\` Railway does.

## Test plan
- [x] Confirmed locally that \`docker build -f Dockerfile .\` succeeds against the current repo state

🤖 Generated with [Claude Code](https://claude.com/claude-code)