### PR TITLE
feat(league): lock league creation to the current sport subdomain

### DIFF
--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -328,4 +328,30 @@ describe('LeaguePortalPage (site admin)', () => {
     expect(toastPush).toHaveBeenCalledWith('bob@example.com added to league', 'success');
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
+
+  // frizat: Create League's Sport field used to be a free-choice dropdown regardless of which
+  // subdomain the admin was on — an admin browsing cfb.* could create an NFL league and vice
+  // versa. The site you're on IS the sport you're creating for, so the field should show the
+  // current sport and not offer the other one at all.
+  it('locks the Create League sport field to the current subdomain, not an editable choice', async () => {
+    sportContext.sport = 'CFB';
+    sportContext.isCfb = true;
+    sportContext.isNfl = false;
+    renderPage();
+    await userEvent.click(await screen.findByRole('button', { name: /create league/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    const sportField = within(dialog).getByLabelText(/^sport$/i);
+    expect(sportField).toHaveValue('CFB');
+    expect(sportField).toBeDisabled();
+    expect(within(dialog).queryByRole('option', { name: /^nfl$/i })).not.toBeInTheDocument();
+  });
+
+  it('locks the Create League sport field to NFL on the NFL subdomain', async () => {
+    renderPage();
+    await userEvent.click(await screen.findByRole('button', { name: /create league/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByLabelText(/^sport$/i)).toHaveValue('NFL');
+  });
 });

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -76,13 +76,16 @@ export default function LeaguePortalPage() {
   const { user } = useAuth();
   const admin = isAdmin(user);
   const toast = useToast();
+  // The wire-format LeagueType for whichever sport's subdomain we're currently on — shared by
+  // the platform-wide league filter below and Create League's locked Sport field.
+  const currentLeagueType = isCfb ? 'Cfb' : 'Nfl';
 
   const [allLeagues, setAllLeagues] = useState<LeagueInfoDto[]>([]);
   const [allLeaguesLoaded, setAllLeaguesLoaded] = useState(false);
   // Admins see every league platform-wide (allLeagues), but still only for the sport they're
   // currently on — ownedLeagues already applies this same filter for non-admins (session.tsx).
   const leagueOptions = admin
-    ? allLeagues.filter((l) => l.leagueType === (isCfb ? 'Cfb' : 'Nfl'))
+    ? allLeagues.filter((l) => l.leagueType === currentLeagueType)
     : ownedLeagues;
   // Guards the empty state against the pre-fetch window — without it, an admin with leagues
   // platform-wide would see a false "no leagues yet" flash while allLeagues is still [].
@@ -260,7 +263,7 @@ export default function LeaguePortalPage() {
   };
 
   const openCreateLeague = () => {
-    setNewLeagueForm({ leagueName: '', leagueType: 'Nfl', ownerUserId: user?.userId ?? '' });
+    setNewLeagueForm({ leagueName: '', leagueType: currentLeagueType, ownerUserId: user?.userId ?? '' });
     setCreateLeagueOpen(true);
   };
 
@@ -472,17 +475,14 @@ export default function LeaguePortalPage() {
               value={newLeagueForm.leagueName}
               onChange={(e) => setNewLeagueForm((f) => ({ ...f, leagueName: e.target.value }))}
             />
-            <FormControl size="small">
-              <InputLabel>Sport</InputLabel>
-              <Select
-                value={newLeagueForm.leagueType}
-                label="Sport"
-                onChange={(e) => setNewLeagueForm((f) => ({ ...f, leagueType: e.target.value }))}
-              >
-                <MenuItem value="Nfl">NFL</MenuItem>
-                <MenuItem value="Cfb">CFB</MenuItem>
-              </Select>
-            </FormControl>
+            {/* frizat: the site you're on IS the sport you're creating for — locked, not a
+                choice, so there's no way to accidentally create a CFB league from the NFL
+                site (or vice versa) the way the old editable dropdown allowed. */}
+            <TextField
+              label="Sport"
+              value={isCfb ? 'CFB' : 'NFL'}
+              disabled
+            />
             {admin && (
               <TextField
                 select

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -328,6 +328,75 @@ public class LeagueOwnershipTests
         Assert.Null(roleAttr); // any authenticated user may call this now — class-level [Authorize] still applies
     }
 
+    // frizat: the frontend locks the Create League Sport field to the current subdomain, but a
+    // crafted/replayed request can still send a mismatched LeagueType directly — this is the
+    // server-side backstop, mirroring useSportContext's own cfb.-prefix host check.
+    //
+    // Origin is the PRIMARY signal, not Host: prod traffic goes through Vercel's /api/:path*
+    // rewrite to the Railway backend with no UseForwardedHeaders middleware, so Request.Host
+    // reflects Railway's own domain, not cfb.ivleague.xyz — using Host directly would silently
+    // resolve every request to Nfl. Origin survives the rewrite untouched (same mechanism the
+    // existing ALLOWED_ORIGINS/CORS check already relies on). Host is only a last-resort
+    // fallback for the no-Origin-no-Referer case (e.g. this test suite's plain DefaultHttpContext).
+    [Fact]
+    public async Task CreateLeague_ReturnsBadRequest_WhenLeagueTypeDoesNotMatchOrigin()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        ctrl.ControllerContext.HttpContext.Request.Headers.Origin = "https://cfb.ivleague.xyz";
+        repo.LeagueExistsAsync(Arg.Any<string>()).Returns(false);
+
+        var dto = new LeagueCreateDto("My League", LeagueType.Nfl, OwnerId, 2025, 0, 0, 0, 0);
+        var result = await ctrl.CreateLeague(dto);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        await repo.DidNotReceive().AddLeagueInfoAsync(Arg.Any<LeagueInfo>());
+    }
+
+    [Fact]
+    public async Task CreateLeague_Succeeds_WhenLeagueTypeMatchesCfbOrigin()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        ctrl.ControllerContext.HttpContext.Request.Headers.Origin = "https://cfb.ivleague.xyz";
+        repo.LeagueExistsAsync(Arg.Any<string>()).Returns(false);
+        var createdLeague = new LeagueInfo { Id = 42, LeagueName = "My League", OwnerUserId = OwnerId, LeagueType = LeagueType.Cfb };
+        repo.AddLeagueInfoAsync(Arg.Any<LeagueInfo>()).Returns(Task.FromResult(createdLeague));
+
+        var dto = new LeagueCreateDto("My League", LeagueType.Cfb, OwnerId, 2025, 0, 0, 0, 0);
+        var result = await ctrl.CreateLeague(dto);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    // Origin absent (e.g. some non-browser callers omit it) but Referer present — same host
+    // extraction, second-priority fallback.
+    [Fact]
+    public async Task CreateLeague_ResolvesSportFromReferer_WhenOriginIsAbsent()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        ctrl.ControllerContext.HttpContext.Request.Headers.Referer = "https://cfb.ivleague.xyz/league/manage";
+        repo.LeagueExistsAsync(Arg.Any<string>()).Returns(false);
+
+        var dto = new LeagueCreateDto("My League", LeagueType.Nfl, OwnerId, 2025, 0, 0, 0, 0);
+        var result = await ctrl.CreateLeague(dto);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    // Neither Origin nor Referer present — falls back to Host (matches this test suite's plain
+    // DefaultHttpContext, and is the pre-existing behavior for that edge case).
+    [Fact]
+    public async Task CreateLeague_FallsBackToHost_WhenOriginAndRefererAreBothAbsent()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        ctrl.ControllerContext.HttpContext.Request.Host = new HostString("cfb.ivleague.xyz");
+        repo.LeagueExistsAsync(Arg.Any<string>()).Returns(false);
+
+        var dto = new LeagueCreateDto("My League", LeagueType.Nfl, OwnerId, 2025, 0, 0, 0, 0);
+        var result = await ctrl.CreateLeague(dto);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
     // frizat-d6l live-testing follow-up: the CreateLeague_* tests above construct LeagueCreateDto
     // directly as a C# record, which never exercises JSON deserialization — so they all passed
     // while the real [FromBody] endpoint 400'd on every request. The frontend sends leagueType as

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -639,6 +639,18 @@ public class LeagueController(
     [ProducesResponseType(typeof(LeagueInfoDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> CreateLeague([FromBody] LeagueCreateDto dto) {
+        // Mirrors useSportContext's own host-prefix check (Client.React/src/services/sport.tsx) —
+        // the frontend locks the Sport field to the current subdomain, but a crafted/replayed
+        // request could still send a mismatched LeagueType directly without this backstop.
+        // Request.Host can't be used here: prod traffic goes through Vercel's /api/:path*
+        // rewrite to the Railway backend (see CLAUDE.md's proxy note), and there's no
+        // UseForwardedHeaders middleware, so Host reflects Railway's own domain, not
+        // cfb.ivleague.xyz — it would resolve to Nfl for every request. Origin/Referer survive
+        // the rewrite untouched and are what the existing ALLOWED_ORIGINS/CORS check already
+        // relies on for this exact same-origin-per-sport distinction.
+        var requestSport = ResolveRequestSport(Request);
+        if (dto.LeagueType != requestSport)
+            return BadRequest($"League type '{dto.LeagueType}' does not match the current site.");
         if (await repo.LeagueExistsAsync(dto.LeagueName))
             return Conflict($"A league named '{dto.LeagueName}' already exists.");
         var ownerUserId = User.IsInRole(AppRoles.Administrator)
@@ -666,6 +678,23 @@ public class LeagueController(
         });
         return Ok(new LeagueInfoDto { Id = league.Id, LeagueName = league.LeagueName, LeagueType = league.LeagueType, OwnerUserId = league.OwnerUserId, DateCreated = league.DateCreated });
     }
+
+    // Prefers Origin (sent on every state-changing fetch, including same-origin ones — see
+    // CreateLeague's comment on why Host can't be used here), falls back to Referer, and if
+    // neither header is present at all falls back to Host rather than blind-guessing Nfl.
+    private static LeagueType ResolveRequestSport(HttpRequest request) {
+        var origin = request.Headers.Origin.FirstOrDefault();
+        if (origin is not null && Uri.TryCreate(origin, UriKind.Absolute, out var originUri))
+            return HostIsCfb(originUri.Host) ? LeagueType.Cfb : LeagueType.Nfl;
+
+        var referer = request.Headers.Referer.FirstOrDefault();
+        if (referer is not null && Uri.TryCreate(referer, UriKind.Absolute, out var refererUri))
+            return HostIsCfb(refererUri.Host) ? LeagueType.Cfb : LeagueType.Nfl;
+
+        return HostIsCfb(request.Host.Host) ? LeagueType.Cfb : LeagueType.Nfl;
+    }
+
+    private static bool HostIsCfb(string host) => host.StartsWith("cfb.", StringComparison.OrdinalIgnoreCase);
 
     [HttpPut("{leagueId:int}/owner/{newOwnerUserId}")]
     [Authorize(Roles = AppRoles.Administrator)]


### PR DESCRIPTION
## Summary
- Create League's Sport field is now locked to the current subdomain instead of an editable NFL/CFB dropdown — the site you're on is the sport you're creating for, so there's no way to create a CFB league from the NFL site (or vice versa) anymore.
- Server-side backstop added to `CreateLeague` rejecting a mismatched `LeagueType`. Resolves sport from `Origin`/`Referer` (falling back to `Host`) rather than `Request.Host` directly — Vercel's `/api/:path*` rewrite to the Railway backend means `Host` reflects Railway's own domain in prod, not `cfb.ivleague.xyz`. An earlier version of this keyed off `Host` and would have silently rejected all real CFB league creation in production; caught during `/simplify`'s altitude review before merge.

## Test plan
- [x] TDD throughout, confirmed RED before each implementation
- [x] `dotnet test` — 518 passed
- [x] `npm run test -- --run` — 305 passed
- [x] `npm run test:e2e -- --project=chromium` — 53 passed
- [x] `npx tsc -b` clean
- [x] `/simplify` — two real findings applied (duplicated sport-mapping ternary extracted to one local constant; the Host-vs-Origin production bug described above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)