### PR TITLE
Promote dev to main — PRs #211-#212

### DIFF
--- a/.env.backend.example
+++ b/.env.backend.example
@@ -16,3 +16,7 @@ ADMIN_USERNAME=frizat
 ADMIN_PASSWORD=DemoPass@123
 
 APP_URL=http://localhost:5174
+# Lets a login on localhost:5174 (NFL) carry over to cfb.localhost:5174 (CFB), matching
+# prod/staging's cross-subdomain cookie sharing (ivleague.com / cfb.ivleague.com) — without
+# this, each subdomain needs its own separate login since cookies default to host-only.
+COOKIE_DOMAIN=.localhost

--- a/.env.backend.example
+++ b/.env.backend.example
@@ -16,7 +16,9 @@ ADMIN_USERNAME=frizat
 ADMIN_PASSWORD=DemoPass@123
 
 APP_URL=http://localhost:5174
-# Lets a login on localhost:5174 (NFL) carry over to cfb.localhost:5174 (CFB), matching
-# prod/staging's cross-subdomain cookie sharing (ivleague.com / cfb.ivleague.com) — without
-# this, each subdomain needs its own separate login since cookies default to host-only.
-COOKIE_DOMAIN=.localhost
+# Do NOT set COOKIE_DOMAIN locally. Prod/staging set it (e.g. .ivleague.com) so a login on
+# ivleague.com carries over to cfb.ivleague.com — that works because .ivleague.com is a real
+# multi-label domain. Chrome specifically refuses to store a cookie scoped to ".localhost"
+# (treats it like a public suffix, similar to ".com") — setting COOKIE_DOMAIN=.localhost here
+# doesn't share the login across subdomains, it silently breaks login entirely, on every host.
+# Log in separately on localhost:5174 and cfb.localhost:5174 for local dev.

--- a/Client.React/src/__tests__/RulesPage.test.tsx
+++ b/Client.React/src/__tests__/RulesPage.test.tsx
@@ -225,4 +225,18 @@ describe('RulesPage — spread lock section', () => {
     expect(upcoming).toHaveStyle({ fontWeight: 600 });
     expect(past).toHaveStyle({ fontWeight: 400 });
   });
+
+  it('shows a "Next" chip only on the highlighted upcoming week', async () => {
+    vi.mocked(useSportContext).mockReturnValue({ sport: 'NFL', isCfb: false, isNfl: true });
+    vi.mocked(getNflSpreadLockSchedule).mockResolvedValue([
+      { weekLabel: 'Past Week', spreadLockDatetime: '2020-01-01T00:00:00Z' },
+      { weekLabel: 'Upcoming Week', spreadLockDatetime: '2099-01-01T00:00:00Z' },
+    ]);
+    renderPage();
+
+    await screen.findByText('Upcoming Week');
+    expect(screen.getByText('Next')).toBeInTheDocument();
+    // Exactly one "Next" chip — not one per row.
+    expect(screen.getAllByText('Next')).toHaveLength(1);
+  });
 });

--- a/Client.React/src/pages/RulesPage.tsx
+++ b/Client.React/src/pages/RulesPage.tsx
@@ -361,16 +361,31 @@ function SpreadLockSchedule({ isCfb }: { isCfb: boolean }) {
           sx={{
             display: 'flex',
             justifyContent: 'space-between',
+            alignItems: 'center',
             gap: 2,
             px: 2,
             py: 1,
-            bgcolor: i === upcomingIndex ? 'action.selected' : 'transparent',
+            // frizat: plain `action.selected` (a faint ~8% gray overlay by default) read as no
+            // highlight at all, especially in dark mode — reuse RuleRow's own info-tint formula
+            // above so "next lock" reads with the same visual language as this page's other info
+            // callouts, plus a border to make the row's extent unambiguous at a glance.
+            ...(i === upcomingIndex && {
+              backgroundColor: (t) =>
+                t.palette.mode === 'dark' ? 'rgba(59,130,246,0.14)' : 'rgba(59,130,246,0.08)',
+              borderLeft: '3px solid',
+              borderColor: 'info.main',
+            }),
             '&:not(:last-child)': { borderBottom: '1px solid', borderColor: 'divider' },
           }}
         >
-          <Typography variant="body2" fontWeight={i === upcomingIndex ? 600 : 400}>
-            {w.weekLabel}
-          </Typography>
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <Typography variant="body2" fontWeight={i === upcomingIndex ? 600 : 400}>
+              {w.weekLabel}
+            </Typography>
+            {i === upcomingIndex && (
+              <Chip label="Next" size="small" color="info" sx={{ height: 20, fontSize: '0.7rem' }} />
+            )}
+          </Stack>
           <Typography
             variant="body2"
             color={i === upcomingIndex ? 'text.primary' : 'text.secondary'}


### PR DESCRIPTION
## Summary
Promotes dev to main: Rules page "Next" week highlight, revert of broken local-only COOKIE_DOMAIN guidance, and the .env.backend.example doc fix.

- #211 — fix(dev): document COOKIE_DOMAIN for local cross-subdomain login
- #212 — fix(rules): highlight next spread-lock week; revert broken local COOKIE_DOMAIN guidance

## Test plan
- [x] Each PR passed its own full CI suite individually before merging to dev
- [x] Scoped fixes, not a season-launch cutover — full manual `/prod-live-test` gate skipped per off-season constraints, matching prior promotions (#205, #210)

🤖 Generated with [Claude Code](https://claude.com/claude-code)