### PR TITLE
fix(ui): revert matrix column, rebuild Picks alignment on ScoresPage pattern

### DIFF
--- a/Client.React/src/__tests__/UserPicksMatrix.test.tsx
+++ b/Client.React/src/__tests__/UserPicksMatrix.test.tsx
@@ -38,35 +38,30 @@ describe('UserPicksMatrix — dark mode cell coloring', () => {
 
 describe('UserPicksMatrix — spread vs Over/Under picks', () => {
   // frizat: a user can have both a spread pick and a separate Over/Under pick in the same
-  // postseason week (O/U isn't counted toward requiredPicks). Indexing into a single mixed-type
-  // array by position meant whichever pick sorted first won the one available column and the
-  // other was silently dropped — so a user's O/U pick could vanish entirely, or overwrite their
-  // spread pick's cell.
+  // postseason week (O/U isn't counted toward requiredPicks). The column count must always equal
+  // requiredPicks — a dedicated "O/U" column broke that for every other week. Both picks render
+  // as separate badges inside the same required-pick cell instead.
   const mixedPicks: NflPickDto[] = [
     { id: 1, userId: 'u1', userName: 'bob', team: 'NE', pick: 'Spread', season: 2025, nflWeek: 22, leagueId: 1, dateCreated: '' },
     { id: 2, userId: 'u1', userName: 'bob', team: 'NE', pick: 'Over', season: 2025, nflWeek: 22, leagueId: 1, dateCreated: '' },
   ];
 
-  function renderMixed() {
-    return render(
+  it('shows both the spread pick and the Over/Under pick as two badges in the same cell, not a new column', () => {
+    render(
       <ThemeProvider theme={createTheme()}>
         <UserPicksMatrix users={['bob']} picks={mixedPicks} spreads={{}} requiredPicks={1} />
       </ThemeProvider>,
     );
-  }
-
-  it('shows both the spread pick and the Over/Under pick, in separate columns', () => {
-    renderMixed();
-    expect(screen.getByText('O/U')).toBeInTheDocument();
+    expect(screen.getAllByRole('columnheader')).toHaveLength(2); // User + Pick 1, no extra column
     expect(screen.getAllByTestId('helmet-NE')).toHaveLength(2);
   });
 
-  it('does not add an O/U column when no one has an Over/Under pick this week', () => {
+  it('column count always equals requiredPicks regardless of Over/Under picks', () => {
     render(
       <ThemeProvider theme={createTheme()}>
-        <UserPicksMatrix users={['alice']} picks={picks} spreads={{}} requiredPicks={1} />
+        <UserPicksMatrix users={['bob']} picks={mixedPicks} spreads={{}} requiredPicks={4} />
       </ThemeProvider>,
     );
-    expect(screen.queryByText('O/U')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('columnheader')).toHaveLength(5); // User + Pick 1-4
   });
 });

--- a/Client.React/src/components/UserPicksMatrix.tsx
+++ b/Client.React/src/components/UserPicksMatrix.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Paper,
   Table,
   TableBody,
@@ -24,14 +25,6 @@ interface UserPicksMatrixProps {
 
 export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }: UserPicksMatrixProps) {
   const isDark = useTheme().palette.mode === 'dark';
-  // frizat: a user can have BOTH a spread pick and a separate Over/Under pick in the same
-  // postseason week (the O/U pick isn't counted toward requiredPicks) — indexing into a single
-  // mixed-type array by position meant whichever pick happened to sort first won that column and
-  // the other was silently dropped. Spread picks fill the requiredPicks columns; O/U (if any
-  // exist this week) gets its own dedicated column so both are always visible.
-  const getSpreadPicks = (user: string) => picks.filter((p) => p.userName === user && p.pick === 'Spread');
-  const getOverUnderPick = (user: string) => picks.find((p) => p.userName === user && p.pick !== 'Spread');
-  const hasOverUnder = picks.some((p) => p.pick !== 'Spread');
 
   const getWinner = (teamAbbr: string, pickType: NflPickDto['pick']) => {
     const calc = spreads[teamAbbr];
@@ -41,18 +34,11 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
     return calc.isUnderWinner;
   };
 
-  const renderCell = (key: string, pick: NflPickDto | undefined) => {
-    if (!pick?.team) {
-      return (
-        <TableCell key={key} align="center">
-          <Paper sx={{ height: 76, width: 60, borderRadius: 2 }} />
-        </TableCell>
-      );
-    }
+  const renderBadge = (pick: NflPickDto) => {
     const result = getWinner(pick.team, pick.pick);
     // TeamHelmet's dark-mode logos are neon assets designed to glow against a dark background
     // (see TeamHelmet.tsx) — the light literal tones below washed them out in dark mode, so pick
-    // each cell's tone from the active theme instead.
+    // each badge's tone from the active theme instead.
     const bgColor = result === true
       ? (isDark ? 'success.dark' : 'success.light')
       : result === false
@@ -60,53 +46,53 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
         : (isDark ? 'grey.800' : 'grey.200');
 
     return (
-      <TableCell key={key} align="center">
-        <Paper
-          sx={{
-            height: 76,
-            width: 60,
-            borderRadius: 2,
-            position: 'relative',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: bgColor,
-          }}
-        >
-          {pick.pick === 'Over' && (
-            <ArrowCircleUpIcon
-              fontSize="small"
-              sx={{ position: 'absolute', top: 4, left: 4, bgcolor: 'white', borderRadius: '50%' }}
-              color={result ? 'success' : 'error'}
-            />
-          )}
-          {pick.pick === 'Under' && (
-            <ArrowCircleDownIcon
-              fontSize="small"
-              sx={{ position: 'absolute', top: 4, left: 4, bgcolor: 'white', borderRadius: '50%' }}
-              color={result ? 'success' : 'error'}
-            />
-          )}
-          {/* frizat: the team logo alone was hard to identify at a glance against the win/loss
-              color-coded background — show the abbreviation too. */}
-          <TeamHelmet abbr={pick.team} size={36} showLabel />
-          {result === true && (
-            <CheckCircleIcon
-              fontSize="small"
-              color="success"
-              sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'white', borderRadius: '50%' }}
-            />
-          )}
-          {result === false && (
-            <CancelIcon
-              fontSize="small"
-              color="error"
-              sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'white', borderRadius: '50%' }}
-            />
-          )}
-        </Paper>
-      </TableCell>
+      <Paper
+        key={`${pick.team}-${pick.pick}`}
+        sx={{
+          height: 76,
+          width: 60,
+          borderRadius: 2,
+          position: 'relative',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: bgColor,
+          flexShrink: 0,
+        }}
+      >
+        {pick.pick === 'Over' && (
+          <ArrowCircleUpIcon
+            fontSize="small"
+            sx={{ position: 'absolute', top: 4, left: 4, bgcolor: 'white', borderRadius: '50%' }}
+            color={result ? 'success' : 'error'}
+          />
+        )}
+        {pick.pick === 'Under' && (
+          <ArrowCircleDownIcon
+            fontSize="small"
+            sx={{ position: 'absolute', top: 4, left: 4, bgcolor: 'white', borderRadius: '50%' }}
+            color={result ? 'success' : 'error'}
+          />
+        )}
+        {/* frizat: the team logo alone was hard to identify at a glance against the win/loss
+            color-coded background — show the abbreviation too. */}
+        <TeamHelmet abbr={pick.team} size={36} showLabel />
+        {result === true && (
+          <CheckCircleIcon
+            fontSize="small"
+            color="success"
+            sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'white', borderRadius: '50%' }}
+          />
+        )}
+        {result === false && (
+          <CancelIcon
+            fontSize="small"
+            color="error"
+            sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'white', borderRadius: '50%' }}
+          />
+        )}
+      </Paper>
     );
   };
 
@@ -119,19 +105,38 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
             {Array.from({ length: requiredPicks }).map((_, idx) => (
               <TableCell key={idx}>Pick {idx + 1}</TableCell>
             ))}
-            {hasOverUnder && <TableCell>O/U</TableCell>}
           </TableRow>
         </TableHead>
         <TableBody>
           {users.sort().map((user) => {
-            const spreadPicks = getSpreadPicks(user);
+            const spreadPicks = picks.filter((p) => p.userName === user && p.pick === 'Spread');
+            // frizat: a user can have both a spread pick AND a separate Over/Under pick for the
+            // same game in a postseason week (O/U isn't counted toward requiredPicks — it's
+            // always a single extra pick tied to that week's one required game). Rather than a
+            // dedicated table column, which breaks "columns == requiredPicks" for every other
+            // week, the O/U pick renders as a second badge alongside the spread pick in that
+            // same required-pick cell.
+            const overUnderPicks = picks.filter((p) => p.userName === user && p.pick !== 'Spread');
             return (
               <TableRow key={user}>
                 <TableCell>
                   <Typography fontWeight={600}>{user}</Typography>
                 </TableCell>
-                {Array.from({ length: requiredPicks }).map((_, idx) => renderCell(`${user}-${idx}`, spreadPicks[idx]))}
-                {hasOverUnder && renderCell(`${user}-ou`, getOverUnderPick(user))}
+                {Array.from({ length: requiredPicks }).map((_, idx) => {
+                  const cellPicks = [spreadPicks[idx], ...(idx === 0 ? overUnderPicks : [])]
+                    .filter((p): p is NflPickDto => Boolean(p?.team));
+                  return (
+                    <TableCell key={idx} align="center">
+                      {cellPicks.length === 0 ? (
+                        <Paper sx={{ height: 76, width: 60, borderRadius: 2 }} />
+                      ) : (
+                        <Box sx={{ display: 'flex', gap: 0.5, justifyContent: 'center' }}>
+                          {cellPicks.map(renderBadge)}
+                        </Box>
+                      )}
+                    </TableCell>
+                  );
+                })}
               </TableRow>
             );
           })}

--- a/Client.React/src/components/sports/GameCard.tsx
+++ b/Client.React/src/components/sports/GameCard.tsx
@@ -93,21 +93,24 @@ export default function GameCard({
   const isLive = gameStatus === 'StatusInProgress' || gameStatus === 'status_in_progress';
   const showScore = mode === 'score' && (isFinal || isLive);
 
-  const pickButtonSx = { minWidth: 80, height: 44, textTransform: 'none', fontSize: '0.85rem', flexShrink: 0 } as const;
+  // frizat: "Picked" (with its checkmark icon) renders ~29px wider than "Pick" at minWidth alone
+  // — since the button sits after the spread value in a right-hugging cluster, that width
+  // difference shifted the value's position between a submitted row and an unsubmitted one. A
+  // fixed `width` (not just minWidth) keeps every pick-state button identical, so the value's
+  // position never depends on which state a given row happens to be in.
+  const pickButtonSx = { width: 112, height: 44, textTransform: 'none', fontSize: '0.85rem', flexShrink: 0 } as const;
 
-  // frizat: a team row's spread/action columns used to be positioned by a flex Stack with
-  // justifyContent="space-between" — whenever a row's record cell was conditionally omitted
-  // (record data unavailable, e.g. every CFB game today, or NFL bye-week/preseason games with no
-  // record yet), the remaining items shifted into different horizontal positions than rows that
-  // did have a record. Since each team row is its own layout container, "auto" column sizing
-  // can't guarantee alignment across rows/cards either — only fixed pixel columns can. The record
-  // cell is always rendered (blank when there's no data) so the column count never changes.
-  const teamRowGridSx = {
-    display: 'grid',
-    gridTemplateColumns: '60px 56px 80px 1fr',
-    alignItems: 'center',
-    columnGap: 1,
-  } as const;
+  // frizat: a rigid fixed-column grid (60/56/80/1fr) made row alignment robust but pinned the
+  // spread value at a fixed offset near the left edge, with a large dead gap before the button —
+  // it read as "left-aligned," not centered, and looked nothing like ScoresPage's own team rows
+  // (a completely separate hand-built layout ScoresPage.tsx uses — GameCard is only ever rendered
+  // in pick mode, never score mode, in the live app). ScoresPage's trick is simpler and more
+  // robust: a flexGrow spacer between the left cluster (logo/record) and the right cluster
+  // (value/action) — the left cluster can vary in width (record present or not) without ever
+  // shifting the right cluster, which always hugs the right edge. The value itself stays
+  // dead-centered within its own fixed-width box, matching what "aligned in the middle" means for
+  // the number itself.
+  const spreadValueSx = { minWidth: 64, textAlign: 'center', flexShrink: 0 } as const;
 
   // MUI's `disabled` state flattens contained (filled) buttons to uniform gray regardless of
   // `color`. Keep the real color at reduced opacity instead of falling back to generic gray.
@@ -137,10 +140,14 @@ export default function GameCard({
     const picked = pickState !== 'none';
     const color = picked ? 'success' : 'info';
     return (
+      // frizat: doesn't share pickButtonSx's fixed width — "Over 45.5 ✓" is much longer than
+      // "Picked" and would overflow/clip a box sized for the shorter label. This row balances via
+      // justifyContent="space-between" across 3 always-present items instead, so it doesn't need
+      // a fixed button width to stay readable.
       <Button
         variant="contained"
         color={color}
-        sx={[pickButtonSx, lockedFillSx(color)]}
+        sx={[{ minWidth: 80, height: 44, textTransform: 'none', fontSize: '0.85rem', flexShrink: 0 }, lockedFillSx(color)]}
         disabled={overUnderLocked && !picked}
         onClick={onPick}
       >
@@ -166,25 +173,24 @@ export default function GameCard({
         {/* Away team row */}
         <Card variant="outlined" sx={{ mb: 1.5 }}>
           <CardContent sx={{ p: '12px !important' }}>
-            <Box sx={teamRowGridSx}>
+            <Stack direction="row" alignItems="center" sx={{ gap: 1 }}>
               {renderTeamLogo(awayTeam, awayJerseyUrl)}
-              <Typography variant="subtitle2">
-                {!isPostSeason ? awayRecord : ''}
-              </Typography>
-              <Typography variant="h6" className="fixed-width" sx={{ textAlign: 'center' }}>
+              {!isPostSeason && awayRecord && (
+                <Typography variant="subtitle2">{awayRecord}</Typography>
+              )}
+              <Box sx={{ flexGrow: 1 }} />
+              <Typography variant="h6" sx={spreadValueSx}>
                 {mode === 'score' && showScore ? awayScore : awaySpread != null ? spreadLabel(awaySpread) : ""}
               </Typography>
-              <Box sx={{ justifySelf: 'end' }}>
-                {mode === 'pick' ? renderPickButton(awayTeam, awayPickState, onPickAway) : (
-                  mode === 'score' && (
-                    <Typography variant="caption" color="text.secondary">
-                      {awaySpread != null ? spreadLabel(awaySpread) : ""}
-                      {awayPickers !== undefined && ` · ${awayPickers}👤`}
-                    </Typography>
-                  )
-                )}
-              </Box>
-            </Box>
+              {mode === 'pick' ? renderPickButton(awayTeam, awayPickState, onPickAway) : (
+                mode === 'score' && (
+                  <Typography variant="caption" color="text.secondary">
+                    {awaySpread != null ? spreadLabel(awaySpread) : ""}
+                    {awayPickers !== undefined && ` · ${awayPickers}👤`}
+                  </Typography>
+                )
+              )}
+            </Stack>
           </CardContent>
         </Card>
 
@@ -212,25 +218,24 @@ export default function GameCard({
         {/* Home team row */}
         <Card variant="outlined">
           <CardContent sx={{ p: '12px !important' }}>
-            <Box sx={teamRowGridSx}>
+            <Stack direction="row" alignItems="center" sx={{ gap: 1 }}>
               {renderTeamLogo(homeTeam, homeJerseyUrl)}
-              <Typography variant="subtitle2">
-                {!isPostSeason ? homeRecord : ''}
-              </Typography>
-              <Typography variant="h6" className="fixed-width" sx={{ textAlign: 'center' }}>
+              {!isPostSeason && homeRecord && (
+                <Typography variant="subtitle2">{homeRecord}</Typography>
+              )}
+              <Box sx={{ flexGrow: 1 }} />
+              <Typography variant="h6" sx={spreadValueSx}>
                 {mode === 'score' && showScore ? homeScore : homeSpread != null ? spreadLabel(homeSpread) : ""}
               </Typography>
-              <Box sx={{ justifySelf: 'end' }}>
-                {mode === 'pick' ? renderPickButton(homeTeam, homePickState, onPickHome) : (
-                  mode === 'score' && (
-                    <Typography variant="caption" color="text.secondary">
-                      {homeSpread != null ? spreadLabel(homeSpread) : ""}
-                      {homePickers !== undefined && ` · ${homePickers}👤`}
-                    </Typography>
-                  )
-                )}
-              </Box>
-            </Box>
+              {mode === 'pick' ? renderPickButton(homeTeam, homePickState, onPickHome) : (
+                mode === 'score' && (
+                  <Typography variant="caption" color="text.secondary">
+                    {homeSpread != null ? spreadLabel(homeSpread) : ""}
+                    {homePickers !== undefined && ` · ${homePickers}👤`}
+                  </Typography>
+                )
+              )}
+            </Stack>
           </CardContent>
         </Card>
 
@@ -248,20 +253,15 @@ export default function GameCard({
             sx={{ mt: 1, p: 0 }}
           >
             <CardContent sx={{ p: '12px !important' }}>
-              {/* Same fixed grid as the team rows above (60/56/80/1fr) so the O/U value lands in
-                  the exact same column as the spread values, instead of centering independently
-                  within this row's own narrower content. */}
-              <Box sx={teamRowGridSx}>
-                <Box sx={{ gridColumn: '1 / 3' }}>
-                  {renderOverUnderButton('Over', overValue, overPickState, onPickOver)}
-                </Box>
-                <Typography variant="h6" className="fixed-width" sx={{ textAlign: 'center', flexShrink: 0 }}>
+              {/* Mirrors ScoresPage's own O/U row (button — value — button, evenly spaced) —
+                  three always-present items balance naturally without needing a spacer. */}
+              <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ gap: 1 }}>
+                {renderOverUnderButton('Over', overValue, overPickState, onPickOver)}
+                <Typography variant="h6" sx={spreadValueSx}>
                   {overValue}
                 </Typography>
-                <Box sx={{ justifySelf: 'end' }}>
-                  {renderOverUnderButton('Under', underValue, underPickState, onPickUnder)}
-                </Box>
-              </Box>
+                {renderOverUnderButton('Under', underValue, underPickState, onPickUnder)}
+              </Stack>
             </CardContent>
           </Card>
         )}


### PR DESCRIPTION
## Summary

Reverts the "O/U dedicated column" from the prior PR (broke `columns == requiredPicks` for every non-championship week) and rebuilds GameCard's Picks-page alignment on ScoresPage's own proven layout pattern instead of a rigid fixed-pixel grid.

- **Matrix**: back to `requiredPicks` columns only. A spread pick + separate O/U pick for the same postseason game now render as two badges side by side in that one cell, not a second table column.
- **GameCard alignment**: GameCard is only ever rendered in pick mode in the live app — ScoresPage.tsx has its own separate, hand-built team-row layout. Replaced GameCard's fixed 60/56/80/1fr column grid with the same `flexGrow:1` spacer pattern ScoresPage already uses: left cluster (logo/record) hugs left, right cluster (value/action) hugs right via the spacer, value stays dead-centered in its own fixed-width box. Robust regardless of whether a row has a team record to show.
- **Button-width fix this surfaced**: "Picked" (checkmark icon) rendered ~29px wider than "Pick", shifting the value's position between rows. Pick/Picked now share a fixed width. O/U buttons intentionally don't (their picked label is much longer and would clip) — that row balances via `space-between` across 3 fixed items instead, matching ScoresPage's own O/U row.

## Test plan
- [x] `npm run test -- --run` — 287 passed (updated matrix tests for the single-column-with-badges behavior)
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm run test:e2e -- --project=chromium` — 51/53 passed, 2 registration.spec.ts failures confirmed flaky/unrelated on retry (isolated re-run: 4/4 passed)
- [x] Manual: verified on a real 390px mobile viewport (chrome-devtools MCP) — spread values now line up exactly between the away/home rows on Super Bowl and Week 18, matching ScoresPage's look

🤖 Generated with [Claude Code](https://claude.com/claude-code)