### PR TITLE
fix(ui): pick-button colors, dark-mode contrast, sport-blindness on home/dashboard/rules

### DIFF
--- a/Client.React/e2e/dashboardStandings.spec.ts
+++ b/Client.React/e2e/dashboardStandings.spec.ts
@@ -19,11 +19,13 @@ test.describe('Dashboard standings (authenticated /dashboard)', () => {
     await expect(standings.getByText('+150')).toBeVisible();
   });
 
-  test('shows nothing when the user has no leaderboard entry yet (empty state)', async ({ page }) => {
+  test('shows an explicit empty state, not a blank panel, when the user has no leaderboard entry yet', async ({ page }) => {
     await mockAuth(page, { authUser: TEST_USER, navigateTo: '/dashboard', leaderboard: [] });
     await waitForSpinner(page);
 
     await expect(page.getByRole('heading', { name: /welcome back/i })).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByTestId('dashboard-standings')).not.toBeVisible();
+    const standings = page.getByTestId('dashboard-standings');
+    await expect(standings).toBeVisible();
+    await expect(standings.getByText(/no nfl results yet this season/i)).toBeVisible();
   });
 });

--- a/Client.React/src/__tests__/DashboardStandings.test.tsx
+++ b/Client.React/src/__tests__/DashboardStandings.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { vi } from 'vitest';
 import DashboardStandings from '../components/DashboardStandings';
@@ -13,6 +13,7 @@ const sessionState = {
 
 vi.mock('../services/session', () => ({ useSession: () => sessionState }));
 vi.mock('../services/auth', () => ({ useAuth: () => ({ user: { userId: 'user-1', name: 'Alice', claims: [] } }) }));
+vi.mock('../services/sport', () => ({ useSportContext: () => ({ isCfb: false, isNfl: true, sport: 'NFL' }) }));
 
 vi.mock('../api/leaderboard', () => ({ getLeaderboard: vi.fn() }));
 import { getLeaderboard } from '../api/leaderboard';
@@ -51,10 +52,10 @@ describe('DashboardStandings', () => {
     sessionState.leaguesLoaded = true;
   });
 
-  it('renders nothing when the user has no leagues', async () => {
+  it('shows an empty state (not a blank panel) when the user has no leagues in this sport', async () => {
     sessionState.availableLeagues = [];
-    const { container } = renderWithClient();
-    await waitFor(() => expect(container).toBeEmptyDOMElement());
+    renderWithClient();
+    await screen.findByText(/not in any NFL leagues yet/i);
   });
 
   it('shows per-league rank and total, plus a summed grand total', async () => {

--- a/Client.React/src/__tests__/GameCard.test.tsx
+++ b/Client.React/src/__tests__/GameCard.test.tsx
@@ -133,6 +133,25 @@ describe('GameCard', () => {
     expect(btn).toBeDisabled();
   });
 
+  // frizat: MUI's disabled state flattens every contained button to the same uniform gray
+  // regardless of `color`, erasing the picked/not-picked distinction the instant a game locks —
+  // the most common state once a week is underway. A locked "Picked" button should stay a filled
+  // success (green) button, not fall back to MUI's default disabled gray class.
+  it('a locked "Picked" button keeps its filled success styling, not the default disabled gray', () => {
+    render(<GameCard {...baseProps} homePickState="submitted" />);
+    const btn = screen.getByRole('button', { name: /KC locked in/i });
+    expect(btn).toHaveClass('MuiButton-contained', 'MuiButton-containedSuccess');
+  });
+
+  // A locked, never-picked button reads as an outlined warning button — visually distinct from
+  // the filled "Picked" button without the two competing as adjacent solid color blocks.
+  it('a locked, never-picked button keeps its outlined warning styling, not the default disabled gray', () => {
+    render(<GameCard {...baseProps} awayPickState="none" locked />);
+    const btn = screen.getByRole('button', { name: /^Pick BUF$/i });
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveClass('MuiButton-outlined', 'MuiButton-outlinedWarning');
+  });
+
   it('unpicked away team button has aria-label "Pick BUF"', () => {
     render(<GameCard {...baseProps} awayPickState="none" />);
     expect(screen.getByRole('button', { name: /^Pick BUF$/i })).toBeInTheDocument();

--- a/Client.React/src/__tests__/HomePage.test.tsx
+++ b/Client.React/src/__tests__/HomePage.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import { useSportContext } from '../services/sport';
+import HomePage from '../pages/HomePage';
+
+vi.mock('../services/sport', () => ({
+  useSportContext: vi.fn(() => ({ sport: 'NFL', isCfb: false, isNfl: true })),
+}));
+
+vi.mock('../services/auth', () => ({
+  useAuth: () => ({ user: null }),
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <HomePage />
+    </MemoryRouter>,
+  );
+}
+
+describe('HomePage — sport indicator', () => {
+  // frizat: unauthenticated visitors had no way to tell which sport a given subdomain (ivleague
+  // vs cfb.ivleague) was for — the hero copy was hardcoded to NFL regardless of hostname.
+  it('shows an "NFL" badge on the NFL site', () => {
+    vi.mocked(useSportContext).mockReturnValue({ sport: 'NFL', isCfb: false, isNfl: true });
+    renderPage();
+    expect(screen.getByText('NFL')).toBeInTheDocument();
+    expect(screen.queryByText('College Football')).not.toBeInTheDocument();
+  });
+
+  it('shows a "College Football" badge on the CFB site', () => {
+    vi.mocked(useSportContext).mockReturnValue({ sport: 'CFB', isCfb: true, isNfl: false });
+    renderPage();
+    expect(screen.getByText('College Football')).toBeInTheDocument();
+    expect(screen.queryByText(/^NFL$/)).not.toBeInTheDocument();
+  });
+});

--- a/Client.React/src/__tests__/UserPicksMatrix.test.tsx
+++ b/Client.React/src/__tests__/UserPicksMatrix.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import UserPicksMatrix from '../components/UserPicksMatrix';
+import type { NflPickDto } from '../types/picks';
+
+vi.mock('../components/sports/TeamHelmet', () => ({
+  default: ({ abbr }: { abbr: string }) => <div data-testid={`helmet-${abbr}`}>{abbr}</div>,
+}));
+
+const picks: NflPickDto[] = [
+  { id: 1, userId: 'u1', userName: 'alice', team: 'KC', pick: 'Spread', season: 2025, nflWeek: 1, leagueId: 1, dateCreated: '2025-09-01T00:00:00Z' },
+];
+
+function renderMatrix(mode: 'light' | 'dark') {
+  return render(
+    <ThemeProvider theme={createTheme({ palette: { mode } })}>
+      <UserPicksMatrix users={['alice']} picks={picks} spreads={{}} requiredPicks={1} />
+    </ThemeProvider>,
+  );
+}
+
+describe('UserPicksMatrix — dark mode cell coloring', () => {
+  // frizat: TeamHelmet's dark-mode logos are neon assets meant to glow against a dark
+  // background (see TeamHelmet.tsx); the matrix cell used a hardcoded light gray in every mode,
+  // washing the helmet out. The cell background must actually change with the theme.
+  it('uses a dark neutral cell background in dark mode, not the light-mode gray', () => {
+    const { getByTestId } = renderMatrix('dark');
+    const cell = getByTestId('helmet-KC').parentElement;
+    expect(cell).toHaveStyle({ backgroundColor: 'rgb(66, 66, 66)' }); // MUI grey.800
+  });
+
+  it('keeps the light neutral cell background in light mode', () => {
+    const { getByTestId } = renderMatrix('light');
+    const cell = getByTestId('helmet-KC').parentElement;
+    expect(cell).toHaveStyle({ backgroundColor: 'rgb(238, 238, 238)' }); // MUI grey.200
+  });
+});

--- a/Client.React/src/app/theme.ts
+++ b/Client.React/src/app/theme.ts
@@ -24,12 +24,16 @@ export function createAppTheme(mode: 'light' | 'dark') {
       light: '#60a5fa',
     },
     success: {
-      main: '#10b981', // Emerald green for positive actions
+      // Emerald-500 pops against the dark navy background; on white it's too pale to read
+      // comfortably as text/border, so light mode uses the darker emerald-700 instead.
+      main: isDark ? '#10b981' : '#047857',
       light: '#34d399',
       contrastText: '#FFFFFF',
     },
     warning: {
-      main: '#f59e0b', // Amber for caution
+      // Same story as success — amber-500 reads fine on dark navy but has poor contrast as
+      // text/border on a white background, so light mode uses the darker amber-700.
+      main: isDark ? '#f59e0b' : '#b45309',
       light: '#fbbf24',
     },
     error: {

--- a/Client.React/src/components/DashboardStandings.tsx
+++ b/Client.React/src/components/DashboardStandings.tsx
@@ -2,6 +2,7 @@ import { Box, Paper, Stack, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useSession } from '../services/session';
 import { useAuth } from '../services/auth';
+import { useSportContext } from '../services/sport';
 import { getLeaderboard } from '../api/leaderboard';
 import type { SportAdapter } from '../services/sportAdapter';
 
@@ -30,6 +31,7 @@ interface DashboardStandingsProps {
 export default function DashboardStandings({ adapter }: DashboardStandingsProps) {
   const { availableLeagues, leaguesLoaded } = useSession();
   const { user } = useAuth();
+  const { isCfb } = useSportContext();
 
   const { data: standings } = useQuery({
     queryKey: [adapter.sport, 'dashboard-standings', availableLeagues.map(l => l.leagueId), user?.userId],
@@ -47,7 +49,39 @@ export default function DashboardStandings({ adapter }: DashboardStandingsProps)
     staleTime: 60_000,
   });
 
-  if (!leaguesLoaded || availableLeagues.length === 0 || !standings || standings.length === 0) return null;
+  // Still resolving session/auth state — avoid flashing an empty state before we know whether
+  // the user has leagues in this sport.
+  if (!leaguesLoaded || !user?.userId) return null;
+
+  const sportLabel = isCfb ? 'CFB' : 'NFL';
+
+  // A user can genuinely have leagues in one sport and none in the other (e.g. NFL-only or
+  // CFB-only membership) — show that explicitly instead of silently rendering nothing, so the
+  // dashboard doesn't look structurally different (or broken) between subdomains for the same
+  // account.
+  if (availableLeagues.length === 0) {
+    return (
+      <Paper data-testid="dashboard-standings" elevation={3} sx={{ p: 3, borderRadius: 2 }}>
+        <Typography variant="h6" fontWeight={700} sx={{ mb: 1 }}>Your Standings</Typography>
+        <Typography variant="body2" color="text.secondary">
+          You're not in any {sportLabel} leagues yet. Ask your commissioner for an invite.
+        </Typography>
+      </Paper>
+    );
+  }
+
+  if (!standings) return null; // leaderboard query still in flight
+
+  if (standings.length === 0) {
+    return (
+      <Paper data-testid="dashboard-standings" elevation={3} sx={{ p: 3, borderRadius: 2 }}>
+        <Typography variant="h6" fontWeight={700} sx={{ mb: 1 }}>Your Standings</Typography>
+        <Typography variant="body2" color="text.secondary">
+          No {sportLabel} results yet this season.
+        </Typography>
+      </Paper>
+    );
+  }
 
   const grandTotal = standings.reduce((sum, s) => sum + s.total, 0);
 

--- a/Client.React/src/components/UserPicksMatrix.tsx
+++ b/Client.React/src/components/UserPicksMatrix.tsx
@@ -6,6 +6,7 @@ import {
   TableHead,
   TableRow,
   Typography,
+  useTheme,
 } from '@mui/material';
 import ArrowCircleUpIcon from '@mui/icons-material/ArrowCircleUp';
 import ArrowCircleDownIcon from '@mui/icons-material/ArrowCircleDown';
@@ -22,6 +23,7 @@ interface UserPicksMatrixProps {
 }
 
 export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }: UserPicksMatrixProps) {
+  const isDark = useTheme().palette.mode === 'dark';
   const getUserPicks = (user: string) => picks.filter((p) => p.userName === user);
 
   const getWinner = (teamAbbr: string, pickType: NflPickDto['pick']) => {
@@ -61,7 +63,14 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
                     );
                   }
                   const result = getWinner(pick.team, pick.pick);
-                  const bgColor = result === true ? 'success.light' : result === false ? 'error.light' : 'grey.200';
+                  // TeamHelmet's dark-mode logos are neon assets designed to glow against a dark
+                  // background (see TeamHelmet.tsx) — the light literal tones below washed them
+                  // out in dark mode, so pick each cell's tone from the active theme instead.
+                  const bgColor = result === true
+                    ? (isDark ? 'success.dark' : 'success.light')
+                    : result === false
+                      ? (isDark ? 'error.dark' : 'error.light')
+                      : (isDark ? 'grey.800' : 'grey.200');
 
                   return (
                     <TableCell key={idx} align="center">

--- a/Client.React/src/components/sports/GameCard.tsx
+++ b/Client.React/src/components/sports/GameCard.tsx
@@ -95,15 +95,51 @@ export default function GameCard({
 
   const pickButtonSx = { minWidth: 80, height: 44, textTransform: 'none', fontSize: '0.85rem', flexShrink: 0 } as const;
 
+  // MUI's `disabled` state flattens contained (filled) buttons to uniform gray regardless of
+  // `color`. Keep the real color at reduced opacity instead of falling back to generic gray.
+  const lockedFillSx = (color: 'success' | 'warning') => ({
+    '&.Mui-disabled': {
+      color: `${color}.contrastText`,
+      backgroundColor: `${color}.main`,
+      opacity: 0.6,
+    },
+  });
+  // Same idea for outlined buttons: keep the tinted border/text instead of MUI's disabled gray.
+  const lockedOutlineSx = (color: 'success' | 'warning') => ({
+    '&.Mui-disabled': {
+      color: `${color}.main`,
+      borderColor: `${color}.main`,
+      opacity: 0.6,
+    },
+  });
+
   const renderPickButton = (team: string, pickState: PickState, onPick?: () => void) => {
     if (pickState === 'submitted')
       // aria-label stays "locked in" for accessible-name test/query stability — only the visible
       // label changed (matches the pending-state "Picked" text; disabled + checkmark still
       // distinguish submitted from pending for sighted users).
-      return <Button color="success" variant="contained" disabled startIcon={<CheckIcon />} aria-label={`${team} locked in`} sx={pickButtonSx}>Picked</Button>;
+      return <Button color="success" variant="contained" disabled startIcon={<CheckIcon />} aria-label={`${team} locked in`} sx={[pickButtonSx, lockedFillSx('success')]}>Picked</Button>;
     if (pickState !== 'none')
       return <Button color="success" variant="contained" onClick={onPick} aria-label={`${team} picked`} sx={pickButtonSx}>Picked</Button>;
-    return <Button color="warning" variant="contained" disabled={locked} onClick={onPick} aria-label={`Pick ${team}`} sx={pickButtonSx}>Pick</Button>;
+    // Outlined, not filled — an unpicked option shouldn't compete visually with a filled "Picked"
+    // button; two solid color blocks side by side read as "both selected," not "pick one."
+    return <Button color="warning" variant="outlined" disabled={locked} onClick={onPick} aria-label={`Pick ${team}`} sx={[pickButtonSx, lockedOutlineSx('warning')]}>Pick</Button>;
+  };
+
+  const renderOverUnderButton = (label: string, value: number, pickState: PickState, onPick?: () => void) => {
+    const picked = pickState !== 'none';
+    const color = picked ? 'success' : 'warning';
+    return (
+      <Button
+        variant={picked ? 'contained' : 'outlined'}
+        color={color}
+        sx={[pickButtonSx, picked ? lockedFillSx(color) : lockedOutlineSx(color)]}
+        disabled={overUnderLocked && !picked}
+        onClick={onPick}
+      >
+        {picked ? `${label} ${value} ✓` : label}
+      </Button>
+    );
   };
 
   const renderTeamLogo = (abbr: string, jerseyUrl: string | undefined) => (
@@ -202,27 +238,11 @@ export default function GameCard({
           >
             <CardContent sx={{ p: '12px !important' }}>
               <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ gap: 1 }}>
-                <Button
-                  variant="contained"
-                  color={overPickState !== 'none' ? 'success' : 'warning'}
-                  sx={pickButtonSx}
-                  disabled={overUnderLocked && overPickState === 'none'}
-                  onClick={onPickOver}
-                >
-                  {overPickState !== 'none' ? `Over ${overValue} ✓` : 'Over'}
-                </Button>
+                {renderOverUnderButton('Over', overValue, overPickState, onPickOver)}
                 <Typography variant="h6" className="fixed-width" sx={{ textAlign: 'center', flexShrink: 0 }}>
                   {overValue}
                 </Typography>
-                <Button
-                  variant="contained"
-                  color={underPickState !== 'none' ? 'success' : 'warning'}
-                  sx={pickButtonSx}
-                  disabled={overUnderLocked && underPickState === 'none'}
-                  onClick={onPickUnder}
-                >
-                  {underPickState !== 'none' ? `Under ${underValue} ✓` : 'Under'}
-                </Button>
+                {renderOverUnderButton('Under', underValue, underPickState, onPickUnder)}
               </Stack>
             </CardContent>
           </Card>

--- a/Client.React/src/pages/HomePage.tsx
+++ b/Client.React/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Container, Dialog, DialogContent, DialogTitle, Grid, IconButton, Paper, Stack, Typography } from '@mui/material';
+import { Box, Button, Chip, Container, Dialog, DialogContent, DialogTitle, Grid, IconButton, Paper, Stack, Typography } from '@mui/material';
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
 import SportsTennisIcon from '@mui/icons-material/SportsTennis';
@@ -10,6 +10,7 @@ import VolumeUpIcon from '@mui/icons-material/VolumeUp';
 import { Link as RouterLink } from 'react-router-dom';
 import { useRef, useState } from 'react';
 import { useAuth } from '../services/auth';
+import { useSportContext } from '../services/sport';
 import { RulesContent } from './RulesPage';
 import DashboardStandings from '../components/DashboardStandings';
 import OwnerCostSummary from '../components/OwnerCostSummary';
@@ -47,6 +48,7 @@ interface HomePageProps {
 
 export default function HomePage({ adapter }: HomePageProps) {
   const { user } = useAuth();
+  const { isCfb } = useSportContext();
   const isAuthed = Boolean(user);
   const videoRef = useRef<HTMLVideoElement>(null);
   const [muted, setMuted] = useState(true);
@@ -79,13 +81,19 @@ export default function HomePage({ adapter }: HomePageProps) {
                 <img src="/Images/retro_logo.png" alt="IV League Logo" className="hero-logo-img" />
               </Box>
               <Box className="hero-text-inner">
+                <Chip
+                  label={isCfb ? 'College Football' : 'NFL'}
+                  color="secondary"
+                  size="small"
+                  sx={{ fontWeight: 700, letterSpacing: '0.04em', mb: 1.5 }}
+                />
                 <Typography variant="h2" className="hero-title">
                   {isAuthed ? 'Welcome Back.' : 'Skip the Draft.\nMake Picks.\nBeat Your Friends.'}
                 </Typography>
                 <Typography variant="h6" className="hero-subtitle">
                   {isAuthed
                     ? 'Your picks are waiting. Check the leaderboard and see where you stand.'
-                    : "IV League is what fantasy football should have been — no draft, no waiver wire, no dead lineups. Pick NFL games against the spread each week and watch the leaderboard."}
+                    : `IV League is what fantasy football should have been — no draft, no waiver wire, no dead lineups. Pick ${isCfb ? 'college football' : 'NFL'} games against the spread each week and watch the leaderboard.`}
                 </Typography>
                 {!isAuthed && (
                   <Stack spacing={1} sx={{ mb: 3 }}>
@@ -229,7 +237,7 @@ export default function HomePage({ adapter }: HomePageProps) {
                     </Box>
                     <Typography variant="h6" fontWeight={700}>2. Pick Against the Spread</Typography>
                     <Typography color="text.secondary">
-                      Each week pick NFL games — not just who wins, but who <em>covers</em>. Chiefs&nbsp;-6.5 means they need to win by 7 or more. Same lines Vegas uses.
+                      Each week pick {isCfb ? 'college football' : 'NFL'} games — not just who wins, but who <em>covers</em>. {isCfb ? 'Ohio State -6.5' : 'Chiefs -6.5'} means they need to win by 7 or more. Same lines Vegas uses.
                     </Typography>
                   </Stack>
                 </Grid>

--- a/Client.React/src/pages/RulesPage.tsx
+++ b/Client.React/src/pages/RulesPage.tsx
@@ -92,10 +92,19 @@ function TeaseFormula() {
 }
 
 function MatchupExample() {
-  const teams = [
-    { name: 'Seattle Seahawks', detail: 'Home favorite', vegas: '−4.5', teased: '+8.5' },
-    { name: 'Chicago Bears', detail: 'Road underdog', vegas: '+4.5', teased: '+17.5' },
-  ];
+  const { isCfb } = useSportContext();
+  const teams = isCfb
+    ? [
+        { name: 'Ohio State Buckeyes', detail: 'Home favorite', vegas: '−4.5', teased: '+8.5' },
+        { name: 'Michigan Wolverines', detail: 'Road underdog', vegas: '+4.5', teased: '+17.5' },
+      ]
+    : [
+        { name: 'Seattle Seahawks', detail: 'Home favorite', vegas: '−4.5', teased: '+8.5' },
+        { name: 'Chicago Bears', detail: 'Road underdog', vegas: '+4.5', teased: '+17.5' },
+      ];
+  const header = isCfb
+    ? 'Week 1 · 2026 · OSU hosts MICH · 13-pt tease example'
+    : 'Week 1 · 2026 · SEA hosts CHI · 13-pt tease example';
 
   return (
     <Paper variant="outlined" sx={{ overflow: 'hidden', borderRadius: 2 }}>
@@ -116,7 +125,7 @@ function MatchupExample() {
           color="text.secondary"
           sx={{ letterSpacing: '0.06em', textTransform: 'uppercase' }}
         >
-          Week 1 · 2026 · SEA hosts CHI · 13-pt tease example
+          {header}
         </Typography>
         <Typography variant="caption" color="text.secondary">
           Vegas → Teased
@@ -161,20 +170,39 @@ function MatchupExample() {
 }
 
 function ScenarioExample() {
-  const rows = [
-    {
-      team: 'Seattle Seahawks',
-      detail: 'Teased line: +8.5 · Lost by 10',
-      score: 17,
-      result: 'Loser' as const,
-    },
-    {
-      team: 'Chicago Bears',
-      detail: 'Teased line: +17.5 · Won outright',
-      score: 27,
-      result: 'Winner' as const,
-    },
-  ];
+  const { isCfb } = useSportContext();
+  const rows = isCfb
+    ? [
+        {
+          team: 'Ohio State Buckeyes',
+          detail: 'Teased line: +8.5 · Lost by 10',
+          score: 17,
+          result: 'Loser' as const,
+        },
+        {
+          team: 'Michigan Wolverines',
+          detail: 'Teased line: +17.5 · Won outright',
+          score: 27,
+          result: 'Winner' as const,
+        },
+      ]
+    : [
+        {
+          team: 'Seattle Seahawks',
+          detail: 'Teased line: +8.5 · Lost by 10',
+          score: 17,
+          result: 'Loser' as const,
+        },
+        {
+          team: 'Chicago Bears',
+          detail: 'Teased line: +17.5 · Won outright',
+          score: 27,
+          result: 'Winner' as const,
+        },
+      ];
+  const header = isCfb
+    ? 'Final: Michigan 27, Ohio State 17  ·  Michigan wins by 10'
+    : 'Final: Bears 27, Seahawks 17  ·  Bears win by 10';
 
   return (
     <Paper variant="outlined" sx={{ overflow: 'hidden', borderRadius: 2 }}>
@@ -188,7 +216,7 @@ function ScenarioExample() {
         }}
       >
         <Typography variant="body2" fontWeight={500}>
-          Final: Bears 27, Seahawks 17 &nbsp;·&nbsp; Bears win by 10
+          {header}
         </Typography>
       </Box>
       {rows.map((row, i) => (
@@ -396,7 +424,9 @@ export function RulesContent() {
         <MatchupExample />
         <InfoCallout>
           You can pick <strong>both sides</strong> of the same game. Expect a close game? Take
-          Seattle +8.5 and Chicago +17.5 — that&apos;s two of your four picks from one matchup.
+          {isCfb
+            ? ' Ohio State +8.5 and Michigan +17.5 — that’s two of your four picks from one matchup.'
+            : ' Seattle +8.5 and Chicago +17.5 — that’s two of your four picks from one matchup.'}
         </InfoCallout>
       </Box>
 
@@ -407,8 +437,9 @@ export function RulesContent() {
         <SectionLabel>Live example — final score</SectionLabel>
         <ScenarioExample />
         <InfoCallout>
-          Seattle lost by 10 — not enough to cover their teased line of +8.5. Chicago won the game
-          outright by 10, easily covering their teased line of +17.5.
+          {isCfb
+            ? 'Ohio State lost by 10 — not enough to cover their teased line of +8.5. Michigan won the game outright by 10, easily covering their teased line of +17.5.'
+            : 'Seattle lost by 10 — not enough to cover their teased line of +8.5. Chicago won the game outright by 10, easily covering their teased line of +17.5.'}
         </InfoCallout>
       </Box>
 


### PR DESCRIPTION
## Summary
- **Picks page button colors** — locked "Picked"/"Pick"/"Over"/"Under" buttons were flattening to MUI's uniform disabled gray, erasing the picked/not-picked distinction. Filled=picked (success), outlined=available/not picked (warning) instead of two adjacent solid color blocks.
- **Light-mode contrast** — the amber/warning color was hard to read on white; light mode now uses darker success/warning shades while dark mode keeps the original punchier tones.
- **No CFB/NFL indicator on homepage** — added a sport badge + adapted hero/how-it-works copy so unauthenticated visitors (and the authenticated dashboard) can tell which subdomain they're on.
- **Dashboard "not aligned" between sports** — `DashboardStandings` was already shared code between NFL/CFB, but silently rendered nothing when a user had no leagues/results in a sport, making the two dashboards look structurally different. Now shows an explicit empty state.
- **Matrix view logos hard to see in dark mode** — `UserPicksMatrix` cell background was a hardcoded light gray in every theme mode, washing out `TeamHelmet`'s neon dark-mode logo assets. Background now follows the active theme.
- **CFB Rules page showed NFL teams** — the tease/matchup examples on the Rules page were hardcoded to Seahawks/Bears regardless of sport; CFB now shows a CFB matchup example.

## Test plan
- [x] `dotnet test` — 509 passed (no backend changes; ran for safety)
- [x] `npm run test -- --run` — 283 passed (incl. new `HomePage.test.tsx`, `UserPicksMatrix.test.tsx`, updated `DashboardStandings.test.tsx`/`GameCard.test.tsx`)
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm run test:e2e -- --project=chromium` — 54 passed (updated `dashboardStandings.spec.ts` for the new empty-state copy)
- [x] Manual verification in Chrome against the local demo stack, both light and dark mode, both NFL and CFB subdomains (dashboard badge, picks page button colors, CFB rules matchup example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)