### PR TITLE
feat(cfb): remove EspnEventId, key on (CfbSlateId, HomeTeam) matching NFL

### DIFF
--- a/Client.React/src/__tests__/cfbAdapter.test.ts
+++ b/Client.React/src/__tests__/cfbAdapter.test.ts
@@ -20,7 +20,7 @@ vi.mock('../api/espn', () => ({
   getCfbLiveGames: vi.fn(),
 }));
 
-import { getCfbCurrentSlate, getCfbSlates, getCfbSpreads, getCfbScores, getCfbUserPicks } from '../api/cfb';
+import { getCfbCurrentSlate, getCfbSlates, getCfbSpreads, getCfbScores, getCfbUserPicks, addCfbPicks } from '../api/cfb';
 import { loadCfbScoresWithRetry, getCfbLiveGames } from '../api/espn';
 
 const slate: CfbSlateDto = {
@@ -28,7 +28,7 @@ const slate: CfbSlateDto = {
   slateType: 'RegularSeason', startDate: '2026-10-20', endDate: '2026-10-26',
 };
 const spread: CfbSpreadDto = {
-  id: 1, cfbSlateId: 10, espnEventId: 999, homeTeam: 'MICH', awayTeam: 'PSU',
+  id: 1, cfbSlateId: 10, homeTeam: 'MICH', awayTeam: 'PSU',
   homeTeamSpread: -3.5, awayTeamSpread: 3.5, overUnder: 44.5,
   gameTime: '2025-10-11T20:00:00Z', dateCreated: '2025-10-09T14:00:00Z',
 };
@@ -86,7 +86,7 @@ describe('cfbAdapter', () => {
       expect(game.homeScore).toBe(27);
       expect(game.awayScore).toBe(13);
       expect(game.gameStatus).toBe('final');
-      expect(game.id).toBe('999');
+      expect(game.id).toBe('MICH');
       expect(game.spreadPostedAt).toBe('2025-10-09T14:00:00Z');
     });
 
@@ -110,10 +110,10 @@ describe('cfbAdapter', () => {
       expect(result.hasOdds).toBe(false);
     });
 
-    it('maps CfbPickDto to PickView with stringified gameId', async () => {
+    it('maps a home-team CfbPickDto to PickView with gameId = homeTeam', async () => {
       const pick: CfbPickDto = {
         id: 1, userId: 'user1', userName: 'user1', leagueId: 1, cfbSlateId: 10,
-        espnEventId: 999, team: 'MICH', pickType: 'Spread', season: 2026,
+        team: 'MICH', pickType: 'Spread', season: 2026,
       };
       vi.mocked(getCfbSlates).mockResolvedValue([slate]);
       vi.mocked(getCfbSpreads).mockResolvedValue([spread]);
@@ -122,9 +122,29 @@ describe('cfbAdapter', () => {
 
       const result = await adapter.loadCurrentGames(1, 'user1');
       expect(result.userPicks).toHaveLength(1);
-      expect(result.userPicks[0].gameId).toBe('999');
+      expect(result.userPicks[0].gameId).toBe('MICH');
       expect(result.userPicks[0].team).toBe('MICH');
       expect(result.userPicks[0].pickType).toBe('Spread');
+    });
+
+    // frizat: CfbPicks.Team can be the AWAY side — since GameView.id is always the game's home
+    // team (a team plays at most one game per slate, so homeTeam alone is the join key), a pick
+    // on the away side must still resolve gameId back to the home team, not to pick.team itself,
+    // or it would never match GameView.id in ScoresPage's pickCountForTeam/didUserPick lookups.
+    it('maps an away-team CfbPickDto to PickView with gameId = the game\'s homeTeam, not the picked team', async () => {
+      const pick: CfbPickDto = {
+        id: 2, userId: 'user1', userName: 'user1', leagueId: 1, cfbSlateId: 10,
+        team: 'PSU', pickType: 'Spread', season: 2026,
+      };
+      vi.mocked(getCfbSlates).mockResolvedValue([slate]);
+      vi.mocked(getCfbSpreads).mockResolvedValue([spread]);
+      vi.mocked(loadCfbScoresWithRetry).mockResolvedValue(espnFinalGame);
+      vi.mocked(getCfbUserPicks).mockResolvedValue([pick]);
+
+      const result = await adapter.loadCurrentGames(1, 'user1');
+      expect(result.userPicks).toHaveLength(1);
+      expect(result.userPicks[0].gameId).toBe('MICH');
+      expect(result.userPicks[0].team).toBe('PSU');
     });
 
     it('derives WeekState from slate slateNumber', async () => {
@@ -148,6 +168,23 @@ describe('cfbAdapter', () => {
       const result = await adapter.loadCurrentGames(1, 'user1');
       expect(result.games[0].gameStatus).toBe('scheduled');
       expect(result.games[0].homeScore).toBeNull();
+    });
+  });
+
+  describe('submitPicks', () => {
+    // frizat: the request payload no longer carries an ESPN event id — just team + pickType,
+    // matching NFL's submitPicks shape exactly (no per-pick game-id field at all).
+    it('sends only team and pickType, no espnEventId, per pick', async () => {
+      vi.mocked(getCfbSlates).mockResolvedValue([slate]);
+      vi.mocked(addCfbPicks).mockResolvedValue({ added: 1 });
+
+      await adapter.submitPicks(1, { season: 2026, week: 8, isPostSeason: false }, [
+        { gameId: 'MICH', team: 'MICH', pickType: 'Spread' },
+      ]);
+
+      expect(addCfbPicks).toHaveBeenCalledWith(1, slate.id, 2026, [
+        { team: 'MICH', pickType: 'Spread' },
+      ]);
     });
   });
 

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -381,7 +381,7 @@ describe('ScoresPage', () => {
     // cache entries" is that once CFB's OWN query settles, ITS data (MICH/PSU) is what renders,
     // not that NFL's cache entry got clobbered or that a spinner necessarily appears.
     const cfbSlate = { id: 1, season: 2025, slateNumber: 8, label: 'Week 8', slateType: 'RegularSeason', startDate: '2025-10-11', endDate: '2025-10-18' };
-    const cfbSpread = { id: 1, cfbSlateId: 1, espnEventId: 100, homeTeam: 'MICH', awayTeam: 'PSU', homeTeamSpread: -3.5, awayTeamSpread: 3.5, overUnder: 44.5, gameTime: '2025-10-11T20:00:00Z', dateCreated: '2025-10-09T14:00:00Z' };
+    const cfbSpread = { id: 1, cfbSlateId: 1, homeTeam: 'MICH', awayTeam: 'PSU', homeTeamSpread: -3.5, awayTeamSpread: 3.5, overUnder: 44.5, gameTime: '2025-10-11T20:00:00Z', dateCreated: '2025-10-09T14:00:00Z' };
     mockedGetCfbCurrentSlate.mockResolvedValue(cfbSlate);
     mockedGetCfbSlates.mockResolvedValue([cfbSlate]);
     mockedGetCfbSpreads.mockResolvedValue([cfbSpread]);

--- a/Client.React/src/__tests__/sharedPickLayout.test.tsx
+++ b/Client.React/src/__tests__/sharedPickLayout.test.tsx
@@ -90,7 +90,7 @@ import { getCfbCurrentSlate, getCfbSlates, getCfbSpreads, getCfbScores, getCfbUs
 import { loadCfbScoresWithRetry, getCfbLiveGames } from '../api/espn';
 
 const slate: CfbSlateDto = { id: 1, season: 2025, slateNumber: 8, label: 'Week 8', slateType: 'RegularSeason', startDate: '2025-10-11', endDate: '2025-10-18' };
-const spread: CfbSpreadDto = { id: 1, cfbSlateId: 1, espnEventId: 100, homeTeam: 'MICH', awayTeam: 'PSU', homeTeamSpread: -3.5, awayTeamSpread: 3.5, overUnder: 44.5, gameTime: '2030-10-11T20:00:00Z', dateCreated: '2030-10-09T14:00:00Z' };
+const spread: CfbSpreadDto = { id: 1, cfbSlateId: 1, homeTeam: 'MICH', awayTeam: 'PSU', homeTeamSpread: -3.5, awayTeamSpread: 3.5, overUnder: 44.5, gameTime: '2030-10-11T20:00:00Z', dateCreated: '2030-10-09T14:00:00Z' };
 
 describe('CFB PicksPage (via adapter) — GameCard layout regression', () => {
   beforeEach(() => {
@@ -128,7 +128,7 @@ describe('CFB PicksPage (via adapter) — GameCard layout regression', () => {
 
   it('shows Locked in when pick already submitted', async () => {
     vi.mocked(getCfbUserPicks).mockResolvedValue([
-      { id: 1, userId: 'u1', userName: 'u1', leagueId: 1, cfbSlateId: 1, espnEventId: 100, team: 'MICH', pickType: 'Spread', season: 2025 }
+      { id: 1, userId: 'u1', userName: 'u1', leagueId: 1, cfbSlateId: 1, team: 'MICH', pickType: 'Spread', season: 2025 }
     ]);
     renderWithClient(<PicksPage adapter={createCfbAdapter()} />);
     await waitFor(() => expect(screen.getByRole('button', { name: /MICH locked in/i })).toBeInTheDocument());

--- a/Client.React/src/api/cfb.ts
+++ b/Client.React/src/api/cfb.ts
@@ -48,7 +48,7 @@ export async function addCfbPicks(
   leagueId: number,
   cfbSlateId: number,
   season: number,
-  picks: { espnEventId: number; team: string; pickType: string }[]
+  picks: { team: string; pickType: string }[]
 ): Promise<{ added: number }> {
   const res = await fetch(`${BASE}/picks`, {
     method: 'POST',

--- a/Client.React/src/services/cfbAdapter.ts
+++ b/Client.React/src/services/cfbAdapter.ts
@@ -36,7 +36,7 @@ function toCfbGameStatusFromString(s: string | null | undefined): GameStatusValu
 /**
  * Build GameView from spread data + live ESPN data.
  * ESPN is the primary source. Falls back to dbScores when ESPN has no event
- * for a given espnEventId (e.g. off-season, demo mode, or before game is created).
+ * for a given team (e.g. off-season, demo mode, or before game is created).
  */
 function buildGamesFromEspn(
   spreads: CfbSpreadDto[],
@@ -44,17 +44,21 @@ function buildGamesFromEspn(
   dbScores: CfbScoreDto[],
   situationMap: Map<string, import('../types/liveGame').GameSituation | null>,
 ): GameView[] {
-  const espnMap = new Map<number, import('../types/espn').Competition>();
+  // frizat: joined by home team abbreviation, not an ESPN event id — a team plays at most one
+  // game per slate (the scope every caller of this function already loads spreads/scores at), so
+  // homeTeam alone is an unambiguous join key. Matches CfbSpreads/CfbScores' own natural key.
+  const espnMap = new Map<string, import('../types/espn').Competition>();
   for (const event of espnData?.events ?? []) {
     for (const comp of event.competitions) {
-      espnMap.set(parseInt(comp.id), comp);
+      const home = comp.competitors.find(c => c.homeAway === 'home');
+      if (home) espnMap.set(home.team.abbreviation, comp);
     }
   }
-  const dbMap = new Map(dbScores.map(s => [s.espnEventId, s]));
+  const dbMap = new Map(dbScores.map(s => [s.homeTeam, s]));
 
   return spreads.map(sp => {
-    const comp = espnMap.get(sp.espnEventId);
-    const db = dbMap.get(sp.espnEventId);
+    const comp = espnMap.get(sp.homeTeam);
+    const db = dbMap.get(sp.homeTeam);
 
     let status: GameStatusValue;
     let hs: number | null;
@@ -81,7 +85,9 @@ function buildGamesFromEspn(
 
     const key = `${sp.homeTeam}-${sp.awayTeam}`;
     return {
-      id: sp.espnEventId.toString(),
+      // Unique within a single slate's spread list (the only scope this ever gets rendered in) —
+      // a team plays at most one game per slate, same reasoning as the espnMap/dbMap join keys.
+      id: sp.homeTeam,
       homeTeam: sp.homeTeam,
       awayTeam: sp.awayTeam,
       homeSpread: sp.homeTeamSpread,
@@ -102,9 +108,23 @@ function buildGamesFromEspn(
   });
 }
 
-function cfbPickToPickView(pick: CfbPickDto): PickView {
+// frizat: CfbPicks.Team is whichever side the user picked — it can be the home OR away team, but
+// GameView.id is always the game's home team (see buildGamesFromEspn). A pick on the away side
+// still needs its PickView.gameId to resolve to the game's home team so it matches GameView.id
+// (pickCountForTeam/didUserPick in ScoresPage.tsx key off exact gameId equality) — this map
+// resolves either side back to that game's homeTeam, built once per slate's spread list.
+function buildTeamToHomeTeamMap(spreads: CfbSpreadDto[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const sp of spreads) {
+    map.set(sp.homeTeam, sp.homeTeam);
+    map.set(sp.awayTeam, sp.homeTeam);
+  }
+  return map;
+}
+
+function cfbPickToPickView(pick: CfbPickDto, teamToHomeTeam: Map<string, string>): PickView {
   return {
-    gameId: pick.espnEventId.toString(),
+    gameId: teamToHomeTeam.get(pick.team) ?? pick.team,
     team: pick.team,
     pickType: pick.pickType as PickView['pickType'],
     userId: pick.userId,
@@ -133,9 +153,10 @@ async function loadSlate(leagueId: number, _userId: string, slateId: number, sla
     getCfbDbScores(slateId),
     fetchCfbEspnData(slate, isCurrent),
   ]);
+  const teamToHomeTeam = buildTeamToHomeTeamMap(spreads);
   return {
     games: buildGamesFromEspn(spreads, espn, dbScores, situations),
-    userPicks: picks.map(cfbPickToPickView),
+    userPicks: picks.map(p => cfbPickToPickView(p, teamToHomeTeam)),
   };
 }
 
@@ -166,7 +187,8 @@ export function createCfbAdapter(): SportAdapter {
       fetchCfbEspnData(slate, isCurrent),
     ]);
     const games = buildGamesFromEspn(spreads, espn, dbScores, situations);
-    const allPicks = allPickDtos.map(cfbPickToPickView);
+    const teamToHomeTeam = buildTeamToHomeTeamMap(spreads);
+    const allPicks = allPickDtos.map(p => cfbPickToPickView(p, teamToHomeTeam));
     const userPicks = allPicks.filter(p => p.userId === userId);
     return { games, allPicks: revealPicksForStartedGames(allPicks, games, userId), userPicks };
   }
@@ -223,7 +245,6 @@ export function createCfbAdapter(): SportAdapter {
       const slate = slates.find(s => s.slateNumber === slateNum);
       if (!slate) return;
       await addCfbPicks(leagueId, slate.id, season, picks.map(p => ({
-        espnEventId: parseInt(p.gameId),
         team: p.team,
         pickType: p.pickType,
       })));
@@ -235,8 +256,12 @@ export function createCfbAdapter(): SportAdapter {
       const slate = slates.find(s => s.slateNumber === slateNum);
       if (!slate) return [];
       await deleteCfbPicks(leagueId, slate.id);
-      const fresh = await getCfbUserPicks(leagueId, slate.id);
-      return fresh.map(cfbPickToPickView);
+      const [fresh, spreads] = await Promise.all([
+        getCfbUserPicks(leagueId, slate.id),
+        getCfbSpreads(slate.id),
+      ]);
+      const teamToHomeTeam = buildTeamToHomeTeamMap(spreads);
+      return fresh.map(p => cfbPickToPickView(p, teamToHomeTeam));
     },
 
     // ─── Scores ─────────────────────────────────────────────────────────────

--- a/Client.React/src/services/cfbAdapter.ts
+++ b/Client.React/src/services/cfbAdapter.ts
@@ -3,7 +3,7 @@ import { loadCfbScoresWithRetry, getCfbScoresForSlate, getCfbLiveGames } from '.
 import { cfbSlateNumberToWeek, cfbWeekToSlateNumber, getCfbWeekName, computeHomeCovers, computeOverWins, getCfbRequiredPicks } from '../utils/gameHelpers';
 import type { CfbSlateDto, CfbSpreadDto, CfbScoreDto, CfbPickDto } from '../types/league';
 import type { EspnScores } from '../types/espn';
-import { getHomeTeamScore, getAwayTeamScore, toGameStatus } from '../utils/gameHelpers';
+import { getHomeTeamScore, getAwayTeamScore, toGameStatus, isHomeAway } from '../utils/gameHelpers';
 import type { SportAdapter, GameView, GameStatusValue, PickView, WeekState } from './sportAdapter';
 import { revealPicksForStartedGames } from './sportAdapter';
 
@@ -50,7 +50,10 @@ function buildGamesFromEspn(
   const espnMap = new Map<string, import('../types/espn').Competition>();
   for (const event of espnData?.events ?? []) {
     for (const comp of event.competitions) {
-      const home = comp.competitors.find(c => c.homeAway === 'home');
+      // isHomeAway handles both string ('home') and numeric (1) forms — our backend re-serializes
+      // the ESPN homeAway enum as a number (see toGameStatus's status.type.name comment above for
+      // the same pattern), so a bare `=== 'home'` string comparison never matches.
+      const home = comp.competitors.find(c => isHomeAway(c.homeAway, 'home'));
       if (home) espnMap.set(home.team.abbreviation, comp);
     }
   }

--- a/Client.React/src/types/league.ts
+++ b/Client.React/src/types/league.ts
@@ -26,7 +26,6 @@ export interface CfbSlateDto {
 export interface CfbSpreadDto {
   id: number;
   cfbSlateId: number;
-  espnEventId: number;
   homeTeam: string;
   awayTeam: string;
   homeTeamSpread: number;
@@ -39,7 +38,6 @@ export interface CfbSpreadDto {
 export interface CfbScoreDto {
   id: number;
   cfbSlateId: number;
-  espnEventId: number;
   homeTeam: string;
   awayTeam: string;
   homeTeamScore: number;
@@ -57,7 +55,6 @@ export interface CfbPickDto {
   userName: string;
   leagueId: number;
   cfbSlateId: number;
-  espnEventId: number;
   team: string;
   pickType: string;
   season: number;

--- a/Client.React/src/utils/gameHelpers.ts
+++ b/Client.React/src/utils/gameHelpers.ts
@@ -266,7 +266,7 @@ export function computeOverWins(
   return (homeScore + awayScore) > overUnder;
 }
 
-function isHomeAway(value: HomeAway, expected: 'home' | 'away') {
+export function isHomeAway(value: HomeAway, expected: 'home' | 'away') {
   if (typeof value === 'number') {
     return expected === 'away' ? value === 0 : value === 1;
   }

--- a/Server.UnitTests/CfbPicksControllerTests.cs
+++ b/Server.UnitTests/CfbPicksControllerTests.cs
@@ -47,9 +47,11 @@ public class CfbPicksControllerTests
         Id = id, Season = 2025, SlateNumber = slateNumber, Label = "Week 1", SlateType = "RegularSeason",
     };
 
-    private static CfbSpreads MakeSpread(int espnEventId, DateTimeOffset gameTime, string home = "ORE", string away = "OSU", bool isLeagueEligible = true) => new()
+    // frizat: a team plays at most one game per slate, so (CfbSlateId, HomeTeam) — not an ESPN id
+    // — is what uniquely identifies a game, mirroring NflSpreads' (Season, NflWeek, HomeTeam).
+    private static CfbSpreads MakeSpread(DateTimeOffset gameTime, string home = "ORE", string away = "OSU", bool isLeagueEligible = true) => new()
     {
-        CfbSlateId = 1, EspnEventId = espnEventId, HomeTeam = home, AwayTeam = away, GameTime = gameTime,
+        CfbSlateId = 1, HomeTeam = home, AwayTeam = away, GameTime = gameTime,
         IsLeagueEligible = isLeagueEligible,
     };
 
@@ -58,7 +60,7 @@ public class CfbPicksControllerTests
     {
         var picks = new List<CfbPicks>
         {
-            new() { Id = 1, UserId = UserId, LeagueId = 1, CfbSlateId = 1, Team = "ORE", EspnEventId = 401800001 }
+            new() { Id = 1, UserId = UserId, LeagueId = 1, CfbSlateId = 1, Team = "ORE" }
         };
         _repo.GetUserPicksAsync(1, 1, UserId).Returns(picks);
 
@@ -73,13 +75,13 @@ public class CfbPicksControllerTests
     public async Task AddPicks_ValidPicks_ReturnsCount()
     {
         _cfbRepo.GetSlateByIdAsync(1).Returns(MakeSlate());
-        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2))]);
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(2))]);
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1,
             CfbSlateId = 1,
             Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
         };
         _repo.GetUserPicksAsync(1, 1, UserId).Returns([]);
         _repo.AddPicksAsync(Arg.Any<IEnumerable<CfbPicks>>()).Returns(Task.CompletedTask);
@@ -94,17 +96,17 @@ public class CfbPicksControllerTests
     public async Task AddPicks_DuplicatePick_IsSkipped()
     {
         _cfbRepo.GetSlateByIdAsync(1).Returns(MakeSlate());
-        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2))]);
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(2))]);
         var existing = new List<CfbPicks>
         {
-            new() { UserId = UserId, LeagueId = 1, CfbSlateId = 1, Team = "ORE", EspnEventId = 401800001 }
+            new() { UserId = UserId, LeagueId = 1, CfbSlateId = 1, Team = "ORE" }
         };
         _repo.GetUserPicksAsync(1, 1, UserId).Returns(existing);
 
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -122,7 +124,7 @@ public class CfbPicksControllerTests
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -137,12 +139,12 @@ public class CfbPicksControllerTests
         // Regression: the required-pick-count cap must fail closed on a bad/stale CfbSlateId, not
         // silently skip enforcement — GetSlateByIdAsync returning null (default NSubstitute stub)
         // must reject the whole request before any picks are inserted.
-        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2))]);
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(2))]);
         _repo.GetUserPicksAsync(1, 1, UserId).Returns([]);
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -157,12 +159,12 @@ public class CfbPicksControllerTests
     public async Task AddPicks_WhenGameKickoffHasPassed_ReturnsBadRequest()
     {
         _cfbRepo.GetSlateByIdAsync(1).Returns(MakeSlate());
-        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(-2))]);
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(-2))]);
         _repo.GetUserPicksAsync(1, 1, UserId).Returns([]);
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -176,13 +178,13 @@ public class CfbPicksControllerTests
     public async Task AddPicks_WhenGameKickoffIsInFuture_ReturnsOk()
     {
         _cfbRepo.GetSlateByIdAsync(1).Returns(MakeSlate());
-        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2))]);
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(2))]);
         _repo.GetUserPicksAsync(1, 1, UserId).Returns([]);
         _repo.AddPicksAsync(Arg.Any<IEnumerable<CfbPicks>>()).Returns(Task.CompletedTask);
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -201,7 +203,7 @@ public class CfbPicksControllerTests
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -217,8 +219,8 @@ public class CfbPicksControllerTests
         // Slate 18 (Championship-style, > 17) requires exactly 1 pick.
         _cfbRepo.GetSlateByIdAsync(1).Returns(MakeSlate(slateNumber: 18));
         _cfbRepo.GetSpreadsForSlateAsync(1).Returns([
-            MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2), "ORE", "OSU"),
-            MakeSpread(401800002, DateTimeOffset.UtcNow.AddHours(2), "ALA", "UGA"),
+            MakeSpread(DateTimeOffset.UtcNow.AddHours(2), "ORE", "OSU"),
+            MakeSpread(DateTimeOffset.UtcNow.AddHours(2), "ALA", "UGA"),
         ]);
         _repo.GetUserPicksAsync(1, 1, UserId).Returns([]);
         var request = new AddCfbPicksRequest
@@ -226,8 +228,8 @@ public class CfbPicksControllerTests
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
             Picks =
             [
-                new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" },
-                new CfbPickItem { Team = "ALA", EspnEventId = 401800002, PickType = "Spread" },
+                new CfbPickItem { Team = "ORE", PickType = "Spread" },
+                new CfbPickItem { Team = "ALA", PickType = "Spread" },
             ]
         };
 
@@ -253,11 +255,11 @@ public class CfbPicksControllerTests
     [Fact]
     public async Task GetAllPicks_HidesOtherUsersPicksForNotYetStartedGames()
     {
-        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2))]);
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(2))]);
         _repo.GetAllPicksForSlateAsync(1, 1).Returns(
         [
-            new CfbPickDto { UserId = UserId, EspnEventId = 401800001, Team = "ORE" },
-            new CfbPickDto { UserId = OtherUserId, EspnEventId = 401800001, Team = "OSU" },
+            new CfbPickDto { UserId = UserId, Team = "ORE" },
+            new CfbPickDto { UserId = OtherUserId, Team = "OSU" },
         ]);
 
         var result = await BuildController().GetAllPicks(1, 1);
@@ -271,11 +273,11 @@ public class CfbPicksControllerTests
     [Fact]
     public async Task GetAllPicks_ShowsOtherUsersPicksForStartedGames()
     {
-        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(-1))]);
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(-1))]);
         _repo.GetAllPicksForSlateAsync(1, 1).Returns(
         [
-            new CfbPickDto { UserId = UserId, EspnEventId = 401800001, Team = "ORE" },
-            new CfbPickDto { UserId = OtherUserId, EspnEventId = 401800001, Team = "OSU" },
+            new CfbPickDto { UserId = UserId, Team = "ORE" },
+            new CfbPickDto { UserId = OtherUserId, Team = "OSU" },
         ]);
 
         var result = await BuildController().GetAllPicks(1, 1);
@@ -289,11 +291,11 @@ public class CfbPicksControllerTests
     public async Task GetAllPicks_AdminSeesAllPicksRegardlessOfGameStatus()
     {
         _leagueRepo.UserExistsInLeagueAsync(Arg.Any<string>(), 1).Returns(false); // admin not a member
-        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2))]);
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(2))]);
         _repo.GetAllPicksForSlateAsync(1, 1).Returns(
         [
-            new CfbPickDto { UserId = UserId, EspnEventId = 401800001, Team = "ORE" },
-            new CfbPickDto { UserId = OtherUserId, EspnEventId = 401800001, Team = "OSU" },
+            new CfbPickDto { UserId = UserId, Team = "ORE" },
+            new CfbPickDto { UserId = OtherUserId, Team = "OSU" },
         ]);
 
         var result = await BuildController("admin-001", isAdmin: true).GetAllPicks(1, 1);
@@ -323,8 +325,8 @@ public class CfbPicksControllerTests
     public async Task GetSpreads_ReturnsOnlyLeagueEligibleSpreads()
     {
         _cfbRepo.GetSpreadsForSlateAsync(1).Returns([
-            MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2), "ORE", "OSU", isLeagueEligible: true),
-            MakeSpread(401800002, DateTimeOffset.UtcNow.AddHours(2), "TOL", "BALLST", isLeagueEligible: false),
+            MakeSpread(DateTimeOffset.UtcNow.AddHours(2), "ORE", "OSU", isLeagueEligible: true),
+            MakeSpread(DateTimeOffset.UtcNow.AddHours(2), "TOL", "BALLST", isLeagueEligible: false),
         ]);
 
         var result = await BuildController().GetSpreads(1);
@@ -332,14 +334,14 @@ public class CfbPicksControllerTests
         var ok = Assert.IsType<OkObjectResult>(result);
         var returned = Assert.IsAssignableFrom<IEnumerable<CfbSpreads>>(ok.Value).ToList();
         Assert.Single(returned);
-        Assert.Equal(401800001, returned[0].EspnEventId);
+        Assert.Equal("ORE", returned[0].HomeTeam);
     }
 
     // ── GetScores — serving-layer eligibility filter (frizat-9m0) ───────────
 
-    private static CfbScores MakeScore(int espnEventId, string home = "ORE", string away = "OSU") => new()
+    private static CfbScores MakeScore(string home = "ORE", string away = "OSU") => new()
     {
-        CfbSlateId = 1, EspnEventId = espnEventId, HomeTeam = home, AwayTeam = away,
+        CfbSlateId = 1, HomeTeam = home, AwayTeam = away,
         HomeTeamScore = 24, AwayTeamScore = 17, GameStatus = "STATUS_FINAL",
     };
 
@@ -347,12 +349,12 @@ public class CfbPicksControllerTests
     public async Task GetScores_ExcludesScoresForKnownIneligibleEvents()
     {
         _cfbRepo.GetSpreadsForSlateAsync(1).Returns([
-            MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(-2), "ORE", "OSU", isLeagueEligible: true),
-            MakeSpread(401800002, DateTimeOffset.UtcNow.AddHours(-2), "TOL", "BALLST", isLeagueEligible: false),
+            MakeSpread(DateTimeOffset.UtcNow.AddHours(-2), "ORE", "OSU", isLeagueEligible: true),
+            MakeSpread(DateTimeOffset.UtcNow.AddHours(-2), "TOL", "BALLST", isLeagueEligible: false),
         ]);
         _cfbRepo.GetScoresForSlateAsync(1).Returns([
-            MakeScore(401800001, "ORE", "OSU"),
-            MakeScore(401800002, "TOL", "BALLST"),
+            MakeScore("ORE", "OSU"),
+            MakeScore("TOL", "BALLST"),
         ]);
 
         var result = await BuildController().GetScores(1);
@@ -360,7 +362,7 @@ public class CfbPicksControllerTests
         var ok = Assert.IsType<OkObjectResult>(result);
         var returned = Assert.IsAssignableFrom<IEnumerable<CfbScoreDto>>(ok.Value).ToList();
         Assert.Single(returned);
-        Assert.Equal(401800001, returned[0].EspnEventId);
+        Assert.Equal("ORE", returned[0].HomeTeam);
     }
 
     [Fact]
@@ -371,34 +373,34 @@ public class CfbPicksControllerTests
         // schedule change) should still show, not silently vanish — only games we POSITIVELY know
         // are ineligible get excluded.
         _cfbRepo.GetSpreadsForSlateAsync(1).Returns([]);
-        _cfbRepo.GetScoresForSlateAsync(1).Returns([MakeScore(401800001, "ORE", "OSU")]);
+        _cfbRepo.GetScoresForSlateAsync(1).Returns([MakeScore("ORE", "OSU")]);
 
         var result = await BuildController().GetScores(1);
 
         var ok = Assert.IsType<OkObjectResult>(result);
         var returned = Assert.IsAssignableFrom<IEnumerable<CfbScoreDto>>(ok.Value).ToList();
         Assert.Single(returned);
-        Assert.Equal(401800001, returned[0].EspnEventId);
+        Assert.Equal("ORE", returned[0].HomeTeam);
     }
 
-    // ── AddPicks — ineligible-event guard (frizat-9m0) ───────────────────────
-    // Rejects a pick for an event we KNOW is excluded (MAC Tue/Wed, unranked, etc.) — distinct
+    // ── AddPicks — ineligible-team guard (frizat-9m0) ────────────────────────
+    // Rejects a pick for a team we KNOW is excluded (MAC Tue/Wed, unranked, etc.) — distinct
     // from AddPicks_WhenNoMatchingSpread_AllowsPick above, which fails open when we have NO data
-    // for the event at all (e.g. ESPN cache gap). Positive knowledge of ineligibility rejects;
+    // for the game at all (e.g. ESPN cache gap). Positive knowledge of ineligibility rejects;
     // absence of knowledge does not.
 
     [Fact]
-    public async Task AddPicks_WhenEventIsKnownIneligible_ReturnsBadRequest()
+    public async Task AddPicks_WhenTeamIsKnownIneligible_ReturnsBadRequest()
     {
         _cfbRepo.GetSlateByIdAsync(1).Returns(MakeSlate());
         _cfbRepo.GetSpreadsForSlateAsync(1).Returns([
-            MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2), isLeagueEligible: false),
+            MakeSpread(DateTimeOffset.UtcNow.AddHours(2), isLeagueEligible: false),
         ]);
         _repo.GetUserPicksAsync(1, 1, UserId).Returns([]);
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
         };
 
         var result = await BuildController().AddPicks(request);

--- a/Server.UnitTests/CfbRepositoryTests.cs
+++ b/Server.UnitTests/CfbRepositoryTests.cs
@@ -7,62 +7,64 @@ using Xunit;
 namespace FourPlayWebApp.Server.UnitTests;
 
 // TDD, written RED first (frizat-pxy follow-on plan, Phase 1): CfbRepository.UpsertAsync must
-// dedupe by EspnEventId (no blind insert -> no duplicate rows on a re-fired spread job) and must
-// preserve the original DateCreated on update, since that's the "line first posted" timestamp
-// shown to users, not a re-fire timestamp.
+// dedupe by (CfbSlateId, HomeTeam) — a natural key mirroring NflSpreadsConfiguration's
+// (Season, NflWeek, HomeTeam), not an ESPN-specific id — (no blind insert -> no duplicate rows on
+// a re-fired spread job) and must preserve the original DateCreated on update, since that's the
+// "line first posted" timestamp shown to users, not a re-fire timestamp.
 public class CfbRepositoryTests
 {
     [Fact]
-    public async Task UpsertAsync_NewEspnEventId_Inserts()
+    public async Task UpsertAsync_NewGame_Inserts()
     {
-        var factory = new DbContextFactoryStub(nameof(UpsertAsync_NewEspnEventId_Inserts));
+        var factory = new DbContextFactoryStub(nameof(UpsertAsync_NewGame_Inserts));
         var repo = new CfbRepository(factory);
 
         await repo.UpsertAsync([
-            new CfbSpreads { CfbSlateId = 1, EspnEventId = 100, HomeTeam = "A", AwayTeam = "B", HomeTeamSpread = -3.5, AwayTeamSpread = 3.5 },
+            new CfbSpreads { CfbSlateId = 1, HomeTeam = "A", AwayTeam = "B", HomeTeamSpread = -3.5, AwayTeamSpread = 3.5 },
         ]);
 
-        var saved = await factory.CreateDbContext().CfbSpreads.SingleAsync(s => s.EspnEventId == 100);
+        var saved = await factory.CreateDbContext().CfbSpreads.SingleAsync(s => s.CfbSlateId == 1 && s.HomeTeam == "A");
         Assert.Equal("A", saved.HomeTeam);
         Assert.Equal(-3.5, saved.HomeTeamSpread);
     }
 
     [Fact]
-    public async Task UpsertAsync_ExistingEspnEventId_UpdatesInPlace_NoDuplicateRow()
+    public async Task UpsertAsync_ExistingGame_UpdatesInPlace_NoDuplicateRow()
     {
-        var factory = new DbContextFactoryStub(nameof(UpsertAsync_ExistingEspnEventId_UpdatesInPlace_NoDuplicateRow));
+        var factory = new DbContextFactoryStub(nameof(UpsertAsync_ExistingGame_UpdatesInPlace_NoDuplicateRow));
         var repo = new CfbRepository(factory);
 
         await repo.UpsertAsync([
-            new CfbSpreads { CfbSlateId = 1, EspnEventId = 100, HomeTeam = "A", AwayTeam = "B", HomeTeamSpread = -3.5, AwayTeamSpread = 3.5 },
+            new CfbSpreads { CfbSlateId = 1, HomeTeam = "A", AwayTeam = "B", HomeTeamSpread = -3.5, AwayTeamSpread = 3.5 },
         ]);
 
-        // Re-fire with the same EspnEventId (e.g. a catch-up run re-processing an already-saved week)
+        // Re-fire with the same (CfbSlateId, HomeTeam) (e.g. a catch-up run re-processing an
+        // already-saved week)
         await repo.UpsertAsync([
-            new CfbSpreads { CfbSlateId = 1, EspnEventId = 100, HomeTeam = "A", AwayTeam = "B", HomeTeamSpread = -4.0, AwayTeamSpread = 4.0 },
+            new CfbSpreads { CfbSlateId = 1, HomeTeam = "A", AwayTeam = "B", HomeTeamSpread = -4.0, AwayTeamSpread = 4.0 },
         ]);
 
-        var all = await factory.CreateDbContext().CfbSpreads.Where(s => s.EspnEventId == 100).ToListAsync();
+        var all = await factory.CreateDbContext().CfbSpreads.Where(s => s.CfbSlateId == 1 && s.HomeTeam == "A").ToListAsync();
         Assert.Single(all);
         Assert.Equal(-4.0, all[0].HomeTeamSpread);
     }
 
     [Fact]
-    public async Task UpsertAsync_ExistingEspnEventId_PreservesOriginalDateCreated()
+    public async Task UpsertAsync_ExistingGame_PreservesOriginalDateCreated()
     {
-        var factory = new DbContextFactoryStub(nameof(UpsertAsync_ExistingEspnEventId_PreservesOriginalDateCreated));
+        var factory = new DbContextFactoryStub(nameof(UpsertAsync_ExistingGame_PreservesOriginalDateCreated));
         var repo = new CfbRepository(factory);
         var originalPostTime = new DateTimeOffset(2026, 9, 1, 9, 0, 0, TimeSpan.Zero);
 
         await repo.UpsertAsync([
-            new CfbSpreads { CfbSlateId = 1, EspnEventId = 100, HomeTeam = "A", AwayTeam = "B", DateCreated = originalPostTime },
+            new CfbSpreads { CfbSlateId = 1, HomeTeam = "A", AwayTeam = "B", DateCreated = originalPostTime },
         ]);
 
         await repo.UpsertAsync([
-            new CfbSpreads { CfbSlateId = 1, EspnEventId = 100, HomeTeam = "A", AwayTeam = "B", HomeTeamSpread = -1, DateCreated = DateTimeOffset.UtcNow },
+            new CfbSpreads { CfbSlateId = 1, HomeTeam = "A", AwayTeam = "B", HomeTeamSpread = -1, DateCreated = DateTimeOffset.UtcNow },
         ]);
 
-        var saved = await factory.CreateDbContext().CfbSpreads.SingleAsync(s => s.EspnEventId == 100);
+        var saved = await factory.CreateDbContext().CfbSpreads.SingleAsync(s => s.CfbSlateId == 1 && s.HomeTeam == "A");
         Assert.Equal(originalPostTime, saved.DateCreated);
     }
 
@@ -77,7 +79,7 @@ public class CfbRepositoryTests
         var seedDb = factory.CreateDbContext();
         var slate = new CfbSlates { Id = 1, Season = 2026, SlateNumber = 3, Label = "Week 3", SlateType = "RegularSeason" };
         seedDb.CfbSlates.Add(slate);
-        seedDb.CfbSpreads.Add(new CfbSpreads { CfbSlateId = 1, EspnEventId = 100, HomeTeam = "A", AwayTeam = "B" });
+        seedDb.CfbSpreads.Add(new CfbSpreads { CfbSlateId = 1, HomeTeam = "A", AwayTeam = "B" });
         await seedDb.SaveChangesAsync();
         var repo = new CfbRepository(factory);
 
@@ -110,7 +112,7 @@ public class CfbRepositoryTests
         var seedDb = factory.CreateDbContext();
         seedDb.CfbSlates.Add(new CfbSlates { Id = 1, Season = 2026, SlateNumber = 3, Label = "Week 3", SlateType = "RegularSeason" });
         seedDb.CfbSlates.Add(new CfbSlates { Id = 2, Season = 2026, SlateNumber = 4, Label = "Week 4", SlateType = "RegularSeason" });
-        seedDb.CfbSpreads.Add(new CfbSpreads { CfbSlateId = 1, EspnEventId = 100, HomeTeam = "A", AwayTeam = "B" });
+        seedDb.CfbSpreads.Add(new CfbSpreads { CfbSlateId = 1, HomeTeam = "A", AwayTeam = "B" });
         await seedDb.SaveChangesAsync();
 
         var repo = new CfbRepository(factory);

--- a/Server.UnitTests/LeaderboardTests.cs
+++ b/Server.UnitTests/LeaderboardTests.cs
@@ -347,15 +347,15 @@ public class LeaderboardServiceTests {
         var cfbRepo = Substitute.For<ICfbRepository>();
         cfbRepo.GetSlatesForSeasonAsync(2025).Returns([slate]);
         cfbRepo.GetSpreadsForSlateAsync(slateId).Returns((IEnumerable<CfbSpreads>)[
-            new CfbSpreads { Id = 1, CfbSlateId = slateId, EspnEventId = 100, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -7, AwayTeamSpread = 7, OverUnder = 50, IsLeagueEligible = true }
+            new CfbSpreads { Id = 1, CfbSlateId = slateId, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -7, AwayTeamSpread = 7, OverUnder = 50, IsLeagueEligible = true }
         ]);
         cfbRepo.GetScoresForSlateAsync(slateId).Returns((IEnumerable<CfbScores>)[
-            new CfbScores { Id = 1, CfbSlateId = slateId, EspnEventId = 100, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "StatusFinal" }
+            new CfbScores { Id = 1, CfbSlateId = slateId, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "StatusFinal" }
         ]);
 
         var picksRepo = Substitute.For<ICfbPicksRepository>();
         picksRepo.GetUserPicksAsync(leagueId, slateId, userId).Returns((IEnumerable<CfbPicks>)[
-            new CfbPicks { UserId = userId, LeagueId = leagueId, CfbSlateId = slateId, EspnEventId = 100, Team = "IU", PickType = "Spread", Season = 2025 }
+            new CfbPicks { UserId = userId, LeagueId = leagueId, CfbSlateId = slateId, Team = "IU", PickType = "Spread", Season = 2025 }
         ]);
 
         return (leagueRepo, cfbRepo, picksRepo);
@@ -381,7 +381,7 @@ public class LeaderboardServiceTests {
 
         // Override scores: IU loses badly — 7 to 35, so IU 7 + (-7+5) = 5; 5 - 35 = -30 < 0 → loss
         cfbRepo.GetScoresForSlateAsync(1).Returns((IEnumerable<CfbScores>)[
-            new CfbScores { Id = 1, CfbSlateId = 1, EspnEventId = 100, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 7, AwayTeamScore = 35, GameStatus = "StatusFinal" }
+            new CfbScores { Id = 1, CfbSlateId = 1, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 7, AwayTeamScore = 35, GameStatus = "StatusFinal" }
         ]);
 
         var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo);
@@ -397,8 +397,8 @@ public class LeaderboardServiceTests {
 
         // Add a second game that the user did NOT pick
         cfbRepo.GetSpreadsForSlateAsync(1).Returns((IEnumerable<CfbSpreads>)[
-            new CfbSpreads { Id = 1, CfbSlateId = 1, EspnEventId = 100, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -7, AwayTeamSpread = 7, OverUnder = 50, IsLeagueEligible = true },
-            new CfbSpreads { Id = 2, CfbSlateId = 1, EspnEventId = 101, HomeTeam = "MIC", AwayTeam = "PSU", HomeTeamSpread = -3, AwayTeamSpread = 3, OverUnder = 47, IsLeagueEligible = true },
+            new CfbSpreads { Id = 1, CfbSlateId = 1, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -7, AwayTeamSpread = 7, OverUnder = 50, IsLeagueEligible = true },
+            new CfbSpreads { Id = 2, CfbSlateId = 1, HomeTeam = "MIC", AwayTeam = "PSU", HomeTeamSpread = -3, AwayTeamSpread = 3, OverUnder = 47, IsLeagueEligible = true },
         ]);
 
         var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo);
@@ -438,22 +438,20 @@ public class LeaderboardServiceTests {
         var cfbRepo = Substitute.For<ICfbRepository>();
         cfbRepo.GetSlatesForSeasonAsync(2025).Returns([slate]);
         cfbRepo.GetSpreadsForSlateAsync(slateId).Returns((IEnumerable<CfbSpreads>)[
-            new CfbSpreads { Id = 1, CfbSlateId = slateId, EspnEventId = 100,
-                HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -7, AwayTeamSpread = 7, OverUnder = 50, IsLeagueEligible = true }
+            new CfbSpreads { Id = 1, CfbSlateId = slateId, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -7, AwayTeamSpread = 7, OverUnder = 50, IsLeagueEligible = true }
         ]);
         cfbRepo.GetScoresForSlateAsync(slateId).Returns((IEnumerable<CfbScores>)[
-            new CfbScores { Id = 1, CfbSlateId = slateId, EspnEventId = 100,
-                HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "StatusFinal" }
+            new CfbScores { Id = 1, CfbSlateId = slateId, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "StatusFinal" }
         ]);
 
         var picksRepo = Substitute.For<ICfbPicksRepository>();
         picksRepo.GetUserPicksAsync(leagueId, slateId, Arg.Is<string>(uid => winnerIds.Contains(uid)))
             .Returns((IEnumerable<CfbPicks>)[
-                new CfbPicks { CfbSlateId = slateId, EspnEventId = 100, Team = "IU", PickType = "Spread", Season = 2025 }
+                new CfbPicks { CfbSlateId = slateId, Team = "IU", PickType = "Spread", Season = 2025 }
             ]);
         picksRepo.GetUserPicksAsync(leagueId, slateId, Arg.Is<string>(uid => loserIds.Contains(uid)))
             .Returns((IEnumerable<CfbPicks>)[
-                new CfbPicks { CfbSlateId = slateId, EspnEventId = 100, Team = "OSU", PickType = "Spread", Season = 2025 }
+                new CfbPicks { CfbSlateId = slateId, Team = "OSU", PickType = "Spread", Season = 2025 }
             ]);
 
         return (leagueRepo, cfbRepo, picksRepo);
@@ -470,12 +468,10 @@ public class LeaderboardServiceTests {
         var (leagueRepo, cfbRepo, picksRepo) = BuildCfbMocks(userId, slateNumber: slateNumber);
 
         cfbRepo.GetSpreadsForSlateAsync(1).Returns((IEnumerable<CfbSpreads>)[
-            new CfbSpreads { Id = 1, CfbSlateId = 1, EspnEventId = 100,
-                HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -10, AwayTeamSpread = 10, OverUnder = 50, IsLeagueEligible = true }
+            new CfbSpreads { Id = 1, CfbSlateId = 1, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -10, AwayTeamSpread = 10, OverUnder = 50, IsLeagueEligible = true }
         ]);
         cfbRepo.GetScoresForSlateAsync(1).Returns((IEnumerable<CfbScores>)[
-            new CfbScores { Id = 1, CfbSlateId = 1, EspnEventId = 100,
-                HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 20, GameStatus = "StatusFinal" }
+            new CfbScores { Id = 1, CfbSlateId = 1, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 20, GameStatus = "StatusFinal" }
         ]);
 
         var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo);

--- a/Server/Controllers/CfbPicksController.cs
+++ b/Server/Controllers/CfbPicksController.cs
@@ -62,12 +62,13 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
         // KNOW are ineligible (a matching CfbSpreads row exists and says so). A completed game
         // with no matching spread row at all (e.g. CfbSpreadJob's one-shot-per-week fetch missed
         // a late schedule change) still shows rather than silently vanishing from the scores page.
-        var ineligibleEventIds = spreadsTask.Result.WhereLeagueIneligible().Select(s => s.EspnEventId).ToHashSet();
-        var scores = scoresTask.Result.Where(s => !ineligibleEventIds.Contains(s.EspnEventId));
+        // Matched by HomeTeam (unique within a slate) rather than an ESPN id — CfbScores.HomeTeam
+        // and CfbSpreads.HomeTeam are populated from the same real-world game by design.
+        var ineligibleHomeTeams = spreadsTask.Result.WhereLeagueIneligible().Select(s => s.HomeTeam).ToHashSet();
+        var scores = scoresTask.Result.Where(s => !ineligibleHomeTeams.Contains(s.HomeTeam));
         var dtos = scores.Select(s => new CfbScoreDto {
             Id                  = s.Id,
             CfbSlateId          = s.CfbSlateId,
-            EspnEventId         = s.EspnEventId,
             HomeTeam            = s.HomeTeam,
             AwayTeam            = s.AwayTeam,
             HomeTeamScore       = s.HomeTeamScore,
@@ -85,8 +86,9 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
 
     // CFB has no live ESPN status feed the way NFL does (see cfbAdapter.ts) — CfbSpreads.GameTime
     // is the source of truth for kickoff time, same as the frontend's own gameIsLocked check.
-    private static HashSet<int> StartedEventIds(IEnumerable<CfbSpreads> spreads, DateTimeOffset now) =>
-        spreads.Where(s => s.GameTime <= now).Select(s => s.EspnEventId).ToHashSet();
+    // Returns both home and away team names for started games — a pick can be on either side.
+    private static HashSet<string> StartedTeams(IEnumerable<CfbSpreads> spreads, DateTimeOffset now) =>
+        spreads.Where(s => s.GameTime <= now).SelectMany(s => new[] { s.HomeTeam, s.AwayTeam }).ToHashSet();
 
     [HttpGet("picks/{leagueId}/{cfbSlateId}")]
     public async Task<IActionResult> GetAllPicks(int leagueId, int cfbSlateId) {
@@ -105,9 +107,9 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
         // Hide other users' picks for games that haven't kicked off yet — same rule as NFL's
         // GetLeaguePicks. Admins always see all picks, same as NFL.
         if (!isAdmin) {
-            var startedEventIds = StartedEventIds(spreadsTask.Result, DateTimeOffset.UtcNow);
+            var startedTeams = StartedTeams(spreadsTask.Result, DateTimeOffset.UtcNow);
             allPicks = allPicks
-                .Where(p => p.UserId == callerId || startedEventIds.Contains(p.EspnEventId))
+                .Where(p => p.UserId == callerId || startedTeams.Contains(p.Team))
                 .ToList();
         }
 
@@ -136,33 +138,35 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
         if (slate is null)
             return BadRequest("Cfb Slate Does Not Exist");
 
-        // Guard: reject picks for any game that has already kicked off.
-        var startedEventIds = StartedEventIds(spreadsTask.Result, DateTimeOffset.UtcNow);
+        // Guard: reject picks for any game that has already kicked off. Matched by team name
+        // (either side) rather than an ESPN id — a team plays at most one game per slate, so
+        // Team alone unambiguously identifies which CfbSpreads row a pick belongs to.
+        var startedTeams = StartedTeams(spreadsTask.Result, DateTimeOffset.UtcNow);
 
-        // Guard: reject picks for an event we KNOW is excluded from the league (MAC Tue/Wed,
+        // Guard: reject picks for a team we KNOW is excluded from the league (MAC Tue/Wed,
         // unranked, etc. — frizat-9m0). Distinct from "no matching spread at all", which stays
         // fail-open below (e.g. an ESPN cache gap) — this only rejects positive knowledge of
         // ineligibility, not absence of data.
-        var ineligibleEventIds = spreadsTask.Result.WhereLeagueIneligible().Select(s => s.EspnEventId).ToHashSet();
+        var ineligibleTeams = spreadsTask.Result.WhereLeagueIneligible()
+            .SelectMany(s => new[] { s.HomeTeam, s.AwayTeam }).ToHashSet();
 
         foreach (var pick in request.Picks) {
-            if (startedEventIds.Contains(pick.EspnEventId))
+            if (startedTeams.Contains(pick.Team))
                 return BadRequest($"Pick rejected: {pick.Team}'s game has already kicked off.");
-            if (ineligibleEventIds.Contains(pick.EspnEventId))
+            if (ineligibleTeams.Contains(pick.Team))
                 return BadRequest($"Pick rejected: {pick.Team}'s game is not part of this league's slate.");
         }
 
         var existingPicks = existingPicksTask.Result.ToList();
         var existingKeys = existingPicks
-            .Select(p => $"{p.EspnEventId}|{p.Team}|{p.PickType}")
+            .Select(p => $"{p.Team}|{p.PickType}")
             .ToHashSet();
         var newPicks = request.Picks
-            .Where(p => !existingKeys.Contains($"{p.EspnEventId}|{p.Team}|{p.PickType}"))
+            .Where(p => !existingKeys.Contains($"{p.Team}|{p.PickType}"))
             .Select(p => new CfbPicks {
                 UserId      = userId,
                 LeagueId    = request.LeagueId,
                 CfbSlateId  = request.CfbSlateId,
-                EspnEventId = p.EspnEventId,
                 Team        = p.Team,
                 PickType    = p.PickType,
                 Season      = request.Season,
@@ -203,7 +207,6 @@ public record AddCfbPicksRequest {
 }
 
 public record CfbPickItem {
-    public int    EspnEventId { get; init; }
     public string Team        { get; init; } = string.Empty;
     public string PickType    { get; init; } = "Spread";
 }

--- a/Server/Data/Configurations/CfbScoresConfiguration.cs
+++ b/Server/Data/Configurations/CfbScoresConfiguration.cs
@@ -14,10 +14,10 @@ public class CfbScoresConfiguration : IEntityTypeConfiguration<CfbScores>
             .HasColumnType("timestamptz")
             .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
-        // Mirrors NflScores' unique index — backstops UpsertCfbScoresAsync's app-level
-        // upsert-by-EspnEventId the same way CfbSpreads' index backstops its upsert.
-        entity.HasIndex(e => e.EspnEventId).IsUnique();
-        entity.HasIndex(e => e.CfbSlateId);
+        // Natural key mirroring NflScoresConfiguration's (Season, NflWeek, HomeTeam) — see
+        // CfbSpreadsConfiguration's comment for the full rationale. Backstops
+        // UpsertCfbScoresAsync's app-level upsert-by-(CfbSlateId, HomeTeam).
+        entity.HasIndex(e => new { e.CfbSlateId, e.HomeTeam }).IsUnique();
 
         // CfbSlateId was previously an unenforced "soft FK" — see CfbSpreadsConfiguration for the
         // full rationale (frizat-896 schema audit). Restrict protects real final-score history from

--- a/Server/Data/Configurations/CfbSpreadsConfiguration.cs
+++ b/Server/Data/Configurations/CfbSpreadsConfiguration.cs
@@ -14,8 +14,11 @@ public class CfbSpreadsConfiguration : IEntityTypeConfiguration<CfbSpreads>
             .HasColumnType("timestamptz")
             .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
-        entity.HasIndex(e => e.EspnEventId).IsUnique();
-        entity.HasIndex(e => e.CfbSlateId);
+        // Natural key mirroring NflSpreadsConfiguration's (Season, NflWeek, HomeTeam) — a team
+        // plays at most one game per slate, so (CfbSlateId, HomeTeam) uniquely identifies a game
+        // without depending on an ESPN-specific id. CfbSlateId already encodes season via
+        // CfbSlates.Season, so a separate Season column isn't needed in this index.
+        entity.HasIndex(e => new { e.CfbSlateId, e.HomeTeam }).IsUnique();
 
         // CfbSlateId was previously an unenforced "soft FK" (indexed, joined against in queries,
         // but no DB-level constraint) — frizat-896 schema audit. Restrict (not Cascade): CfbSlates

--- a/Server/Jobs/CfbScoresJob.cs
+++ b/Server/Jobs/CfbScoresJob.cs
@@ -53,7 +53,6 @@ public class CfbScoresJob(ICfbLiveScoreFetcher fetcher, ICfbRepository repo) : I
 
             scores.Add(new CfbScores {
                 CfbSlateId          = slate.Id,
-                EspnEventId         = int.Parse(evt.Id),
                 HomeTeam            = home.Team.Abbreviation,
                 AwayTeam            = away.Team.Abbreviation,
                 HomeTeamScore       = (int)home.Score,

--- a/Server/Jobs/CfbSpreadJob.cs
+++ b/Server/Jobs/CfbSpreadJob.cs
@@ -95,7 +95,6 @@ public class CfbSpreadJob(
 
                 spreads.Add(new CfbSpreads {
                     CfbSlateId    = slate.Id,
-                    EspnEventId   = eventId,
                     HomeTeam      = home,
                     AwayTeam      = away,
                     HomeTeamSpread = parsedHome,

--- a/Server/Migrations/20260813205213_RemoveCfbEspnEventIdUseNaturalKey.Designer.cs
+++ b/Server/Migrations/20260813205213_RemoveCfbEspnEventIdUseNaturalKey.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260813205213_RemoveCfbEspnEventIdUseNaturalKey")]
+    partial class RemoveCfbEspnEventIdUseNaturalKey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/20260813205213_RemoveCfbEspnEventIdUseNaturalKey.cs
+++ b/Server/Migrations/20260813205213_RemoveCfbEspnEventIdUseNaturalKey.cs
@@ -1,0 +1,109 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveCfbEspnEventIdUseNaturalKey : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CfbSpreads_CfbSlateId",
+                table: "CfbSpreads");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CfbSpreads_EspnEventId",
+                table: "CfbSpreads");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CfbScores_CfbSlateId",
+                table: "CfbScores");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CfbScores_EspnEventId",
+                table: "CfbScores");
+
+            migrationBuilder.DropColumn(
+                name: "EspnEventId",
+                table: "CfbSpreads");
+
+            migrationBuilder.DropColumn(
+                name: "EspnEventId",
+                table: "CfbScores");
+
+            migrationBuilder.DropColumn(
+                name: "EspnEventId",
+                table: "CfbPicks");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CfbSpreads_CfbSlateId_HomeTeam",
+                table: "CfbSpreads",
+                columns: new[] { "CfbSlateId", "HomeTeam" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CfbScores_CfbSlateId_HomeTeam",
+                table: "CfbScores",
+                columns: new[] { "CfbSlateId", "HomeTeam" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CfbSpreads_CfbSlateId_HomeTeam",
+                table: "CfbSpreads");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CfbScores_CfbSlateId_HomeTeam",
+                table: "CfbScores");
+
+            migrationBuilder.AddColumn<int>(
+                name: "EspnEventId",
+                table: "CfbSpreads",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EspnEventId",
+                table: "CfbScores",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EspnEventId",
+                table: "CfbPicks",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CfbSpreads_CfbSlateId",
+                table: "CfbSpreads",
+                column: "CfbSlateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CfbSpreads_EspnEventId",
+                table: "CfbSpreads",
+                column: "EspnEventId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CfbScores_CfbSlateId",
+                table: "CfbScores",
+                column: "CfbSlateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CfbScores_EspnEventId",
+                table: "CfbScores",
+                column: "EspnEventId",
+                unique: true);
+        }
+    }
+}

--- a/Server/Services/DemoDataSeeder.cs
+++ b/Server/Services/DemoDataSeeder.cs
@@ -295,7 +295,6 @@ public class DemoDataSeeder(
 
         db.CfbSpreads.Add(new CfbSpreads {
             CfbSlateId = slate.Id,
-            EspnEventId = 401772636,
             HomeTeam = "IND",
             AwayTeam = "ATL",
             HomeTeamSpread = -3.5,
@@ -1066,7 +1065,6 @@ public class DemoDataSeeder(
         var spreads = allGames.Select(g => new CfbSpreads
         {
             CfbSlateId     = slates.First(s => s.SlateNumber == g.SlateIdx).Id,
-            EspnEventId    = g.EventId,
             HomeTeam       = g.Home,
             AwayTeam       = g.Away,
             HomeTeamSpread = g.HomeSpread,
@@ -1105,7 +1103,6 @@ public class DemoDataSeeder(
         var scores = allGames.Select(g => new CfbScores
         {
             CfbSlateId    = slates.First(s => s.SlateNumber == g.SlateIdx).Id,
-            EspnEventId   = g.EventId,
             HomeTeam      = g.Home,
             AwayTeam      = g.Away,
             HomeTeamScore = g.HomeScore,
@@ -1237,8 +1234,8 @@ public class DemoDataSeeder(
 
         var picks = new List<CfbPicks>();
 
-        void AddPick(int leagueId, string userId, int slateId, int eventId, string team) =>
-            picks.Add(new CfbPicks { UserId = userId, LeagueId = leagueId, CfbSlateId = slateId, EspnEventId = eventId, Team = team, PickType = "Spread", Season = CfbDemoSeason });
+        void AddPick(int leagueId, string userId, int slateId, string team) =>
+            picks.Add(new CfbPicks { UserId = userId, LeagueId = leagueId, CfbSlateId = slateId, Team = team, PickType = "Spread", Season = CfbDemoSeason });
 
         // frizat: Over/Under is an alternate PICK TYPE for a game, not an additional pick beyond
         // the slate's required count — CfbPicksController's server-side validation enforces total
@@ -1248,16 +1245,16 @@ public class DemoDataSeeder(
         // requiredPicks+1 total picks, which no real submission could ever produce (confirmed via
         // direct DB query: Bob had 4 rows for a 3-required-pick week). Bob/Dana's O/U pick now
         // replaces their game-0 spread pick instead of adding to it.
-        void AddFirstPickOrOverUnder(string uName, string userId, int slateId, int eventId, string homeTeam, string pickedTeam) {
+        void AddFirstPickOrOverUnder(string uName, string userId, int slateId, string homeTeam, string pickedTeam) {
             if (uName == "Bob") {
-                picks.Add(new CfbPicks { UserId = userId, LeagueId = league.Id, CfbSlateId = slateId, EspnEventId = eventId, Team = homeTeam, PickType = "Over", Season = CfbDemoSeason });
+                picks.Add(new CfbPicks { UserId = userId, LeagueId = league.Id, CfbSlateId = slateId, Team = homeTeam, PickType = "Over", Season = CfbDemoSeason });
                 return;
             }
             if (uName == "Dana") {
-                picks.Add(new CfbPicks { UserId = userId, LeagueId = league.Id, CfbSlateId = slateId, EspnEventId = eventId, Team = homeTeam, PickType = "Under", Season = CfbDemoSeason });
+                picks.Add(new CfbPicks { UserId = userId, LeagueId = league.Id, CfbSlateId = slateId, Team = homeTeam, PickType = "Under", Season = CfbDemoSeason });
                 return;
             }
-            AddPick(league.Id, userId, slateId, eventId, pickedTeam);
+            AddPick(league.Id, userId, slateId, pickedTeam);
         }
 
         var seedUsernames = DemoUsers.Select(d => d.Username).Append("frizat");
@@ -1278,14 +1275,14 @@ public class DemoDataSeeder(
                 {
                     if (slates.FirstOrDefault(s => s.SlateNumber == slateNum) is not { } slate) continue;
                     for (int i = 0; i < Math.Min(rsPattern.Length, gamesArr.Length); i++)
-                        AddPick(league.Id, user.Id, slate.Id, gamesArr[i].EventId, rsPattern[i] ? gamesArr[i].Home : gamesArr[i].Away);
+                        AddPick(league.Id, user.Id, slate.Id, rsPattern[i] ? gamesArr[i].Home : gamesArr[i].Away);
                 }
             }
 
             // Week 8: 4 picks from 6 games
             if (CfbWeek8Picks.TryGetValue(username, out var w8) && slates.FirstOrDefault(s => s.SlateNumber == 8) is { } slate8)
                 for (int i = 0; i < Math.Min(w8.Length, Week8Games.Length); i++)
-                    AddPick(league.Id, user.Id, slate8.Id, Week8Games[i].EventId, w8[i] ? Week8Games[i].Home : Week8Games[i].Away);
+                    AddPick(league.Id, user.Id, slate8.Id, w8[i] ? Week8Games[i].Home : Week8Games[i].Away);
 
             // Regular season slates 9-13: 4 picks each
             if (CfbRegularSeasonPickPattern.TryGetValue(username, out var rsPattern2))
@@ -1299,7 +1296,7 @@ public class DemoDataSeeder(
                 {
                     if (slates.FirstOrDefault(s => s.SlateNumber == slateNum) is not { } slate) continue;
                     for (int i = 0; i < Math.Min(rsPattern2.Length, gamesArr.Length); i++)
-                        AddPick(league.Id, user.Id, slate.Id, gamesArr[i].EventId, rsPattern2[i] ? gamesArr[i].Home : gamesArr[i].Away);
+                        AddPick(league.Id, user.Id, slate.Id, rsPattern2[i] ? gamesArr[i].Home : gamesArr[i].Away);
                 }
             }
 
@@ -1308,8 +1305,8 @@ public class DemoDataSeeder(
             {
                 for (int i = 0; i < Math.Min(confPattern.Length, Slate15Games.Length); i++) {
                     var team = confPattern[i] ? Slate15Games[i].Home : Slate15Games[i].Away;
-                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slate14Champ.Id, Slate15Games[0].EventId, Slate15Games[0].Home, team);
-                    else AddPick(league.Id, user.Id, slate14Champ.Id, Slate15Games[i].EventId, team);
+                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slate14Champ.Id, Slate15Games[0].Home, team);
+                    else AddPick(league.Id, user.Id, slate14Champ.Id, team);
                 }
             }
 
@@ -1319,8 +1316,8 @@ public class DemoDataSeeder(
                 var fr15Games = CfpGames.Where(g => g.SlateIdx == 15).ToArray();
                 for (int i = 0; i < Math.Min(fr15Pattern.Length, fr15Games.Length); i++) {
                     var team = fr15Pattern[i] ? fr15Games[i].Home : fr15Games[i].Away;
-                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slate15.Id, fr15Games[0].EventId, fr15Games[0].Home, team);
-                    else AddPick(league.Id, user.Id, slate15.Id, fr15Games[i].EventId, team);
+                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slate15.Id, fr15Games[0].Home, team);
+                    else AddPick(league.Id, user.Id, slate15.Id, team);
                 }
             }
 
@@ -1330,8 +1327,8 @@ public class DemoDataSeeder(
                 var qfGames = CfpGames.Where(g => g.SlateIdx == 16).ToArray();
                 for (int i = 0; i < Math.Min(qf.Length, qfGames.Length); i++) {
                     var team = qf[i] ? qfGames[i].Home : qfGames[i].Away;
-                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slateQf.Id, qfGames[0].EventId, qfGames[0].Home, team);
-                    else AddPick(league.Id, user.Id, slateQf.Id, qfGames[i].EventId, team);
+                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slateQf.Id, qfGames[0].Home, team);
+                    else AddPick(league.Id, user.Id, slateQf.Id, team);
                 }
             }
 
@@ -1341,8 +1338,8 @@ public class DemoDataSeeder(
                 var sfGames = CfpGames.Where(g => g.SlateIdx == 17).ToArray();
                 for (int i = 0; i < Math.Min(sf.Length, sfGames.Length); i++) {
                     var team = sf[i] ? sfGames[i].Home : sfGames[i].Away;
-                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slateSf.Id, sfGames[0].EventId, sfGames[0].Home, team);
-                    else AddPick(league.Id, user.Id, slateSf.Id, sfGames[i].EventId, team);
+                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slateSf.Id, sfGames[0].Home, team);
+                    else AddPick(league.Id, user.Id, slateSf.Id, team);
                 }
             }
 
@@ -1352,7 +1349,7 @@ public class DemoDataSeeder(
                 var finalGame = CfpGames.First(g => g.SlateIdx == 18);
                 if (CfbFinalPicks.TryGetValue(username, out var final)) {
                     var team = final ? finalGame.Home : finalGame.Away;
-                    AddFirstPickOrOverUnder(username, user.Id, slateFinal.Id, finalGame.EventId, finalGame.Home, team);
+                    AddFirstPickOrOverUnder(username, user.Id, slateFinal.Id, finalGame.Home, team);
                 }
             }
         }

--- a/Server/Services/Repositories/CfbPicksRepository.cs
+++ b/Server/Services/Repositories/CfbPicksRepository.cs
@@ -24,7 +24,6 @@ public class CfbPicksRepository(IDbContextFactory<ApplicationDbContext> dbFactor
                 UserName   = u.UserName ?? string.Empty,
                 LeagueId   = p.LeagueId,
                 CfbSlateId = p.CfbSlateId,
-                EspnEventId = p.EspnEventId,
                 Team       = p.Team,
                 PickType   = p.PickType,
                 Season     = p.Season,

--- a/Server/Services/Repositories/CfbRepository.cs
+++ b/Server/Services/Repositories/CfbRepository.cs
@@ -54,17 +54,15 @@ public class CfbRepository(IDbContextFactory<ApplicationDbContext> dbFactory) : 
     public async Task UpsertAsync(IEnumerable<CfbSpreads> spreads) {
         await using var db = await dbFactory.CreateDbContextAsync();
         var spreadList = spreads.ToList();
-        var ids = spreadList.Select(s => s.EspnEventId).ToHashSet();
+        var slateIds = spreadList.Select(s => s.CfbSlateId).ToHashSet();
         var existingMap = await db.CfbSpreads
-            .Where(s => ids.Contains(s.EspnEventId))
-            .ToDictionaryAsync(s => s.EspnEventId);
+            .Where(s => slateIds.Contains(s.CfbSlateId))
+            .ToDictionaryAsync(s => (s.CfbSlateId, s.HomeTeam));
 
         foreach (var spread in spreadList) {
-            if (!existingMap.TryGetValue(spread.EspnEventId, out var existing))
+            if (!existingMap.TryGetValue((spread.CfbSlateId, spread.HomeTeam), out var existing))
                 db.CfbSpreads.Add(spread);
             else {
-                existing.CfbSlateId       = spread.CfbSlateId;
-                existing.HomeTeam         = spread.HomeTeam;
                 existing.AwayTeam         = spread.AwayTeam;
                 existing.HomeTeamSpread   = spread.HomeTeamSpread;
                 existing.AwayTeamSpread   = spread.AwayTeamSpread;
@@ -126,13 +124,13 @@ public class CfbRepository(IDbContextFactory<ApplicationDbContext> dbFactory) : 
     public async Task UpsertCfbScoresAsync(IEnumerable<CfbScores> scores) {
         await using var db = await dbFactory.CreateDbContextAsync();
         var scoreList = scores.ToList();
-        var ids = scoreList.Select(s => s.EspnEventId).ToHashSet();
+        var slateIds = scoreList.Select(s => s.CfbSlateId).ToHashSet();
         var existingMap = await db.CfbScores
-            .Where(s => ids.Contains(s.EspnEventId))
-            .ToDictionaryAsync(s => s.EspnEventId);
+            .Where(s => slateIds.Contains(s.CfbSlateId))
+            .ToDictionaryAsync(s => (s.CfbSlateId, s.HomeTeam));
 
         foreach (var score in scoreList) {
-            if (!existingMap.TryGetValue(score.EspnEventId, out var existing))
+            if (!existingMap.TryGetValue((score.CfbSlateId, score.HomeTeam), out var existing))
                 db.CfbScores.Add(score);
             else {
                 existing.HomeTeamScore       = score.HomeTeamScore;

--- a/Shared/Models/Data/CfbPicks.cs
+++ b/Shared/Models/Data/CfbPicks.cs
@@ -10,7 +10,6 @@ public class CfbPicks {
     public string UserId { get; set; } = string.Empty;
     public int LeagueId { get; set; }
     public int CfbSlateId { get; set; }
-    public int EspnEventId { get; set; }
     public string Team { get; set; } = string.Empty;
     public string PickType { get; set; } = "Spread"; // "Spread" | "Over" | "Under"
     public int Season { get; set; }

--- a/Shared/Models/Data/CfbScores.cs
+++ b/Shared/Models/Data/CfbScores.cs
@@ -8,7 +8,6 @@ public class CfbScores {
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public int Id { get; set; }
     public int CfbSlateId { get; set; }
-    public int EspnEventId { get; set; }
     public string HomeTeam { get; set; } = string.Empty;
     public string AwayTeam { get; set; } = string.Empty;
     public int HomeTeamScore { get; set; }

--- a/Shared/Models/Data/CfbSpreads.cs
+++ b/Shared/Models/Data/CfbSpreads.cs
@@ -8,7 +8,6 @@ public class CfbSpreads {
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public int Id { get; set; }
     public int CfbSlateId { get; set; }
-    public int EspnEventId { get; set; }
     public string HomeTeam { get; set; } = string.Empty;
     public string AwayTeam { get; set; } = string.Empty;
     public double HomeTeamSpread { get; set; }

--- a/Shared/Models/Data/Dtos/CfbPickDto.cs
+++ b/Shared/Models/Data/Dtos/CfbPickDto.cs
@@ -6,7 +6,6 @@ public class CfbPickDto {
     public string UserName { get; set; } = string.Empty;
     public int LeagueId { get; set; }
     public int CfbSlateId { get; set; }
-    public int EspnEventId { get; set; }
     public string Team { get; set; } = string.Empty;
     public string PickType { get; set; } = "Spread";
     public int Season { get; set; }

--- a/Shared/Models/Data/Dtos/CfbScoreDto.cs
+++ b/Shared/Models/Data/Dtos/CfbScoreDto.cs
@@ -3,7 +3,6 @@ namespace FourPlayWebApp.Shared.Models.Data.Dtos;
 public class CfbScoreDto {
     public int    Id             { get; set; }
     public int    CfbSlateId     { get; set; }
-    public int    EspnEventId    { get; set; }
     public string HomeTeam       { get; set; } = string.Empty;
     public string AwayTeam       { get; set; } = string.Empty;
     public int    HomeTeamScore  { get; set; }


### PR DESCRIPTION
## Summary
- Removes `EspnEventId` from `CfbSpreads`, `CfbScores`, and `CfbPicks` — CFB now mirrors NFL's key design exactly instead of depending on an ESPN-specific id.
- New natural key: unique index on `(CfbSlateId, HomeTeam)` on `CfbSpreads`/`CfbScores`, direct structural match to `NflSpreadsConfiguration`/`NflScoresConfiguration`'s `(Season, NflWeek, HomeTeam)`.
- `CfbPicksController.AddPicks` guards (kickoff, ineligibility, dedupe) rewritten to match by team instead of event id, mirroring the pattern `CfbLeaderboardService` already used.
- Frontend `cfbAdapter.ts` joins ESPN live data to DB rows by home-team abbreviation instead of event id; adds `buildTeamToHomeTeamMap` so an away-side pick's `PickView.gameId` still resolves to the game's home team (matching `GameView.id`).
- `CfbRanking.EspnEventId` is intentionally untouched — it's an ESPN-rank audit trail with no NFL equivalent to mirror.

## Test plan
- [x] `dotnet test` — 513 passed, 0 failed
- [x] `npm run test -- --run` — full suite passed (new cfbAdapter tests cover home-team pick resolution and away-team pick resolution)
- [x] `npx tsc -b` clean
- [x] Manual verification against a freshly migrated local DB: CFB Scores page pick badges, matrix view win/loss coloring, NFL regression-checked as unaffected
- [ ] `npm run test:e2e:demo` — run once more against this branch's exact commit before merge
- [ ] Verify `\d "CfbSpreads"` / `\d "CfbScores"` / `\d "CfbPicks"` post-deploy show no `EspnEventId` column, in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)