### PR TITLE
Promote dev to main — PRs #206-#209

### DIFF
--- a/Client.React/e2e/admin.spec.ts
+++ b/Client.React/e2e/admin.spec.ts
@@ -12,7 +12,7 @@ test.describe('Admin pages (administrator role)', () => {
     await adminAuth(page, '/admin/jobManagement');
     await waitForSpinner(page);
 
-    await expect(page.getByRole('heading', { name: /administrator user management/i })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('heading', { name: /^job manager$/i })).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('NflScoresJob')).toBeVisible({ timeout: 5000 });
   });
 

--- a/Client.React/src/__tests__/UserPicksMatrix.test.tsx
+++ b/Client.React/src/__tests__/UserPicksMatrix.test.tsx
@@ -36,27 +36,29 @@ describe('UserPicksMatrix — dark mode cell coloring', () => {
   });
 });
 
-describe('UserPicksMatrix — spread vs Over/Under picks', () => {
-  // frizat: a user can have both a spread pick and a separate Over/Under pick in the same
-  // postseason week (O/U isn't counted toward requiredPicks). The column count must always equal
-  // requiredPicks — a dedicated "O/U" column broke that for every other week. Both picks render
-  // as separate badges inside the same required-pick cell instead.
+describe('UserPicksMatrix — Over/Under is an alternate pick type, not an additional pick', () => {
+  // frizat: AddPicks' server-side validation caps total picks (any type) at requiredPicks — a
+  // real user's Over/Under pick REPLACES one of their spread picks, it never adds a pick beyond
+  // requiredPicks. One badge per required-pick column; column count always equals requiredPicks.
   const mixedPicks: NflPickDto[] = [
-    { id: 1, userId: 'u1', userName: 'bob', team: 'NE', pick: 'Spread', season: 2025, nflWeek: 22, leagueId: 1, dateCreated: '' },
-    { id: 2, userId: 'u1', userName: 'bob', team: 'NE', pick: 'Over', season: 2025, nflWeek: 22, leagueId: 1, dateCreated: '' },
+    { id: 1, userId: 'u1', userName: 'bob', team: 'NE', pick: 'Over', season: 2025, nflWeek: 19, leagueId: 1, dateCreated: '' },
+    { id: 2, userId: 'u1', userName: 'bob', team: 'KC', pick: 'Spread', season: 2025, nflWeek: 19, leagueId: 1, dateCreated: '' },
+    { id: 3, userId: 'u1', userName: 'bob', team: 'BUF', pick: 'Spread', season: 2025, nflWeek: 19, leagueId: 1, dateCreated: '' },
   ];
 
-  it('shows both the spread pick and the Over/Under pick as two badges in the same cell, not a new column', () => {
+  it('renders exactly one badge per required-pick column, regardless of pick type', () => {
     render(
       <ThemeProvider theme={createTheme()}>
-        <UserPicksMatrix users={['bob']} picks={mixedPicks} spreads={{}} requiredPicks={1} />
+        <UserPicksMatrix users={['bob']} picks={mixedPicks} spreads={{}} requiredPicks={3} />
       </ThemeProvider>,
     );
-    expect(screen.getAllByRole('columnheader')).toHaveLength(2); // User + Pick 1, no extra column
-    expect(screen.getAllByTestId('helmet-NE')).toHaveLength(2);
+    expect(screen.getAllByRole('columnheader')).toHaveLength(4); // User + Pick 1-3
+    expect(screen.getAllByTestId('helmet-NE')).toHaveLength(1);
+    expect(screen.getAllByTestId('helmet-KC')).toHaveLength(1);
+    expect(screen.getAllByTestId('helmet-BUF')).toHaveLength(1);
   });
 
-  it('column count always equals requiredPicks regardless of Over/Under picks', () => {
+  it('column count always equals requiredPicks', () => {
     render(
       <ThemeProvider theme={createTheme()}>
         <UserPicksMatrix users={['bob']} picks={mixedPicks} spreads={{}} requiredPicks={4} />

--- a/Client.React/src/__tests__/UserPicksMatrix.test.tsx
+++ b/Client.React/src/__tests__/UserPicksMatrix.test.tsx
@@ -38,35 +38,30 @@ describe('UserPicksMatrix — dark mode cell coloring', () => {
 
 describe('UserPicksMatrix — spread vs Over/Under picks', () => {
   // frizat: a user can have both a spread pick and a separate Over/Under pick in the same
-  // postseason week (O/U isn't counted toward requiredPicks). Indexing into a single mixed-type
-  // array by position meant whichever pick sorted first won the one available column and the
-  // other was silently dropped — so a user's O/U pick could vanish entirely, or overwrite their
-  // spread pick's cell.
+  // postseason week (O/U isn't counted toward requiredPicks). The column count must always equal
+  // requiredPicks — a dedicated "O/U" column broke that for every other week. Both picks render
+  // as separate badges inside the same required-pick cell instead.
   const mixedPicks: NflPickDto[] = [
     { id: 1, userId: 'u1', userName: 'bob', team: 'NE', pick: 'Spread', season: 2025, nflWeek: 22, leagueId: 1, dateCreated: '' },
     { id: 2, userId: 'u1', userName: 'bob', team: 'NE', pick: 'Over', season: 2025, nflWeek: 22, leagueId: 1, dateCreated: '' },
   ];
 
-  function renderMixed() {
-    return render(
+  it('shows both the spread pick and the Over/Under pick as two badges in the same cell, not a new column', () => {
+    render(
       <ThemeProvider theme={createTheme()}>
         <UserPicksMatrix users={['bob']} picks={mixedPicks} spreads={{}} requiredPicks={1} />
       </ThemeProvider>,
     );
-  }
-
-  it('shows both the spread pick and the Over/Under pick, in separate columns', () => {
-    renderMixed();
-    expect(screen.getByText('O/U')).toBeInTheDocument();
+    expect(screen.getAllByRole('columnheader')).toHaveLength(2); // User + Pick 1, no extra column
     expect(screen.getAllByTestId('helmet-NE')).toHaveLength(2);
   });
 
-  it('does not add an O/U column when no one has an Over/Under pick this week', () => {
+  it('column count always equals requiredPicks regardless of Over/Under picks', () => {
     render(
       <ThemeProvider theme={createTheme()}>
-        <UserPicksMatrix users={['alice']} picks={picks} spreads={{}} requiredPicks={1} />
+        <UserPicksMatrix users={['bob']} picks={mixedPicks} spreads={{}} requiredPicks={4} />
       </ThemeProvider>,
     );
-    expect(screen.queryByText('O/U')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('columnheader')).toHaveLength(5); // User + Pick 1-4
   });
 });

--- a/Client.React/src/components/OwnerCostSummary.tsx
+++ b/Client.React/src/components/OwnerCostSummary.tsx
@@ -22,8 +22,14 @@ export default function OwnerCostSummary() {
   return (
     <Chip
       data-testid="owner-cost-summary"
+      // frizat: this chip renders on the Dashboard hero, which always has a dark navy background
+      // regardless of the app's light/dark theme (see .hero-section in home.css — it isn't
+      // theme-aware). An outlined chip has no fill, so in light mode primary.main (near-black
+      // navy, tuned for text on a light background) was nearly invisible against that fixed-dark
+      // backdrop. A filled chip always paints an opaque colored background with contrastText
+      // (white), so it stays legible everywhere this component is used, in both themes.
       color="primary"
-      variant="outlined"
+      variant="filled"
       label={`$${total} across ${count} league${count !== 1 ? 's' : ''}`}
     />
   );

--- a/Client.React/src/components/UserPicksMatrix.tsx
+++ b/Client.React/src/components/UserPicksMatrix.tsx
@@ -14,6 +14,7 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
 import type { NflPickDto, SpreadCalculationResponse } from '../types/picks';
 import TeamHelmet from './sports/TeamHelmet';
+import { stickyColumnSx } from '../utils/tableStyles';
 
 interface UserPicksMatrixProps {
   users: string[];
@@ -100,7 +101,7 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
       <Table size="small">
         <TableHead>
           <TableRow>
-            <TableCell>User</TableCell>
+            <TableCell sx={stickyColumnSx}>User</TableCell>
             {Array.from({ length: requiredPicks }).map((_, idx) => (
               <TableCell key={idx}>Pick {idx + 1}</TableCell>
             ))}
@@ -115,7 +116,7 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
             const userPicks = picks.filter((p) => p.userName === user);
             return (
               <TableRow key={user}>
-                <TableCell>
+                <TableCell sx={stickyColumnSx}>
                   <Typography fontWeight={600}>{user}</Typography>
                 </TableCell>
                 {Array.from({ length: requiredPicks }).map((_, idx) => {

--- a/Client.React/src/components/UserPicksMatrix.tsx
+++ b/Client.React/src/components/UserPicksMatrix.tsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   Paper,
   Table,
   TableBody,
@@ -109,31 +108,21 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
         </TableHead>
         <TableBody>
           {users.sort().map((user) => {
-            const spreadPicks = picks.filter((p) => p.userName === user && p.pick === 'Spread');
-            // frizat: a user can have both a spread pick AND a separate Over/Under pick for the
-            // same game in a postseason week (O/U isn't counted toward requiredPicks — it's
-            // always a single extra pick tied to that week's one required game). Rather than a
-            // dedicated table column, which breaks "columns == requiredPicks" for every other
-            // week, the O/U pick renders as a second badge alongside the spread pick in that
-            // same required-pick cell.
-            const overUnderPicks = picks.filter((p) => p.userName === user && p.pick !== 'Spread');
+            // frizat: Over/Under is an alternate pick TYPE for one game, not an additional pick —
+            // AddPicks' server-side validation caps total picks (any type) at requiredPicks, so a
+            // real user's picks for this user/week always number exactly requiredPicks regardless
+            // of type mix. One badge per required-pick column, no type filtering needed.
+            const userPicks = picks.filter((p) => p.userName === user);
             return (
               <TableRow key={user}>
                 <TableCell>
                   <Typography fontWeight={600}>{user}</Typography>
                 </TableCell>
                 {Array.from({ length: requiredPicks }).map((_, idx) => {
-                  const cellPicks = [spreadPicks[idx], ...(idx === 0 ? overUnderPicks : [])]
-                    .filter((p): p is NflPickDto => Boolean(p?.team));
+                  const pick = userPicks[idx];
                   return (
                     <TableCell key={idx} align="center">
-                      {cellPicks.length === 0 ? (
-                        <Paper sx={{ height: 76, width: 60, borderRadius: 2 }} />
-                      ) : (
-                        <Box sx={{ display: 'flex', gap: 0.5, justifyContent: 'center' }}>
-                          {cellPicks.map(renderBadge)}
-                        </Box>
-                      )}
+                      {pick ? renderBadge(pick) : <Paper sx={{ height: 76, width: 60, borderRadius: 2 }} />}
                     </TableCell>
                   );
                 })}

--- a/Client.React/src/components/UserPicksMatrix.tsx
+++ b/Client.React/src/components/UserPicksMatrix.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Paper,
   Table,
   TableBody,
@@ -24,14 +25,6 @@ interface UserPicksMatrixProps {
 
 export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }: UserPicksMatrixProps) {
   const isDark = useTheme().palette.mode === 'dark';
-  // frizat: a user can have BOTH a spread pick and a separate Over/Under pick in the same
-  // postseason week (the O/U pick isn't counted toward requiredPicks) — indexing into a single
-  // mixed-type array by position meant whichever pick happened to sort first won that column and
-  // the other was silently dropped. Spread picks fill the requiredPicks columns; O/U (if any
-  // exist this week) gets its own dedicated column so both are always visible.
-  const getSpreadPicks = (user: string) => picks.filter((p) => p.userName === user && p.pick === 'Spread');
-  const getOverUnderPick = (user: string) => picks.find((p) => p.userName === user && p.pick !== 'Spread');
-  const hasOverUnder = picks.some((p) => p.pick !== 'Spread');
 
   const getWinner = (teamAbbr: string, pickType: NflPickDto['pick']) => {
     const calc = spreads[teamAbbr];
@@ -41,18 +34,11 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
     return calc.isUnderWinner;
   };
 
-  const renderCell = (key: string, pick: NflPickDto | undefined) => {
-    if (!pick?.team) {
-      return (
-        <TableCell key={key} align="center">
-          <Paper sx={{ height: 76, width: 60, borderRadius: 2 }} />
-        </TableCell>
-      );
-    }
+  const renderBadge = (pick: NflPickDto) => {
     const result = getWinner(pick.team, pick.pick);
     // TeamHelmet's dark-mode logos are neon assets designed to glow against a dark background
     // (see TeamHelmet.tsx) — the light literal tones below washed them out in dark mode, so pick
-    // each cell's tone from the active theme instead.
+    // each badge's tone from the active theme instead.
     const bgColor = result === true
       ? (isDark ? 'success.dark' : 'success.light')
       : result === false
@@ -60,53 +46,53 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
         : (isDark ? 'grey.800' : 'grey.200');
 
     return (
-      <TableCell key={key} align="center">
-        <Paper
-          sx={{
-            height: 76,
-            width: 60,
-            borderRadius: 2,
-            position: 'relative',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: bgColor,
-          }}
-        >
-          {pick.pick === 'Over' && (
-            <ArrowCircleUpIcon
-              fontSize="small"
-              sx={{ position: 'absolute', top: 4, left: 4, bgcolor: 'white', borderRadius: '50%' }}
-              color={result ? 'success' : 'error'}
-            />
-          )}
-          {pick.pick === 'Under' && (
-            <ArrowCircleDownIcon
-              fontSize="small"
-              sx={{ position: 'absolute', top: 4, left: 4, bgcolor: 'white', borderRadius: '50%' }}
-              color={result ? 'success' : 'error'}
-            />
-          )}
-          {/* frizat: the team logo alone was hard to identify at a glance against the win/loss
-              color-coded background — show the abbreviation too. */}
-          <TeamHelmet abbr={pick.team} size={36} showLabel />
-          {result === true && (
-            <CheckCircleIcon
-              fontSize="small"
-              color="success"
-              sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'white', borderRadius: '50%' }}
-            />
-          )}
-          {result === false && (
-            <CancelIcon
-              fontSize="small"
-              color="error"
-              sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'white', borderRadius: '50%' }}
-            />
-          )}
-        </Paper>
-      </TableCell>
+      <Paper
+        key={`${pick.team}-${pick.pick}`}
+        sx={{
+          height: 76,
+          width: 60,
+          borderRadius: 2,
+          position: 'relative',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: bgColor,
+          flexShrink: 0,
+        }}
+      >
+        {pick.pick === 'Over' && (
+          <ArrowCircleUpIcon
+            fontSize="small"
+            sx={{ position: 'absolute', top: 4, left: 4, bgcolor: 'white', borderRadius: '50%' }}
+            color={result ? 'success' : 'error'}
+          />
+        )}
+        {pick.pick === 'Under' && (
+          <ArrowCircleDownIcon
+            fontSize="small"
+            sx={{ position: 'absolute', top: 4, left: 4, bgcolor: 'white', borderRadius: '50%' }}
+            color={result ? 'success' : 'error'}
+          />
+        )}
+        {/* frizat: the team logo alone was hard to identify at a glance against the win/loss
+            color-coded background — show the abbreviation too. */}
+        <TeamHelmet abbr={pick.team} size={36} showLabel />
+        {result === true && (
+          <CheckCircleIcon
+            fontSize="small"
+            color="success"
+            sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'white', borderRadius: '50%' }}
+          />
+        )}
+        {result === false && (
+          <CancelIcon
+            fontSize="small"
+            color="error"
+            sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'white', borderRadius: '50%' }}
+          />
+        )}
+      </Paper>
     );
   };
 
@@ -119,19 +105,38 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
             {Array.from({ length: requiredPicks }).map((_, idx) => (
               <TableCell key={idx}>Pick {idx + 1}</TableCell>
             ))}
-            {hasOverUnder && <TableCell>O/U</TableCell>}
           </TableRow>
         </TableHead>
         <TableBody>
           {users.sort().map((user) => {
-            const spreadPicks = getSpreadPicks(user);
+            const spreadPicks = picks.filter((p) => p.userName === user && p.pick === 'Spread');
+            // frizat: a user can have both a spread pick AND a separate Over/Under pick for the
+            // same game in a postseason week (O/U isn't counted toward requiredPicks — it's
+            // always a single extra pick tied to that week's one required game). Rather than a
+            // dedicated table column, which breaks "columns == requiredPicks" for every other
+            // week, the O/U pick renders as a second badge alongside the spread pick in that
+            // same required-pick cell.
+            const overUnderPicks = picks.filter((p) => p.userName === user && p.pick !== 'Spread');
             return (
               <TableRow key={user}>
                 <TableCell>
                   <Typography fontWeight={600}>{user}</Typography>
                 </TableCell>
-                {Array.from({ length: requiredPicks }).map((_, idx) => renderCell(`${user}-${idx}`, spreadPicks[idx]))}
-                {hasOverUnder && renderCell(`${user}-ou`, getOverUnderPick(user))}
+                {Array.from({ length: requiredPicks }).map((_, idx) => {
+                  const cellPicks = [spreadPicks[idx], ...(idx === 0 ? overUnderPicks : [])]
+                    .filter((p): p is NflPickDto => Boolean(p?.team));
+                  return (
+                    <TableCell key={idx} align="center">
+                      {cellPicks.length === 0 ? (
+                        <Paper sx={{ height: 76, width: 60, borderRadius: 2 }} />
+                      ) : (
+                        <Box sx={{ display: 'flex', gap: 0.5, justifyContent: 'center' }}>
+                          {cellPicks.map(renderBadge)}
+                        </Box>
+                      )}
+                    </TableCell>
+                  );
+                })}
               </TableRow>
             );
           })}

--- a/Client.React/src/components/sports/GameCard.tsx
+++ b/Client.React/src/components/sports/GameCard.tsx
@@ -93,21 +93,24 @@ export default function GameCard({
   const isLive = gameStatus === 'StatusInProgress' || gameStatus === 'status_in_progress';
   const showScore = mode === 'score' && (isFinal || isLive);
 
-  const pickButtonSx = { minWidth: 80, height: 44, textTransform: 'none', fontSize: '0.85rem', flexShrink: 0 } as const;
+  // frizat: "Picked" (with its checkmark icon) renders ~29px wider than "Pick" at minWidth alone
+  // — since the button sits after the spread value in a right-hugging cluster, that width
+  // difference shifted the value's position between a submitted row and an unsubmitted one. A
+  // fixed `width` (not just minWidth) keeps every pick-state button identical, so the value's
+  // position never depends on which state a given row happens to be in.
+  const pickButtonSx = { width: 112, height: 44, textTransform: 'none', fontSize: '0.85rem', flexShrink: 0 } as const;
 
-  // frizat: a team row's spread/action columns used to be positioned by a flex Stack with
-  // justifyContent="space-between" — whenever a row's record cell was conditionally omitted
-  // (record data unavailable, e.g. every CFB game today, or NFL bye-week/preseason games with no
-  // record yet), the remaining items shifted into different horizontal positions than rows that
-  // did have a record. Since each team row is its own layout container, "auto" column sizing
-  // can't guarantee alignment across rows/cards either — only fixed pixel columns can. The record
-  // cell is always rendered (blank when there's no data) so the column count never changes.
-  const teamRowGridSx = {
-    display: 'grid',
-    gridTemplateColumns: '60px 56px 80px 1fr',
-    alignItems: 'center',
-    columnGap: 1,
-  } as const;
+  // frizat: a rigid fixed-column grid (60/56/80/1fr) made row alignment robust but pinned the
+  // spread value at a fixed offset near the left edge, with a large dead gap before the button —
+  // it read as "left-aligned," not centered, and looked nothing like ScoresPage's own team rows
+  // (a completely separate hand-built layout ScoresPage.tsx uses — GameCard is only ever rendered
+  // in pick mode, never score mode, in the live app). ScoresPage's trick is simpler and more
+  // robust: a flexGrow spacer between the left cluster (logo/record) and the right cluster
+  // (value/action) — the left cluster can vary in width (record present or not) without ever
+  // shifting the right cluster, which always hugs the right edge. The value itself stays
+  // dead-centered within its own fixed-width box, matching what "aligned in the middle" means for
+  // the number itself.
+  const spreadValueSx = { minWidth: 64, textAlign: 'center', flexShrink: 0 } as const;
 
   // MUI's `disabled` state flattens contained (filled) buttons to uniform gray regardless of
   // `color`. Keep the real color at reduced opacity instead of falling back to generic gray.
@@ -137,10 +140,14 @@ export default function GameCard({
     const picked = pickState !== 'none';
     const color = picked ? 'success' : 'info';
     return (
+      // frizat: doesn't share pickButtonSx's fixed width — "Over 45.5 ✓" is much longer than
+      // "Picked" and would overflow/clip a box sized for the shorter label. This row balances via
+      // justifyContent="space-between" across 3 always-present items instead, so it doesn't need
+      // a fixed button width to stay readable.
       <Button
         variant="contained"
         color={color}
-        sx={[pickButtonSx, lockedFillSx(color)]}
+        sx={[{ minWidth: 80, height: 44, textTransform: 'none', fontSize: '0.85rem', flexShrink: 0 }, lockedFillSx(color)]}
         disabled={overUnderLocked && !picked}
         onClick={onPick}
       >
@@ -166,25 +173,24 @@ export default function GameCard({
         {/* Away team row */}
         <Card variant="outlined" sx={{ mb: 1.5 }}>
           <CardContent sx={{ p: '12px !important' }}>
-            <Box sx={teamRowGridSx}>
+            <Stack direction="row" alignItems="center" sx={{ gap: 1 }}>
               {renderTeamLogo(awayTeam, awayJerseyUrl)}
-              <Typography variant="subtitle2">
-                {!isPostSeason ? awayRecord : ''}
-              </Typography>
-              <Typography variant="h6" className="fixed-width" sx={{ textAlign: 'center' }}>
+              {!isPostSeason && awayRecord && (
+                <Typography variant="subtitle2">{awayRecord}</Typography>
+              )}
+              <Box sx={{ flexGrow: 1 }} />
+              <Typography variant="h6" sx={spreadValueSx}>
                 {mode === 'score' && showScore ? awayScore : awaySpread != null ? spreadLabel(awaySpread) : ""}
               </Typography>
-              <Box sx={{ justifySelf: 'end' }}>
-                {mode === 'pick' ? renderPickButton(awayTeam, awayPickState, onPickAway) : (
-                  mode === 'score' && (
-                    <Typography variant="caption" color="text.secondary">
-                      {awaySpread != null ? spreadLabel(awaySpread) : ""}
-                      {awayPickers !== undefined && ` · ${awayPickers}👤`}
-                    </Typography>
-                  )
-                )}
-              </Box>
-            </Box>
+              {mode === 'pick' ? renderPickButton(awayTeam, awayPickState, onPickAway) : (
+                mode === 'score' && (
+                  <Typography variant="caption" color="text.secondary">
+                    {awaySpread != null ? spreadLabel(awaySpread) : ""}
+                    {awayPickers !== undefined && ` · ${awayPickers}👤`}
+                  </Typography>
+                )
+              )}
+            </Stack>
           </CardContent>
         </Card>
 
@@ -212,25 +218,24 @@ export default function GameCard({
         {/* Home team row */}
         <Card variant="outlined">
           <CardContent sx={{ p: '12px !important' }}>
-            <Box sx={teamRowGridSx}>
+            <Stack direction="row" alignItems="center" sx={{ gap: 1 }}>
               {renderTeamLogo(homeTeam, homeJerseyUrl)}
-              <Typography variant="subtitle2">
-                {!isPostSeason ? homeRecord : ''}
-              </Typography>
-              <Typography variant="h6" className="fixed-width" sx={{ textAlign: 'center' }}>
+              {!isPostSeason && homeRecord && (
+                <Typography variant="subtitle2">{homeRecord}</Typography>
+              )}
+              <Box sx={{ flexGrow: 1 }} />
+              <Typography variant="h6" sx={spreadValueSx}>
                 {mode === 'score' && showScore ? homeScore : homeSpread != null ? spreadLabel(homeSpread) : ""}
               </Typography>
-              <Box sx={{ justifySelf: 'end' }}>
-                {mode === 'pick' ? renderPickButton(homeTeam, homePickState, onPickHome) : (
-                  mode === 'score' && (
-                    <Typography variant="caption" color="text.secondary">
-                      {homeSpread != null ? spreadLabel(homeSpread) : ""}
-                      {homePickers !== undefined && ` · ${homePickers}👤`}
-                    </Typography>
-                  )
-                )}
-              </Box>
-            </Box>
+              {mode === 'pick' ? renderPickButton(homeTeam, homePickState, onPickHome) : (
+                mode === 'score' && (
+                  <Typography variant="caption" color="text.secondary">
+                    {homeSpread != null ? spreadLabel(homeSpread) : ""}
+                    {homePickers !== undefined && ` · ${homePickers}👤`}
+                  </Typography>
+                )
+              )}
+            </Stack>
           </CardContent>
         </Card>
 
@@ -248,20 +253,15 @@ export default function GameCard({
             sx={{ mt: 1, p: 0 }}
           >
             <CardContent sx={{ p: '12px !important' }}>
-              {/* Same fixed grid as the team rows above (60/56/80/1fr) so the O/U value lands in
-                  the exact same column as the spread values, instead of centering independently
-                  within this row's own narrower content. */}
-              <Box sx={teamRowGridSx}>
-                <Box sx={{ gridColumn: '1 / 3' }}>
-                  {renderOverUnderButton('Over', overValue, overPickState, onPickOver)}
-                </Box>
-                <Typography variant="h6" className="fixed-width" sx={{ textAlign: 'center', flexShrink: 0 }}>
+              {/* Mirrors ScoresPage's own O/U row (button — value — button, evenly spaced) —
+                  three always-present items balance naturally without needing a spacer. */}
+              <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ gap: 1 }}>
+                {renderOverUnderButton('Over', overValue, overPickState, onPickOver)}
+                <Typography variant="h6" sx={spreadValueSx}>
                   {overValue}
                 </Typography>
-                <Box sx={{ justifySelf: 'end' }}>
-                  {renderOverUnderButton('Under', underValue, underPickState, onPickUnder)}
-                </Box>
-              </Box>
+                {renderOverUnderButton('Under', underValue, underPickState, onPickUnder)}
+              </Stack>
             </CardContent>
           </Card>
         )}

--- a/Client.React/src/components/sports/GameCard.tsx
+++ b/Client.React/src/components/sports/GameCard.tsx
@@ -109,8 +109,10 @@ export default function GameCard({
   // (value/action) — the left cluster can vary in width (record present or not) without ever
   // shifting the right cluster, which always hugs the right edge. The value itself stays
   // dead-centered within its own fixed-width box, matching what "aligned in the middle" means for
-  // the number itself.
+  // the number itself. Typography variant matches ScoresPage's own spread-value text
+  // (subtitle1, not h6) — h6 read visibly larger than Scores' equivalent number.
   const spreadValueSx = { minWidth: 64, textAlign: 'center', flexShrink: 0 } as const;
+  const spreadValueVariant = 'subtitle1' as const;
 
   // MUI's `disabled` state flattens contained (filled) buttons to uniform gray regardless of
   // `color`. Keep the real color at reduced opacity instead of falling back to generic gray.
@@ -171,31 +173,27 @@ export default function GameCard({
     <Card elevation={2} sx={{ height: '100%' }}>
       <CardContent sx={{ pb: '12px !important' }}>
         {/* Away team row */}
-        <Card variant="outlined" sx={{ mb: 1.5 }}>
-          <CardContent sx={{ p: '12px !important' }}>
-            <Stack direction="row" alignItems="center" sx={{ gap: 1 }}>
-              {renderTeamLogo(awayTeam, awayJerseyUrl)}
-              {!isPostSeason && awayRecord && (
-                <Typography variant="subtitle2">{awayRecord}</Typography>
-              )}
-              <Box sx={{ flexGrow: 1 }} />
-              <Typography variant="h6" sx={spreadValueSx}>
-                {mode === 'score' && showScore ? awayScore : awaySpread != null ? spreadLabel(awaySpread) : ""}
+        <Stack direction="row" alignItems="center" sx={{ gap: 1 }}>
+          {renderTeamLogo(awayTeam, awayJerseyUrl)}
+          {!isPostSeason && awayRecord && (
+            <Typography variant="subtitle2">{awayRecord}</Typography>
+          )}
+          <Box sx={{ flexGrow: 1 }} />
+          <Typography variant={spreadValueVariant} sx={spreadValueSx}>
+            {mode === 'score' && showScore ? awayScore : awaySpread != null ? spreadLabel(awaySpread) : ""}
+          </Typography>
+          {mode === 'pick' ? renderPickButton(awayTeam, awayPickState, onPickAway) : (
+            mode === 'score' && (
+              <Typography variant="caption" color="text.secondary">
+                {awaySpread != null ? spreadLabel(awaySpread) : ""}
+                {awayPickers !== undefined && ` · ${awayPickers}👤`}
               </Typography>
-              {mode === 'pick' ? renderPickButton(awayTeam, awayPickState, onPickAway) : (
-                mode === 'score' && (
-                  <Typography variant="caption" color="text.secondary">
-                    {awaySpread != null ? spreadLabel(awaySpread) : ""}
-                    {awayPickers !== undefined && ` · ${awayPickers}👤`}
-                  </Typography>
-                )
-              )}
-            </Stack>
-          </CardContent>
-        </Card>
+            )
+          )}
+        </Stack>
 
         {/* Middle: weather + status/detail */}
-        <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1.5, gap: 1 }}>
+        <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mt: 1.5, gap: 1 }}>
           {weatherDisplayValue ? (
             <WeatherIcon
               iconKey={weatherDisplayValue}
@@ -215,29 +213,27 @@ export default function GameCard({
           </Box>
         </Stack>
 
-        {/* Home team row */}
-        <Card variant="outlined">
-          <CardContent sx={{ p: '12px !important' }}>
-            <Stack direction="row" alignItems="center" sx={{ gap: 1 }}>
-              {renderTeamLogo(homeTeam, homeJerseyUrl)}
-              {!isPostSeason && homeRecord && (
-                <Typography variant="subtitle2">{homeRecord}</Typography>
-              )}
-              <Box sx={{ flexGrow: 1 }} />
-              <Typography variant="h6" sx={spreadValueSx}>
-                {mode === 'score' && showScore ? homeScore : homeSpread != null ? spreadLabel(homeSpread) : ""}
+        {/* Home team row — flat Stack, no nested Card, matching ScoresPage's own team rows
+            (see spreadValueSx comment above): two bordered boxes per game read as separate
+            panels rather than one continuous list, which was the "HUGE"/disjointed feel. */}
+        <Stack direction="row" alignItems="center" sx={{ mt: 1.5, gap: 1 }}>
+          {renderTeamLogo(homeTeam, homeJerseyUrl)}
+          {!isPostSeason && homeRecord && (
+            <Typography variant="subtitle2">{homeRecord}</Typography>
+          )}
+          <Box sx={{ flexGrow: 1 }} />
+          <Typography variant={spreadValueVariant} sx={spreadValueSx}>
+            {mode === 'score' && showScore ? homeScore : homeSpread != null ? spreadLabel(homeSpread) : ""}
+          </Typography>
+          {mode === 'pick' ? renderPickButton(homeTeam, homePickState, onPickHome) : (
+            mode === 'score' && (
+              <Typography variant="caption" color="text.secondary">
+                {homeSpread != null ? spreadLabel(homeSpread) : ""}
+                {homePickers !== undefined && ` · ${homePickers}👤`}
               </Typography>
-              {mode === 'pick' ? renderPickButton(homeTeam, homePickState, onPickHome) : (
-                mode === 'score' && (
-                  <Typography variant="caption" color="text.secondary">
-                    {homeSpread != null ? spreadLabel(homeSpread) : ""}
-                    {homePickers !== undefined && ` · ${homePickers}👤`}
-                  </Typography>
-                )
-              )}
-            </Stack>
-          </CardContent>
-        </Card>
+            )
+          )}
+        </Stack>
 
         {spreadPostedAt && (
           <Typography variant="caption" color="text.secondary" display="block" sx={{ textAlign: 'center', mt: 0.75 }}>
@@ -247,23 +243,17 @@ export default function GameCard({
 
         {/* Postseason O/U picks */}
         {isPostSeason && mode === 'pick' && overValue != null && underValue != null && (
-          <Card
+          <Stack
             data-testid="over-under-controls"
-            variant="outlined"
-            sx={{ mt: 1, p: 0 }}
+            direction="row" alignItems="center" justifyContent="space-between"
+            sx={{ mt: 2, gap: 1 }}
           >
-            <CardContent sx={{ p: '12px !important' }}>
-              {/* Mirrors ScoresPage's own O/U row (button — value — button, evenly spaced) —
-                  three always-present items balance naturally without needing a spacer. */}
-              <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ gap: 1 }}>
-                {renderOverUnderButton('Over', overValue, overPickState, onPickOver)}
-                <Typography variant="h6" sx={spreadValueSx}>
-                  {overValue}
-                </Typography>
-                {renderOverUnderButton('Under', underValue, underPickState, onPickUnder)}
-              </Stack>
-            </CardContent>
-          </Card>
+            {renderOverUnderButton('Over', overValue, overPickState, onPickOver)}
+            <Typography variant={spreadValueVariant} sx={spreadValueSx}>
+              {overValue}
+            </Typography>
+            {renderOverUnderButton('Under', underValue, underPickState, onPickUnder)}
+          </Stack>
         )}
       </CardContent>
     </Card>

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -130,11 +130,15 @@ export default function AppLayout() {
               onDelete={(e) => setMenuAnchor(e.currentTarget)}
               deleteIcon={<ArrowDropDownIcon />}
               variant="outlined"
-              size="small"
+              // frizat: MUI's small Chip is only 24px tall — well under the 44px minimum touch
+              // target (see CLAUDE.md "Dev Environment"). This chip doubles as the league
+              // switcher button in the header, so bump its height explicitly rather than using
+              // size="small"/"medium" (neither MUI Chip size meets 44px).
               sx={{
                 color: 'inherit',
                 borderColor: 'rgba(255,255,255,0.4)',
                 maxWidth: 140,
+                height: 44,
                 '& .MuiChip-label': { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
                 '& .MuiChip-deleteIcon': { color: 'inherit', opacity: 0.7 },
                 '& .MuiChip-deleteIcon:hover': { color: 'inherit', opacity: 1 },
@@ -305,6 +309,7 @@ export default function AppLayout() {
                       component={NavLink}
                       to="/admin/jobManagement"
                       sx={adminNavItemSx}
+                      onClick={() => handleNavClick('/admin/jobManagement')}
                     >
                       <ListItemIcon sx={{ minWidth: 36 }}>
                         <WorkIcon sx={{ fontSize: 20 }} />
@@ -315,6 +320,7 @@ export default function AppLayout() {
                       component={NavLink}
                       to="/admin/users"
                       sx={adminNavItemSx}
+                      onClick={() => handleNavClick('/admin/users')}
                     >
                       <ListItemIcon sx={{ minWidth: 36 }}>
                         <PersonIcon sx={{ fontSize: 20 }} />
@@ -325,6 +331,7 @@ export default function AppLayout() {
                       component={NavLink}
                       to="/admin/invitations"
                       sx={adminNavItemSx}
+                      onClick={() => handleNavClick('/admin/invitations')}
                     >
                       <ListItemIcon sx={{ minWidth: 36 }}>
                         <MailIcon sx={{ fontSize: 20 }} />

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -19,6 +19,7 @@ import { useAuth } from '../services/auth';
 import { getLeaderboard } from '../api/leaderboard';
 import type { LeaderboardDto } from '../types/leaderboard';
 import type { SportAdapter } from '../services/sportAdapter';
+import { stickyColumnSx } from '../utils/tableStyles';
 
 interface LeaderboardPageProps {
   adapter: SportAdapter;
@@ -121,7 +122,7 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
                 <TableHead>
                   <TableRow>
                     <TableCell>Rank</TableCell>
-                    <TableCell>User</TableCell>
+                    <TableCell sx={stickyColumnSx}>User</TableCell>
                     <TableCell>Total</TableCell>
                     {Array.from({ length: maxWeek }).map((_, idx) => (
                       <TableCell key={idx}>{`W${maxWeek - idx}`}</TableCell>
@@ -132,7 +133,7 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
                   {leaderboard.map((row) => (
                     <TableRow key={row.userId} sx={rowClass(row)}>
                       <TableCell>{row.rank}</TableCell>
-                      <TableCell>{row.userName}</TableCell>
+                      <TableCell sx={stickyColumnSx}>{row.userName}</TableCell>
                       <TableCell sx={{ color: getTotalColor(row.total), fontWeight: 'bold' }}>
                         {row.total}
                       </TableCell>

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -51,6 +51,7 @@ import {
 import type { LeagueInfoDto, LeagueJuiceMappingDto, LeagueCostDto, UserSummaryDto } from '../types/admin';
 import type { LeagueUserMappingDto } from '../types/league';
 import { computeLeagueCost } from '../utils/leagueHelpers';
+import { stickyColumnSx } from '../utils/tableStyles';
 
 const CURRENT_SEASON = new Date().getFullYear();
 
@@ -368,7 +369,7 @@ export default function LeaguePortalPage() {
           >
             {leagueOptions.map((l) => (
               <MenuItem key={l.id} value={l.id}>
-                {l.leagueName} {admin && `(${l.leagueType})`}
+                {l.leagueName} {admin && `(${l.leagueType.toUpperCase()})`}
               </MenuItem>
             ))}
           </Select>
@@ -588,7 +589,7 @@ function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInv
           <Table size="small">
             <TableHead>
               <TableRow>
-                <TableCell>Name</TableCell>
+                <TableCell sx={stickyColumnSx}>Name</TableCell>
                 <TableCell>Email</TableCell>
                 <TableCell>Joined</TableCell>
                 <TableCell align="right">Actions</TableCell>
@@ -604,7 +605,7 @@ function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInv
               )}
               {members.map((m) => (
                 <TableRow key={m.id}>
-                  <TableCell>{m.userName ?? m.userId}</TableCell>
+                  <TableCell sx={stickyColumnSx}>{m.userName ?? m.userId}</TableCell>
                   <TableCell>{m.email ?? m.userId}</TableCell>
                   <TableCell>{new Date(m.dateCreated).toLocaleDateString()}</TableCell>
                   <TableCell align="right">
@@ -724,7 +725,7 @@ function InfoTab({ league, isAdmin: admin, onChangeOwner }: { league: LeagueInfo
         </Stack>
         <Stack direction="row" justifyContent="space-between">
           <Typography color="text.secondary">Sport</Typography>
-          <Typography fontWeight={600}>{league.leagueType}</Typography>
+          <Typography fontWeight={600}>{league.leagueType.toUpperCase()}</Typography>
         </Stack>
         <Stack direction="row" justifyContent="space-between">
           <Typography color="text.secondary">Created</Typography>

--- a/Client.React/src/pages/admin/InvitationsPage.tsx
+++ b/Client.React/src/pages/admin/InvitationsPage.tsx
@@ -167,7 +167,7 @@ export default function AdminInvitationsPage() {
                 <MenuItem value=""><em>No league</em></MenuItem>
                 {leagues.map((l) => (
                   <MenuItem key={l.id} value={l.id}>
-                    {l.leagueName} ({l.leagueType})
+                    {l.leagueName} ({l.leagueType.toUpperCase()})
                   </MenuItem>
                 ))}
               </Select>

--- a/Client.React/src/pages/admin/JobManagerPage.tsx
+++ b/Client.React/src/pages/admin/JobManagerPage.tsx
@@ -21,6 +21,7 @@ import PageHeader from '../../components/PageHeader';
 import { getAllJobsStatus, runScores, runSpreads, runUserManager } from '../../api/jobManager';
 import type { JobStatusResponse } from '../../types/admin';
 import { useToast } from '../../services/toast';
+import { stickyColumnSx } from '../../utils/tableStyles';
 
 export default function AdminJobManagerPage() {
   const [jobs, setJobs] = useState<JobStatusResponse[]>([]);
@@ -60,7 +61,7 @@ export default function AdminJobManagerPage() {
 
   return (
     <Box>
-      <PageHeader title="Administrator User Management" />
+      <PageHeader title="Job Manager" />
       <Paper sx={{ p: 3, mb: 3 }}>
         <Typography variant="h5" align="center" sx={{ mb: 2 }}>
           Admin Tasks
@@ -114,7 +115,7 @@ export default function AdminJobManagerPage() {
           <Box sx={{ overflowX: 'auto' }}><Table size="small">
             <TableHead>
               <TableRow>
-                <TableCell>Job Name</TableCell>
+                <TableCell sx={stickyColumnSx}>Job Name</TableCell>
                 <TableCell>Description</TableCell>
                 <TableCell>Status</TableCell>
                 <TableCell>Next Run</TableCell>
@@ -125,7 +126,7 @@ export default function AdminJobManagerPage() {
             <TableBody>
               {jobs.map((job) => (
                 <TableRow key={job.jobName}>
-                  <TableCell>{job.jobName}</TableCell>
+                  <TableCell sx={stickyColumnSx}>{job.jobName}</TableCell>
                   <TableCell>{job.description}</TableCell>
                   <TableCell>
                     <Chip size="small" label={job.status} color={getStatusColor(job.status)} />

--- a/Client.React/src/utils/tableStyles.ts
+++ b/Client.React/src/utils/tableStyles.ts
@@ -1,0 +1,15 @@
+import type { SxProps, Theme } from '@mui/material';
+
+/**
+ * Pins a table's leading identity column (user/team name) in place while the rest of a wide
+ * table scrolls horizontally underneath it — mobile viewports (~390px) can't fit a full data
+ * table, so without this the reader loses track of which row they're looking at once they
+ * scroll right. Needs an opaque background (not the default transparent TableCell) so sibling
+ * cell content doesn't visibly bleed through as it scrolls underneath the pinned column.
+ */
+export const stickyColumnSx: SxProps<Theme> = {
+  position: 'sticky',
+  left: 0,
+  zIndex: 1,
+  backgroundColor: 'background.paper',
+};

--- a/Server/Services/DemoDataSeeder.cs
+++ b/Server/Services/DemoDataSeeder.cs
@@ -729,9 +729,23 @@ public class DemoDataSeeder(
             var patternKey = pickPatterns.ContainsKey(name) ? name : "Alice";
             if (!pickPatterns.TryGetValue(patternKey, out var pattern)) continue;
 
-            // Only seed as many picks as the pattern specifies — pattern.Length = required picks for this round
+            // Only seed as many picks as the pattern specifies — pattern.Length = required picks
+            // for this round. frizat: Over/Under is an alternate pick TYPE, not an additional
+            // pick beyond the week's required count — AddPicks' server-side validation caps total
+            // picks (any type) at GetRequiredPicks(week), so a real user could never submit
+            // pattern.Length spread picks PLUS a separate O/U pick (confirmed via direct DB
+            // query: Bob had 4 rows for NflWeek 19, a 3-required-pick week). Bob/Dana's O/U pick
+            // now replaces their game-0 spread pick instead of adding to it.
             for (int i = 0; i < Math.Min(pattern.Length, games.Length); i++)
             {
+                if (i == 0 && name == "Bob") {
+                    db.NflPicks.Add(new NflPicks { UserId = user.Id, LeagueId = league.Id, Team = games[0].Home, Pick = PickType.Over, NflWeek = week, Season = DemoSeason, NflWeekId = nflWeek.Id, DateCreated = DateTimeOffset.UtcNow });
+                    continue;
+                }
+                if (i == 0 && name == "Dana") {
+                    db.NflPicks.Add(new NflPicks { UserId = user.Id, LeagueId = league.Id, Team = games[0].Home, Pick = PickType.Under, NflWeek = week, Season = DemoSeason, NflWeekId = nflWeek.Id, DateCreated = DateTimeOffset.UtcNow });
+                    continue;
+                }
                 var team = pattern[i] ? games[i].Home : games[i].Away;
                 db.NflPicks.Add(new NflPicks
                 {
@@ -739,11 +753,6 @@ public class DemoDataSeeder(
                     Pick = PickType.Spread, NflWeek = week, Season = DemoSeason,
                     NflWeekId = nflWeek.Id, DateCreated = DateTimeOffset.UtcNow,
                 });
-                // Add Over/Under picks for Bob and Dana so the O/U row is testable in-progress games
-                if (name == "Bob" && i == 0)
-                    db.NflPicks.Add(new NflPicks { UserId = user.Id, LeagueId = league.Id, Team = games[0].Home, Pick = PickType.Over, NflWeek = week, Season = DemoSeason, NflWeekId = nflWeek.Id, DateCreated = DateTimeOffset.UtcNow });
-                if (name == "Dana" && i == 0)
-                    db.NflPicks.Add(new NflPicks { UserId = user.Id, LeagueId = league.Id, Team = games[0].Home, Pick = PickType.Under, NflWeek = week, Season = DemoSeason, NflWeekId = nflWeek.Id, DateCreated = DateTimeOffset.UtcNow });
             }
         }
         await db.SaveChangesAsync();
@@ -1210,13 +1219,17 @@ public class DemoDataSeeder(
     private async Task SeedCfbPicksAsync(LeagueInfo? league, List<CfbSlates> slates)
     {
         if (league == null) return;
-        // 6 users × 65 picks each, except admin (frizat) who has no slate-18 spread pick — see
+        // 6 users × 65 picks each, except admin (frizat) who has no slate-18 pick — see
         // CfbFinalPicks comment (replay E2E needs that slot free):
         // Slates 1-7: 7×4=28, Slate 8: 4, Slates 9-13: 5×4=20, Slate 14 (Conf.Champs): 4
         // Slate 15 (FR): 3, Slate 16 (QF): 3, Slate 17 (SF): 2, Slate 18 (Champ): 1
         // Total per user: 28+4+20+4+3+3+2+1 = 65 → 5×65 + 64 (frizat, no slate-18 pick) = 389
-        // + Bob Over + Dana Under in each postseason slate (14-18) = 10 O/U picks
-        const int ExpectedPickCount = 399; // 389 spread + 10 O/U across all 5 postseason slates
+        // frizat: Over/Under is an alternate pick TYPE for Bob/Dana's first pick in each
+        // postseason slate (14-18), not an additional pick — CfbPicksController's server-side
+        // validation caps total picks (any type) at GetCfbRequiredPicks(slateNumber), so the
+        // count above already accounts for it; O/U doesn't add to the total, just recolors 5 of
+        // Bob's and 5 of Dana's picks from Spread to Over/Under.
+        const int ExpectedPickCount = 389;
         if (await db.CfbPicks.CountAsync(p => p.LeagueId == league.Id) >= ExpectedPickCount) return;
         // Clear any partial seed before re-seeding
         db.CfbPicks.RemoveRange(db.CfbPicks.Where(p => p.LeagueId == league.Id));
@@ -1227,11 +1240,24 @@ public class DemoDataSeeder(
         void AddPick(int leagueId, string userId, int slateId, int eventId, string team) =>
             picks.Add(new CfbPicks { UserId = userId, LeagueId = leagueId, CfbSlateId = slateId, EspnEventId = eventId, Team = team, PickType = "Spread", Season = CfbDemoSeason });
 
-        void AddOverUnder(string uName, string userId, int slateId, int eventId, string homeTeam) {
-            if (uName == "Bob")
+        // frizat: Over/Under is an alternate PICK TYPE for a game, not an additional pick beyond
+        // the slate's required count — CfbPicksController's server-side validation enforces total
+        // picks (any type) <= GetCfbRequiredPicks(slateNumber), so a real user can never submit
+        // more picks than required. This used to call AddPick for every game INCLUDING game 0,
+        // then separately add an O/U pick for Bob/Dana on that same game — giving them
+        // requiredPicks+1 total picks, which no real submission could ever produce (confirmed via
+        // direct DB query: Bob had 4 rows for a 3-required-pick week). Bob/Dana's O/U pick now
+        // replaces their game-0 spread pick instead of adding to it.
+        void AddFirstPickOrOverUnder(string uName, string userId, int slateId, int eventId, string homeTeam, string pickedTeam) {
+            if (uName == "Bob") {
                 picks.Add(new CfbPicks { UserId = userId, LeagueId = league.Id, CfbSlateId = slateId, EspnEventId = eventId, Team = homeTeam, PickType = "Over", Season = CfbDemoSeason });
-            if (uName == "Dana")
+                return;
+            }
+            if (uName == "Dana") {
                 picks.Add(new CfbPicks { UserId = userId, LeagueId = league.Id, CfbSlateId = slateId, EspnEventId = eventId, Team = homeTeam, PickType = "Under", Season = CfbDemoSeason });
+                return;
+            }
+            AddPick(league.Id, userId, slateId, eventId, pickedTeam);
         }
 
         var seedUsernames = DemoUsers.Select(d => d.Username).Append("frizat");
@@ -1277,48 +1303,57 @@ public class DemoDataSeeder(
                 }
             }
 
-            // Slate 14: Conference Championships — 4 picks + O/U for Bob/Dana
+            // Slate 14: Conference Championships — 4 picks total (Bob/Dana's first pick is O/U instead of spread)
             if (CfbConfChampPicks.TryGetValue(username, out var confPattern) && slates.FirstOrDefault(s => s.SlateNumber == 14) is { } slate14Champ)
             {
-                for (int i = 0; i < Math.Min(confPattern.Length, Slate15Games.Length); i++)
-                    AddPick(league.Id, user.Id, slate14Champ.Id, Slate15Games[i].EventId, confPattern[i] ? Slate15Games[i].Home : Slate15Games[i].Away);
-                AddOverUnder(username, user.Id, slate14Champ.Id, Slate15Games[0].EventId, Slate15Games[0].Home);
+                for (int i = 0; i < Math.Min(confPattern.Length, Slate15Games.Length); i++) {
+                    var team = confPattern[i] ? Slate15Games[i].Home : Slate15Games[i].Away;
+                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slate14Champ.Id, Slate15Games[0].EventId, Slate15Games[0].Home, team);
+                    else AddPick(league.Id, user.Id, slate14Champ.Id, Slate15Games[i].EventId, team);
+                }
             }
 
-            // CFP First Round (slate 15): 3 picks + O/U for Bob/Dana
+            // CFP First Round (slate 15): 3 picks total (Bob/Dana's first pick is O/U instead of spread)
             if (CfbFirstRoundPicks.TryGetValue(username, out var fr15Pattern) && slates.FirstOrDefault(s => s.SlateNumber == 15) is { } slate15)
             {
                 var fr15Games = CfpGames.Where(g => g.SlateIdx == 15).ToArray();
-                for (int i = 0; i < Math.Min(fr15Pattern.Length, fr15Games.Length); i++)
-                    AddPick(league.Id, user.Id, slate15.Id, fr15Games[i].EventId, fr15Pattern[i] ? fr15Games[i].Home : fr15Games[i].Away);
-                AddOverUnder(username, user.Id, slate15.Id, fr15Games[0].EventId, fr15Games[0].Home);
+                for (int i = 0; i < Math.Min(fr15Pattern.Length, fr15Games.Length); i++) {
+                    var team = fr15Pattern[i] ? fr15Games[i].Home : fr15Games[i].Away;
+                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slate15.Id, fr15Games[0].EventId, fr15Games[0].Home, team);
+                    else AddPick(league.Id, user.Id, slate15.Id, fr15Games[i].EventId, team);
+                }
             }
 
-            // CFP Quarterfinals (slate 16): 3 picks + O/U for Bob/Dana
+            // CFP Quarterfinals (slate 16): 3 picks total (Bob/Dana's first pick is O/U instead of spread)
             if (CfbQfPicks.TryGetValue(username, out var qf) && slates.FirstOrDefault(s => s.SlateNumber == 16) is { } slateQf)
             {
                 var qfGames = CfpGames.Where(g => g.SlateIdx == 16).ToArray();
-                for (int i = 0; i < Math.Min(qf.Length, qfGames.Length); i++)
-                    AddPick(league.Id, user.Id, slateQf.Id, qfGames[i].EventId, qf[i] ? qfGames[i].Home : qfGames[i].Away);
-                AddOverUnder(username, user.Id, slateQf.Id, qfGames[0].EventId, qfGames[0].Home);
+                for (int i = 0; i < Math.Min(qf.Length, qfGames.Length); i++) {
+                    var team = qf[i] ? qfGames[i].Home : qfGames[i].Away;
+                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slateQf.Id, qfGames[0].EventId, qfGames[0].Home, team);
+                    else AddPick(league.Id, user.Id, slateQf.Id, qfGames[i].EventId, team);
+                }
             }
 
-            // CFP Semifinals (slate 17): 2 picks + O/U for Bob/Dana
+            // CFP Semifinals (slate 17): 2 picks total (Bob/Dana's first pick is O/U instead of spread)
             if (CfbSfPicks.TryGetValue(username, out var sf) && slates.FirstOrDefault(s => s.SlateNumber == 17) is { } slateSf)
             {
                 var sfGames = CfpGames.Where(g => g.SlateIdx == 17).ToArray();
-                for (int i = 0; i < Math.Min(sf.Length, sfGames.Length); i++)
-                    AddPick(league.Id, user.Id, slateSf.Id, sfGames[i].EventId, sf[i] ? sfGames[i].Home : sfGames[i].Away);
-                AddOverUnder(username, user.Id, slateSf.Id, sfGames[0].EventId, sfGames[0].Home);
+                for (int i = 0; i < Math.Min(sf.Length, sfGames.Length); i++) {
+                    var team = sf[i] ? sfGames[i].Home : sfGames[i].Away;
+                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slateSf.Id, sfGames[0].EventId, sfGames[0].Home, team);
+                    else AddPick(league.Id, user.Id, slateSf.Id, sfGames[i].EventId, team);
+                }
             }
 
-            // CFP Championship (slate 18): 1 spread pick + O/U for Bob/Dana (in-progress game)
+            // CFP Championship (slate 18): 1 pick total — Bob/Dana's is O/U instead of spread
             if (slates.FirstOrDefault(s => s.SlateNumber == 18) is { } slateFinal)
             {
                 var finalGame = CfpGames.First(g => g.SlateIdx == 18);
-                if (CfbFinalPicks.TryGetValue(username, out var final))
-                    AddPick(league.Id, user.Id, slateFinal.Id, finalGame.EventId, final ? finalGame.Home : finalGame.Away);
-                AddOverUnder(username, user.Id, slateFinal.Id, finalGame.EventId, finalGame.Home);
+                if (CfbFinalPicks.TryGetValue(username, out var final)) {
+                    var team = final ? finalGame.Home : finalGame.Away;
+                    AddFirstPickOrOverUnder(username, user.Id, slateFinal.Id, finalGame.EventId, finalGame.Home, team);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
Promotes dev to main: matrix/demo-data pick-count fix, Picks/Scores alignment, and mobile UX audit.

- #206 — revert matrix column, rebuild Picks alignment on ScoresPage pattern
- #207 — fix(demo/matrix): seeder must never produce more picks than a week allows
- #208 — fix(ui): flatten GameCard team rows to match ScoresPage's proven layout
- #209 — fix(mobile): pin identity columns, fix touch targets, contrast, and casing across mobile UI

## Test plan
- [x] Each PR passed its own full CI suite individually (backend, frontend, mocked e2e, demo e2e, replay e2e) before merging to dev
- [x] Scoped UI/data fixes, not a season-launch cutover — full manual `/prod-live-test` gate skipped per off-season constraints (no live games available), matching the prior dev→main promotion (#205)

🤖 Generated with [Claude Code](https://claude.com/claude-code)