### PR TITLE
fix(dev): document COOKIE_DOMAIN for local cross-subdomain login

### DIFF
--- a/.env.backend.example
+++ b/.env.backend.example
@@ -16,3 +16,7 @@ ADMIN_USERNAME=frizat
 ADMIN_PASSWORD=DemoPass@123
 
 APP_URL=http://localhost:5174
+# Lets a login on localhost:5174 (NFL) carry over to cfb.localhost:5174 (CFB), matching
+# prod/staging's cross-subdomain cookie sharing (ivleague.com / cfb.ivleague.com) — without
+# this, each subdomain needs its own separate login since cookies default to host-only.
+COOKIE_DOMAIN=.localhost


### PR DESCRIPTION
## Summary
Local dev's \`.env.backend.example\` never documented \`COOKIE_DOMAIN\`, even though prod/staging Railway already sets it (confirmed via \`railway list-variables\` on both environments) so a login on \`ivleague.com\` carries over to \`cfb.ivleague.com\`. Without it locally, \`AuthToken\` is a host-only cookie — a login on \`localhost:5174\` never reaches \`cfb.localhost:5174\`, forcing a separate login per subdomain and making it look like leagues silently disappeared.

## Test plan
- [x] Verified via \`curl -i\` against the local backend: with \`COOKIE_DOMAIN=.localhost\` set, \`POST /api/auth/login\` now returns \`Set-Cookie: AuthToken=...; domain=.localhost\` (previously host-only, no \`domain\` attribute)
- [x] Decoded the returned JWT — correct current admin user ID, confirming the cookie is live and valid, not just present

Doc-only change to \`.env.backend.example\` (\`.env.backend\` itself is gitignored, local-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)