### PR TITLE
feat(rules): explain Over/Under in the postseason with NFL/CFB examples

### DIFF
--- a/Client.React/src/__tests__/RulesPage.test.tsx
+++ b/Client.React/src/__tests__/RulesPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 import { useSportContext } from '../services/sport';
@@ -86,15 +86,16 @@ describe('RulesPage — NFL', () => {
 
   it('shows all four NFL playoff rounds', () => {
     renderPage();
-    expect(screen.getByText(/wild card/i)).toBeInTheDocument();
-    expect(screen.getByText(/divisional/i)).toBeInTheDocument();
-    expect(screen.getByText(/championship/i)).toBeInTheDocument();
-    expect(screen.getByText(/super bowl/i)).toBeInTheDocument();
+    const grid = within(screen.getByTestId('playoff-grid'));
+    expect(grid.getByText(/wild card/i)).toBeInTheDocument();
+    expect(grid.getByText(/divisional/i)).toBeInTheDocument();
+    expect(grid.getByText(/championship/i)).toBeInTheDocument();
+    expect(grid.getByText(/super bowl/i)).toBeInTheDocument();
   });
 
   it('shows correct Wild Card required picks (3)', () => {
     renderPage();
-    const wildCardSection = screen.getByText(/wild card/i).closest('div');
+    const wildCardSection = within(screen.getByTestId('playoff-grid')).getByText(/wild card/i).closest('div');
     expect(wildCardSection).toHaveTextContent('3');
   });
 
@@ -107,6 +108,35 @@ describe('RulesPage — NFL', () => {
   it('mentions server-side enforcement of deadlines', () => {
     renderPage();
     expect(screen.getByText(/enforced server-side/i)).toBeInTheDocument();
+  });
+});
+
+describe('RulesPage — Over/Under in the postseason', () => {
+  it('explains Over/Under replaces a pick rather than adding one (NFL)', () => {
+    vi.mocked(useSportContext).mockReturnValue({ sport: 'NFL', isCfb: false, isNfl: true });
+    renderPage();
+    expect(screen.getByText(/over\/under in the postseason/i)).toBeInTheDocument();
+    expect(screen.getByText(/replaces/i)).toBeInTheDocument();
+    expect(screen.getByText(/not 4/i)).toBeInTheDocument();
+  });
+
+  it('shows an NFL example with exactly one Over/Under pick among the required picks', () => {
+    vi.mocked(useSportContext).mockReturnValue({ sport: 'NFL', isCfb: false, isNfl: true });
+    renderPage();
+    const example = within(screen.getByTestId('over-under-example'));
+    expect(example.getByText(/wild card · 3 picks required/i)).toBeInTheDocument();
+    expect(example.getAllByText('Spread')).toHaveLength(2);
+    expect(example.getAllByText('Over/Under')).toHaveLength(1);
+  });
+
+  it('shows a CFB example with exactly one Over/Under pick among the required picks', () => {
+    vi.mocked(useSportContext).mockReturnValue({ sport: 'CFB', isCfb: true, isNfl: false });
+    renderPage();
+    const example = within(screen.getByTestId('over-under-example'));
+    expect(example.getByText(/cfp first round · 3 picks required/i)).toBeInTheDocument();
+    expect(example.getAllByText('Spread')).toHaveLength(2);
+    expect(example.getAllByText('Over/Under')).toHaveLength(1);
+    expect(screen.getByText(/not 4/i)).toBeInTheDocument();
   });
 });
 
@@ -128,7 +158,7 @@ describe('RulesPage — CFB playoff grid', () => {
 
   it('shows First Round with 3 picks', () => {
     renderPage();
-    const section = screen.getByText(/first round/i).closest('div');
+    const section = within(screen.getByTestId('playoff-grid')).getByText(/first round/i).closest('div');
     expect(section).toHaveTextContent('3');
   });
 
@@ -148,11 +178,12 @@ describe('RulesPage — CFB playoff grid', () => {
 
   it('shows 5 CFB rounds, not 4 NFL rounds', () => {
     renderPage();
-    expect(screen.getByText(/conf\. championships/i)).toBeInTheDocument();
-    expect(screen.getByText(/first round/i)).toBeInTheDocument();
-    expect(screen.getByText(/quarterfinals/i)).toBeInTheDocument();
-    expect(screen.getByText(/semifinals/i)).toBeInTheDocument();
-    // NFL-specific rounds should not appear
+    const grid = within(screen.getByTestId('playoff-grid'));
+    expect(grid.getByText(/conf\. championships/i)).toBeInTheDocument();
+    expect(grid.getByText(/first round/i)).toBeInTheDocument();
+    expect(grid.getByText(/quarterfinals/i)).toBeInTheDocument();
+    expect(grid.getByText(/semifinals/i)).toBeInTheDocument();
+    // NFL-specific rounds should not appear anywhere on the page
     expect(screen.queryByText(/wild card/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/super bowl/i)).not.toBeInTheDocument();
   });

--- a/Client.React/src/pages/RulesPage.tsx
+++ b/Client.React/src/pages/RulesPage.tsx
@@ -170,6 +170,80 @@ function MatchupExample() {
   );
 }
 
+// frizat: Over/Under is an alternate pick TYPE for one game, not an additional pick beyond
+// requiredPicks — AddPicks'/CfbPicksController's server-side validation caps total picks (any
+// type) at requiredPicks for that round. This example exists specifically because that rule was
+// once violated in seeded demo data (a user showing requiredPicks+1 total picks), which read as a
+// UI bug until traced back to the data itself — the Rules page should state the rule plainly so
+// it's never ambiguous again.
+function OverUnderExample() {
+  const { isCfb } = useSportContext();
+  const roundLabel = isCfb ? 'CFP First Round' : 'Wild Card';
+  const requiredPicks = isCfb ? getCfbRequiredPicks(15) : getEspnRequiredPicks(1, true);
+  const picks = isCfb
+    ? [
+        { type: 'spread' as const, label: 'Ohio State Buckeyes', detail: 'Teased line +8.5' },
+        { type: 'spread' as const, label: 'Michigan Wolverines', detail: 'Teased line +17.5' },
+        { type: 'overUnder' as const, label: 'Over 54.5', detail: 'Georgia @ Texas total' },
+      ]
+    : [
+        { type: 'spread' as const, label: 'Seattle Seahawks', detail: 'Teased line +8.5' },
+        { type: 'spread' as const, label: 'Chicago Bears', detail: 'Teased line +17.5' },
+        { type: 'overUnder' as const, label: 'Over 45.5', detail: 'Buffalo @ Kansas City total' },
+      ];
+
+  return (
+    <Paper variant="outlined" sx={{ overflow: 'hidden', borderRadius: 2 }} data-testid="over-under-example">
+      <Box
+        sx={{
+          px: 2,
+          py: 1,
+          bgcolor: 'action.hover',
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+        }}
+      >
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ letterSpacing: '0.06em', textTransform: 'uppercase' }}
+        >
+          {roundLabel} · {requiredPicks} picks required
+        </Typography>
+      </Box>
+      {picks.map((p, i) => (
+        <Box
+          key={p.label}
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            px: 2,
+            py: 1.25,
+            borderBottom: i < picks.length - 1 ? '1px solid' : 'none',
+            borderColor: 'divider',
+          }}
+        >
+          <Box>
+            <Typography variant="body2" fontWeight={500}>
+              Pick {i + 1}: {p.label}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {p.detail}
+            </Typography>
+          </Box>
+          <Chip
+            label={p.type === 'overUnder' ? 'Over/Under' : 'Spread'}
+            size="small"
+            color={p.type === 'overUnder' ? 'info' : 'default'}
+            variant="outlined"
+          />
+        </Box>
+      ))}
+    </Paper>
+  );
+}
+
 function ScenarioExample() {
   const { isCfb } = useSportContext();
   const rows = isCfb
@@ -276,7 +350,7 @@ function PlayoffGrid() {
       ];
 
   return (
-    <Grid container spacing={1}>
+    <Grid container spacing={1} data-testid="playoff-grid">
       {rounds.map(({ round, picks }) => (
         <Grid size={6} key={round}>
           <Box sx={{ bgcolor: 'action.hover', borderRadius: 1.5, p: 1.5 }}>
@@ -542,6 +616,35 @@ export function RulesContent() {
           Fewer games each round means fewer required picks.
         </Typography>
         <PlayoffGrid />
+      </Box>
+
+      <Divider />
+
+      {/* Over/Under in the postseason */}
+      <Box>
+        <SectionLabel>Over/Under in the postseason</SectionLabel>
+        <Paper variant="outlined" sx={{ borderRadius: 2, p: 1.5 }}>
+          <RuleRow color="info">
+            Starting in the postseason, one of your required picks each week can be an{' '}
+            <strong>Over/Under</strong> total on any game instead of a side of the spread — pick
+            whether the combined score finishes above or below the posted number.
+          </RuleRow>
+          <RuleRow color="secondary">
+            Over/Under <strong>replaces</strong> one of your spread picks — it&apos;s never an
+            extra pick added on top. Your total number of picks for the week never changes, no
+            matter how many of them are Over/Under.
+          </RuleRow>
+          <RuleRow color="error">
+            An Over/Under pick counts exactly like a spread pick toward winning the week — get it
+            wrong and it&apos;s the same as missing any other pick.
+          </RuleRow>
+        </Paper>
+        <OverUnderExample />
+        <InfoCallout>
+          {isCfb
+            ? 'CFP First Round needs 3 correct picks. Two spread picks plus one Over/Under is still 3 total picks — not 4.'
+            : 'Wild Card needs 3 correct picks. Two spread picks plus one Over/Under is still 3 total picks — not 4.'}
+        </InfoCallout>
       </Box>
     </Stack>
   );


### PR DESCRIPTION
## Summary
New Rules page section: "Over/Under in the postseason." Explains the rule this session traced a real demo-data bug back to (PR #207) — Over/Under is an alternate pick **type** for one game, not an additional pick beyond that round's required count. Server-side validation already enforces this (`AddPicks`/`CfbPicksController` cap total picks at `requiredPicks`); the Rules page just never said so explicitly.

Includes a worked example per sport (NFL Wild Card, CFB CFP First Round) showing 2 spread picks + 1 Over/Under still totaling exactly `requiredPicks` (3), not 4.

## Test plan
- [x] `npm run test -- --run` — 291 passed (added 3 new tests for the section + fixed 3 pre-existing tests that now correctly scope to the playoff-grid/example containers, since round names like "Wild Card"/"First Round" legitimately appear twice on the page now)
- [x] `npm run test:e2e -- --project=chromium` — 53 passed
- [x] Verified visually in Chrome for both NFL and CFB (light theme) — example renders correctly, chips clearly distinguish Spread vs Over/Under picks

🤖 Generated with [Claude Code](https://claude.com/claude-code)