### PR TITLE
fix(admin): surface Add Player fetch failures instead of silently leaving pickers empty

### DIFF
--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { vi } from 'vitest';
@@ -29,11 +29,12 @@ const ADMIN_USER: UserInfo = { userId: 'admin-1', name: 'Admin', claims: [{ type
 
 const authState = { user: OWNER_USER as UserInfo | null };
 const sportContext = { sport: 'NFL' as 'NFL' | 'CFB', isCfb: false, isNfl: true };
+const toastPush = vi.fn();
 
 vi.mock('../services/session', () => ({ useSession: () => sessionState }));
 vi.mock('../services/sport', () => ({ useSportContext: () => sportContext }));
 vi.mock('../services/auth', () => ({ useAuth: () => authState }));
-vi.mock('../services/toast', () => ({ useToast: () => ({ push: vi.fn() }) }));
+vi.mock('../services/toast', () => ({ useToast: () => ({ push: toastPush }) }));
 
 vi.mock('../api/league', () => ({
   getLeagueUserMappings: vi.fn(),
@@ -56,6 +57,7 @@ import {
   getAllLeagues,
   getUsers,
   createLeague,
+  addLeagueUserMapping,
 } from '../api/league';
 
 const mockedGetMappings = vi.mocked(getLeagueUserMappings);
@@ -64,6 +66,7 @@ const mockedGetCost = vi.mocked(getLeagueCost);
 const mockedGetAllLeagues = vi.mocked(getAllLeagues);
 const mockedGetUsers = vi.mocked(getUsers);
 const mockedCreateLeague = vi.mocked(createLeague);
+const mockedAddLeagueUserMapping = vi.mocked(addLeagueUserMapping);
 
 const CURRENT_SEASON = new Date().getFullYear();
 
@@ -122,7 +125,9 @@ beforeEach(() => {
   mockedGetAllLeagues.mockResolvedValue([]);
   mockedGetUsers.mockResolvedValue([makeUser()]);
   mockedCreateLeague.mockResolvedValue(makeLeague({ id: 99, leagueName: 'New League' }));
+  mockedAddLeagueUserMapping.mockResolvedValue(undefined);
   sessionState.reloadLeagues.mockClear();
+  toastPush.mockClear();
 });
 
 describe('LeaguePortalPage (owner, non-admin)', () => {
@@ -298,5 +303,29 @@ describe('LeaguePortalPage (site admin)', () => {
     expect(screen.getByRole('button', { name: /add user/i })).toBeInTheDocument();
     await userEvent.click(screen.getByRole('tab', { name: 'Info' }));
     expect(screen.getByRole('button', { name: /change owner/i })).toBeInTheDocument();
+  });
+
+  // frizat: getUsers() backs Add User, Create League's owner picker, and Assign Owner —
+  // a failed fetch previously left all three silently empty forever (no catch, no toast,
+  // no retry). This proves the failure is now surfaced instead of invisible.
+  it('shows an error toast when the platform user list fails to load', async () => {
+    mockedGetUsers.mockRejectedValue(new Error('network down'));
+    renderPage();
+    await screen.findByText('frizat@example.com');
+    await waitFor(() => expect(toastPush).toHaveBeenCalledWith(expect.stringMatching(/failed to load users/i), 'error'));
+  });
+
+  it('adds a selected user to the league via the Add User dialog', async () => {
+    renderPage();
+    await userEvent.click(await screen.findByRole('button', { name: /add user/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    const userSelect = within(dialog).getByLabelText(/^user$/i);
+    await userEvent.selectOptions(userSelect, 'bob@example.com');
+    await userEvent.click(within(dialog).getByRole('button', { name: /^add user$/i }));
+
+    await waitFor(() => expect(mockedAddLeagueUserMapping).toHaveBeenCalledWith(1, 'user-2'));
+    expect(toastPush).toHaveBeenCalledWith('bob@example.com added to league', 'success');
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
 });

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -140,11 +140,18 @@ export default function LeaguePortalPage() {
   useEffect(() => { void loadAllLeagues(); }, [loadAllLeagues]);
 
   // Platform user list backs all three admin dialogs (Create League, Add User, Assign Owner) —
-  // fetched once per admin visit rather than on every dialog open.
+  // fetched once per admin visit rather than on every dialog open. Without a .catch(), a failed
+  // fetch left availableUsers at [] for the whole session with no error and no retry — all three
+  // pickers looked "broken" with nothing to select and no indication why.
   useEffect(() => {
     if (!admin) return;
-    void getUsers().then(setAvailableUsers);
-  }, [admin]);
+    getUsers()
+      .then(setAvailableUsers)
+      .catch((err) => {
+        console.error('Failed to load platform user list', err);
+        toast.push('Failed to load users — try reloading the page', 'error');
+      });
+  }, [admin, toast]);
 
   useEffect(() => {
     if (leagueOptions.length > 0 && !selectedLeague) {

--- a/Server.UnitTests/LeagueControllerDtoTests.cs
+++ b/Server.UnitTests/LeagueControllerDtoTests.cs
@@ -18,11 +18,13 @@ namespace FourPlayWebApp.Server.UnitTests;
 /// </summary>
 public class LeagueControllerDtoTests
 {
-    private static LeagueController BuildController(ILeagueRepository repo)
+    private static LeagueController BuildController(ILeagueRepository repo, UserManager<ApplicationUser>? userManager = null)
     {
-        var store = Substitute.For<IUserStore<ApplicationUser>>();
-        var userManager = Substitute.For<UserManager<ApplicationUser>>(
-            store, null, null, null, null, null, null, null, null);
+        if (userManager is null) {
+            var store = Substitute.For<IUserStore<ApplicationUser>>();
+            userManager = Substitute.For<UserManager<ApplicationUser>>(
+                store, null, null, null, null, null, null, null, null);
+        }
 
         var controller = new LeagueController(
             new MemoryCache(new MemoryCacheOptions()),
@@ -133,5 +135,36 @@ public class LeagueControllerDtoTests
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var dtos = Assert.IsType<List<NflSpreadDto>>(ok.Value);
         Assert.Empty(dtos);
+    }
+
+    // ── GetUsers ────────────────────────────────────────────────────────────
+
+    // frizat: GetUsers previously called userManager.GetRolesAsync(u) once per user
+    // (N+1) to compute IsAdmin — slow/timeout-prone as the user base grows, and a
+    // plausible reason the frontend's Add User/Create League/Assign Owner pickers went
+    // silently empty intermittently. This proves IsAdmin is still computed correctly via
+    // a single batched GetUsersInRoleAsync call instead.
+    [Fact]
+    public async Task GetUsers_ComputesIsAdmin_ViaSingleBatchedRoleLookup_NotPerUser()
+    {
+        var admin = new ApplicationUser { Id = "u1", UserName = "admin", Email = "admin@x.com", EmailConfirmed = true };
+        var regular = new ApplicationUser { Id = "u2", UserName = "bob", Email = "bob@x.com", EmailConfirmed = true };
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetUsersAsync().Returns([admin, regular]);
+
+        var store = Substitute.For<IUserStore<ApplicationUser>>();
+        var userManager = Substitute.For<UserManager<ApplicationUser>>(
+            store, null, null, null, null, null, null, null, null);
+        userManager.GetUsersInRoleAsync("Administrator").Returns([admin]);
+
+        var result = await BuildController(repo, userManager).GetUsers();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dtos = Assert.IsType<List<UserSummaryDto>>(ok.Value);
+        Assert.Equal(2, dtos.Count);
+        Assert.True(dtos.Single(d => d.Id == "u1").IsAdmin);
+        Assert.False(dtos.Single(d => d.Id == "u2").IsAdmin);
+        await userManager.Received(1).GetUsersInRoleAsync("Administrator");
+        await userManager.DidNotReceive().GetRolesAsync(Arg.Any<ApplicationUser>());
     }
 }

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -197,17 +197,19 @@ public class LeagueController(
     [ProducesResponseType(typeof(List<UserSummaryDto>), StatusCodes.Status200OK)]
     public async Task<ActionResult<List<UserSummaryDto>>> GetUsers() {
 
-        var users = await repo.GetUsersAsync(); // returns List<IdentityUser>
-        var usersOutput = new List<UserSummaryDto>();
-        foreach (var u in users) {
-            // Check if the user is in the Administrator role
-            var roles = await userManager.GetRolesAsync(u);
-            var isAdmin = roles.Contains("Administrator");
-
-            usersOutput.Add(new UserSummaryDto(u.Id, u.UserName, u.Email, u.EmailConfirmed, isAdmin));
-
-            //Console.WriteLine($"User: {u.Id}, {u.UserName}, {u.Email}, IsAdmin: {isAdmin}");
-        }
+        // Single batched role lookup instead of one GetRolesAsync call per user (N+1) — was slow
+        // enough at real user-base sizes to plausibly time out, which combined with a missing
+        // frontend error handler left Add User/Create League/Assign Owner pickers silently empty.
+        // repo.GetUsersAsync() and userManager.GetUsersInRoleAsync() use separate DbContexts
+        // (IDbContextFactory-created vs. Identity's request-scoped one), so they're safe to run
+        // concurrently rather than as two sequential round trips.
+        var usersTask = repo.GetUsersAsync();
+        var adminsTask = userManager.GetUsersInRoleAsync(AppRoles.Administrator);
+        await Task.WhenAll(usersTask, adminsTask);
+        var adminIds = adminsTask.Result.Select(u => u.Id).ToHashSet();
+        var usersOutput = usersTask.Result
+            .Select(u => new UserSummaryDto(u.Id, u.UserName, u.Email, u.EmailConfirmed, adminIds.Contains(u.Id)))
+            .ToList();
 
         return Ok(usersOutput);
     }


### PR DESCRIPTION
## Summary
- `getUsers()` (backs Add User / Create League owner / Assign Owner pickers in `/league/manage`) had no `.catch()` — a failed fetch left all three silently empty for the whole session, no error, no retry. This is what "Add Player is not working" looked like in production, with zero diagnostic trail.
- Fixed the N+1 `GetRolesAsync`-per-user role lookup in `LeagueController.GetUsers` (replaced with a single batched `GetUsersInRoleAsync`, run concurrently with the user-list fetch since they use separate `DbContext`s) — a plausible reason the original fetch was slow/timeout-prone enough to fail in the first place.

## Test plan
- [x] TDD: both fixes were written test-first (confirmed RED before implementing)
- [x] `dotnet test` — 514 passed
- [x] `npm run test -- --run` — 303 passed
- [x] `npm run test:e2e -- --project=chromium` — 53 passed
- [x] `npx tsc -b` clean
- [x] `/simplify` — one efficiency finding (sequential DB calls that could run concurrently) applied; reuse/simplification/altitude clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)