### PR TITLE
fix(matrix): O/U picks get a dedicated column instead of overwriting the spread pick

### DIFF
--- a/Client.React/src/__tests__/UserPicksMatrix.test.tsx
+++ b/Client.React/src/__tests__/UserPicksMatrix.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import UserPicksMatrix from '../components/UserPicksMatrix';
 import type { NflPickDto } from '../types/picks';
@@ -33,5 +33,40 @@ describe('UserPicksMatrix — dark mode cell coloring', () => {
     const { getByTestId } = renderMatrix('light');
     const cell = getByTestId('helmet-KC').parentElement;
     expect(cell).toHaveStyle({ backgroundColor: 'rgb(238, 238, 238)' }); // MUI grey.200
+  });
+});
+
+describe('UserPicksMatrix — spread vs Over/Under picks', () => {
+  // frizat: a user can have both a spread pick and a separate Over/Under pick in the same
+  // postseason week (O/U isn't counted toward requiredPicks). Indexing into a single mixed-type
+  // array by position meant whichever pick sorted first won the one available column and the
+  // other was silently dropped — so a user's O/U pick could vanish entirely, or overwrite their
+  // spread pick's cell.
+  const mixedPicks: NflPickDto[] = [
+    { id: 1, userId: 'u1', userName: 'bob', team: 'NE', pick: 'Spread', season: 2025, nflWeek: 22, leagueId: 1, dateCreated: '' },
+    { id: 2, userId: 'u1', userName: 'bob', team: 'NE', pick: 'Over', season: 2025, nflWeek: 22, leagueId: 1, dateCreated: '' },
+  ];
+
+  function renderMixed() {
+    return render(
+      <ThemeProvider theme={createTheme()}>
+        <UserPicksMatrix users={['bob']} picks={mixedPicks} spreads={{}} requiredPicks={1} />
+      </ThemeProvider>,
+    );
+  }
+
+  it('shows both the spread pick and the Over/Under pick, in separate columns', () => {
+    renderMixed();
+    expect(screen.getByText('O/U')).toBeInTheDocument();
+    expect(screen.getAllByTestId('helmet-NE')).toHaveLength(2);
+  });
+
+  it('does not add an O/U column when no one has an Over/Under pick this week', () => {
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <UserPicksMatrix users={['alice']} picks={picks} spreads={{}} requiredPicks={1} />
+      </ThemeProvider>,
+    );
+    expect(screen.queryByText('O/U')).not.toBeInTheDocument();
   });
 });

--- a/Client.React/src/components/UserPicksMatrix.tsx
+++ b/Client.React/src/components/UserPicksMatrix.tsx
@@ -24,7 +24,14 @@ interface UserPicksMatrixProps {
 
 export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }: UserPicksMatrixProps) {
   const isDark = useTheme().palette.mode === 'dark';
-  const getUserPicks = (user: string) => picks.filter((p) => p.userName === user);
+  // frizat: a user can have BOTH a spread pick and a separate Over/Under pick in the same
+  // postseason week (the O/U pick isn't counted toward requiredPicks) — indexing into a single
+  // mixed-type array by position meant whichever pick happened to sort first won that column and
+  // the other was silently dropped. Spread picks fill the requiredPicks columns; O/U (if any
+  // exist this week) gets its own dedicated column so both are always visible.
+  const getSpreadPicks = (user: string) => picks.filter((p) => p.userName === user && p.pick === 'Spread');
+  const getOverUnderPick = (user: string) => picks.find((p) => p.userName === user && p.pick !== 'Spread');
+  const hasOverUnder = picks.some((p) => p.pick !== 'Spread');
 
   const getWinner = (teamAbbr: string, pickType: NflPickDto['pick']) => {
     const calc = spreads[teamAbbr];
@@ -32,6 +39,75 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
     if (pickType === 'Spread') return calc.isWinner;
     if (pickType === 'Over') return calc.isOverWinner;
     return calc.isUnderWinner;
+  };
+
+  const renderCell = (key: string, pick: NflPickDto | undefined) => {
+    if (!pick?.team) {
+      return (
+        <TableCell key={key} align="center">
+          <Paper sx={{ height: 76, width: 60, borderRadius: 2 }} />
+        </TableCell>
+      );
+    }
+    const result = getWinner(pick.team, pick.pick);
+    // TeamHelmet's dark-mode logos are neon assets designed to glow against a dark background
+    // (see TeamHelmet.tsx) — the light literal tones below washed them out in dark mode, so pick
+    // each cell's tone from the active theme instead.
+    const bgColor = result === true
+      ? (isDark ? 'success.dark' : 'success.light')
+      : result === false
+        ? (isDark ? 'error.dark' : 'error.light')
+        : (isDark ? 'grey.800' : 'grey.200');
+
+    return (
+      <TableCell key={key} align="center">
+        <Paper
+          sx={{
+            height: 76,
+            width: 60,
+            borderRadius: 2,
+            position: 'relative',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: bgColor,
+          }}
+        >
+          {pick.pick === 'Over' && (
+            <ArrowCircleUpIcon
+              fontSize="small"
+              sx={{ position: 'absolute', top: 4, left: 4, bgcolor: 'white', borderRadius: '50%' }}
+              color={result ? 'success' : 'error'}
+            />
+          )}
+          {pick.pick === 'Under' && (
+            <ArrowCircleDownIcon
+              fontSize="small"
+              sx={{ position: 'absolute', top: 4, left: 4, bgcolor: 'white', borderRadius: '50%' }}
+              color={result ? 'success' : 'error'}
+            />
+          )}
+          {/* frizat: the team logo alone was hard to identify at a glance against the win/loss
+              color-coded background — show the abbreviation too. */}
+          <TeamHelmet abbr={pick.team} size={36} showLabel />
+          {result === true && (
+            <CheckCircleIcon
+              fontSize="small"
+              color="success"
+              sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'white', borderRadius: '50%' }}
+            />
+          )}
+          {result === false && (
+            <CancelIcon
+              fontSize="small"
+              color="error"
+              sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'white', borderRadius: '50%' }}
+            />
+          )}
+        </Paper>
+      </TableCell>
+    );
   };
 
   return (
@@ -43,85 +119,19 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
             {Array.from({ length: requiredPicks }).map((_, idx) => (
               <TableCell key={idx}>Pick {idx + 1}</TableCell>
             ))}
+            {hasOverUnder && <TableCell>O/U</TableCell>}
           </TableRow>
         </TableHead>
         <TableBody>
           {users.sort().map((user) => {
-            const userPicks = getUserPicks(user);
+            const spreadPicks = getSpreadPicks(user);
             return (
               <TableRow key={user}>
                 <TableCell>
                   <Typography fontWeight={600}>{user}</Typography>
                 </TableCell>
-                {Array.from({ length: requiredPicks }).map((_, idx) => {
-                  const pick = userPicks[idx];
-                  if (!pick?.team) {
-                    return (
-                      <TableCell key={idx} align="center">
-                        <Paper sx={{ height: 76, width: 60, borderRadius: 2 }} />
-                      </TableCell>
-                    );
-                  }
-                  const result = getWinner(pick.team, pick.pick);
-                  // TeamHelmet's dark-mode logos are neon assets designed to glow against a dark
-                  // background (see TeamHelmet.tsx) — the light literal tones below washed them
-                  // out in dark mode, so pick each cell's tone from the active theme instead.
-                  const bgColor = result === true
-                    ? (isDark ? 'success.dark' : 'success.light')
-                    : result === false
-                      ? (isDark ? 'error.dark' : 'error.light')
-                      : (isDark ? 'grey.800' : 'grey.200');
-
-                  return (
-                    <TableCell key={idx} align="center">
-                      <Paper
-                        sx={{
-                          height: 76,
-                          width: 60,
-                          borderRadius: 2,
-                          position: 'relative',
-                          display: 'flex',
-                          flexDirection: 'column',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          backgroundColor: bgColor,
-                        }}
-                      >
-                        {pick.pick === 'Over' && (
-                          <ArrowCircleUpIcon
-                            fontSize="small"
-                            sx={{ position: 'absolute', top: 4, left: 4, bgcolor: 'white', borderRadius: '50%' }}
-                            color={result ? 'success' : 'error'}
-                          />
-                        )}
-                        {pick.pick === 'Under' && (
-                          <ArrowCircleDownIcon
-                            fontSize="small"
-                            sx={{ position: 'absolute', top: 4, left: 4, bgcolor: 'white', borderRadius: '50%' }}
-                            color={result ? 'success' : 'error'}
-                          />
-                        )}
-                        {/* frizat: the team logo alone was hard to identify at a glance against
-                            the win/loss color-coded background — show the abbreviation too. */}
-                        <TeamHelmet abbr={pick.team} size={36} showLabel />
-                        {result === true && (
-                          <CheckCircleIcon
-                            fontSize="small"
-                            color="success"
-                            sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'white', borderRadius: '50%' }}
-                          />
-                        )}
-                        {result === false && (
-                          <CancelIcon
-                            fontSize="small"
-                            color="error"
-                            sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'white', borderRadius: '50%' }}
-                          />
-                        )}
-                      </Paper>
-                    </TableCell>
-                  );
-                })}
+                {Array.from({ length: requiredPicks }).map((_, idx) => renderCell(`${user}-${idx}`, spreadPicks[idx]))}
+                {hasOverUnder && renderCell(`${user}-ou`, getOverUnderPick(user))}
               </TableRow>
             );
           })}


### PR DESCRIPTION
## Summary
A user can have both a spread pick and a separate Over/Under pick in the same postseason week (O/U isn't counted toward `requiredPicks`). `UserPicksMatrix` indexed into a single mixed-type picks array by position, so whichever pick happened to sort first won the one available column and the other was silently dropped — reported live as "matrix doesn't show over/under overlay anymore" on the Super Bowl/CFP Championship matrix.

Spread picks now fill the `requiredPicks` columns; a dedicated "O/U" column appears only when at least one pick that week is Over/Under.

## Test plan
- [x] `npm run test -- --run` — 287 passed (2 new tests: O/U gets its own column, no O/U column added when nobody has one)
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm run test:e2e -- --project=chromium` — 53 passed
- [x] Manual: NFL Super Bowl matrix now shows Bob/Dana's Over/Under picks in a dedicated column alongside their spread pick, both correctly colored/overlaid; CFB CFP Championship unaffected (already worked by coincidence of array order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)