### PR TITLE
feat(league): rename payout labels, add Delete League, soft-delete Remove Member

### DIFF
--- a/Client.React/e2e/leaguePortal.spec.ts
+++ b/Client.React/e2e/leaguePortal.spec.ts
@@ -45,11 +45,11 @@ test.describe('Commissioner portal (/league/manage)', () => {
     await expect(page.getByText(/members.*\$100\/season/)).toBeVisible({ timeout: 5000 });
   });
 
-  test('Juice Settings tab loads existing juice values', async ({ page }) => {
+  test('League Payouts tab loads existing juice values', async ({ page }) => {
     await ownerAuth(page);
     await waitForSpinner(page);
 
-    await page.getByRole('tab', { name: /juice settings/i }).click();
+    await page.getByRole('tab', { name: /league payouts/i }).click();
     await waitForSpinner(page);
 
     // Mocked juice: 13 pts tease — "Tease Pts (Regular Season)" label should be visible

--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -49,6 +49,7 @@ vi.mock('../api/league', () => ({
   createLeague: vi.fn(),
   addLeagueUserMapping: vi.fn(),
   assignLeagueOwner: vi.fn(),
+  deleteLeague: vi.fn(),
 }));
 import {
   getLeagueUserMappings,
@@ -58,6 +59,7 @@ import {
   getUsers,
   createLeague,
   addLeagueUserMapping,
+  deleteLeague,
 } from '../api/league';
 
 const mockedGetMappings = vi.mocked(getLeagueUserMappings);
@@ -67,6 +69,7 @@ const mockedGetAllLeagues = vi.mocked(getAllLeagues);
 const mockedGetUsers = vi.mocked(getUsers);
 const mockedCreateLeague = vi.mocked(createLeague);
 const mockedAddLeagueUserMapping = vi.mocked(addLeagueUserMapping);
+const mockedDeleteLeague = vi.mocked(deleteLeague);
 
 const CURRENT_SEASON = new Date().getFullYear();
 
@@ -126,6 +129,7 @@ beforeEach(() => {
   mockedGetUsers.mockResolvedValue([makeUser()]);
   mockedCreateLeague.mockResolvedValue(makeLeague({ id: 99, leagueName: 'New League' }));
   mockedAddLeagueUserMapping.mockResolvedValue(undefined);
+  mockedDeleteLeague.mockResolvedValue(undefined);
   sessionState.reloadLeagues.mockClear();
   toastPush.mockClear();
 });
@@ -139,7 +143,7 @@ describe('LeaguePortalPage (owner, non-admin)', () => {
 
   it('locks juice fields for a past season and keeps them editable for the current season', async () => {
     renderPage();
-    await userEvent.click(await screen.findByRole('tab', { name: 'Juice Settings' }));
+    await userEvent.click(await screen.findByRole('tab', { name: 'League Payouts' }));
 
     const seasonSelect = screen.getAllByRole('combobox')[0];
     await userEvent.click(seasonSelect);
@@ -154,6 +158,16 @@ describe('LeaguePortalPage (owner, non-admin)', () => {
 
     await waitFor(() => expect(screen.getByLabelText(/Tease Pts \(Regular Season\)/i)).not.toBeDisabled());
     expect(screen.getByRole('button', { name: /save/i })).not.toBeDisabled();
+  });
+
+  // frizat: "Juice Settings"/"Weekly Cost" read as gambling jargon to a general audience —
+  // renamed to plain language. Locking in the new copy so this doesn't silently regress.
+  it('shows the League Payouts tab and Cost Per Week field with plain-language labels', async () => {
+    renderPage();
+    await userEvent.click(await screen.findByRole('tab', { name: 'League Payouts' }));
+    expect(await screen.findByLabelText(/cost per week/i)).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: /juice settings/i })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/weekly cost/i)).not.toBeInTheDocument();
   });
 
   it('does not show a raw owner id on the Info tab', async () => {
@@ -195,6 +209,42 @@ describe('LeaguePortalPage (owner, non-admin)', () => {
       expect.objectContaining({ leagueName: 'New League', ownerUserId: 'owner-1' })
     ));
     expect(sessionState.reloadLeagues).toHaveBeenCalled();
+  });
+
+  // frizat: Remove Member is now a soft-delete (kept for audit/history, can be re-added) — the
+  // dialog copy must say so, not "cannot be undone", which stopped being true.
+  it('tells the admin a removed member can be re-added, not that it cannot be undone', async () => {
+    renderPage();
+    await userEvent.click(await screen.findByRole('button', { name: /remove/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(/re-added/i)).toBeInTheDocument();
+    expect(within(dialog).queryByText(/cannot be undone/i)).not.toBeInTheDocument();
+  });
+
+  // frizat: deleting an entire league (all picks, members, payout history) is a much bigger
+  // blast radius than removing one member, so a plain Cancel/Confirm click is too easy to
+  // mis-click — the confirm button stays disabled until the league name is typed exactly.
+  it('gates Delete League behind typing the exact league name, then deletes it', async () => {
+    renderPage();
+    await userEvent.click(await screen.findByRole('tab', { name: 'Info' }));
+    await userEvent.click(await screen.findByRole('button', { name: /delete league/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    const confirmButton = within(dialog).getByRole('button', { name: /^delete league$/i });
+    expect(confirmButton).toBeDisabled();
+
+    const confirmInput = within(dialog).getByLabelText(/league name/i);
+    await userEvent.type(confirmInput, 'Demo Leagu');
+    expect(confirmButton).toBeDisabled();
+
+    await userEvent.type(confirmInput, 'e');
+    expect(confirmButton).not.toBeDisabled();
+
+    await userEvent.click(confirmButton);
+
+    await waitFor(() => expect(mockedDeleteLeague).toHaveBeenCalledWith(1));
+    expect(toastPush).toHaveBeenCalledWith(expect.stringMatching(/deleted/i), 'success');
   });
 });
 

--- a/Client.React/src/api/league.ts
+++ b/Client.React/src/api/league.ts
@@ -154,6 +154,10 @@ export async function removeLeagueMember(leagueId: number, userId: string) {
   await http.delete(`/api/league/${leagueId}/members/${encodeURIComponent(userId)}`);
 }
 
+export async function deleteLeague(leagueId: number) {
+  await http.delete(`/api/league/${leagueId}`);
+}
+
 export async function inviteToLeague(leagueId: number, email: string) {
   await http.post(`/api/league/${leagueId}/invite`, { email, baseUrl: window.location.origin });
 }

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -47,6 +47,7 @@ import {
   createLeague,
   addLeagueUserMapping,
   assignLeagueOwner,
+  deleteLeague,
 } from '../api/league';
 import type { LeagueInfoDto, LeagueJuiceMappingDto, LeagueCostDto, UserSummaryDto } from '../types/admin';
 import type { LeagueUserMappingDto } from '../types/league';
@@ -132,6 +133,12 @@ export default function LeaguePortalPage() {
   const [assignOwnerOpen, setAssignOwnerOpen] = useState(false);
   const [newOwnerId, setNewOwnerId] = useState('');
   const [assigningOwner, setAssigningOwner] = useState(false);
+
+  // Owner or admin: Delete League dialog (Info tab) — type-to-confirm since this permanently
+  // removes the league's members, payout settings, picks, and invitations along with it.
+  const [deleteLeagueOpen, setDeleteLeagueOpen] = useState(false);
+  const [deleteConfirmText, setDeleteConfirmText] = useState('');
+  const [deletingLeague, setDeletingLeague] = useState(false);
 
   const loadAllLeagues = useCallback(async () => {
     if (!admin) return;
@@ -336,6 +343,27 @@ export default function LeaguePortalPage() {
     }
   };
 
+  const openDeleteLeague = () => {
+    setDeleteConfirmText('');
+    setDeleteLeagueOpen(true);
+  };
+
+  const handleDeleteLeague = async () => {
+    if (!selectedLeague) return;
+    setDeletingLeague(true);
+    try {
+      await deleteLeague(selectedLeague.id);
+      toast.push(`League "${selectedLeague.leagueName}" deleted`, 'success');
+      setDeleteLeagueOpen(false);
+      setSelectedLeague(null);
+      await Promise.all([loadAllLeagues(), reloadLeagues()]);
+    } catch {
+      toast.push('Failed to delete league', 'error');
+    } finally {
+      setDeletingLeague(false);
+    }
+  };
+
   const currentJuiceMapping = juiceMappings.find((m) => m.season === selectedSeason);
   const availableSeasons = juiceMappings.map((m) => m.season).sort((a, b) => b - a);
   if (!availableSeasons.includes(CURRENT_SEASON)) availableSeasons.unshift(CURRENT_SEASON);
@@ -390,7 +418,7 @@ export default function LeaguePortalPage() {
         <>
           <Tabs value={tab} onChange={(_, v: number) => setTab(v)} sx={{ mb: 2 }}>
             <Tab label="Members" />
-            <Tab label="Juice Settings" />
+            <Tab label="League Payouts" />
             <Tab label="Info" />
           </Tabs>
 
@@ -421,7 +449,13 @@ export default function LeaguePortalPage() {
             />
           )}
           {tab === 2 && (
-            <InfoTab league={selectedLeague} isAdmin={admin} onChangeOwner={openAssignOwner} />
+            <InfoTab
+              league={selectedLeague}
+              isAdmin={admin}
+              canDelete={admin || selectedLeague.ownerUserId === user?.userId}
+              onChangeOwner={openAssignOwner}
+              onDeleteLeague={openDeleteLeague}
+            />
           )}
         </>
       )}
@@ -431,7 +465,8 @@ export default function LeaguePortalPage() {
         <DialogContent>
           <Typography>
             Remove <strong>{removeTarget?.userName ?? removeTarget?.userId}</strong> from{' '}
-            <strong>{selectedLeague?.leagueName}</strong>? This cannot be undone.
+            <strong>{selectedLeague?.leagueName}</strong>? Their pick history is kept, and they
+            can be re-added later.
           </Typography>
         </DialogContent>
         <DialogActions>
@@ -555,6 +590,35 @@ export default function LeaguePortalPage() {
           <Button onClick={() => setAssignOwnerOpen(false)}>Cancel</Button>
           <Button variant="contained" onClick={() => void handleAssignOwner()} disabled={assigningOwner || !newOwnerId}>
             {assigningOwner ? <CircularProgress size={18} /> : 'Assign'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={deleteLeagueOpen} onClose={() => setDeleteLeagueOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Delete League</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <Typography>
+              Deleting <strong>{selectedLeague?.leagueName}</strong> permanently removes its members,
+              payout settings, picks, and invitations. This cannot be undone.
+            </Typography>
+            <TextField
+              autoFocus
+              label="Type the league name to confirm"
+              value={deleteConfirmText}
+              onChange={(e) => setDeleteConfirmText(e.target.value)}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteLeagueOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={() => void handleDeleteLeague()}
+            disabled={deletingLeague || deleteConfirmText !== selectedLeague?.leagueName}
+          >
+            {deletingLeague ? <CircularProgress size={18} /> : 'Delete League'}
           </Button>
         </DialogActions>
       </Dialog>
@@ -707,7 +771,7 @@ function JuiceTab({
           onChange={(e) => onJuiceFormChange('juiceConference', Number(e.target.value))}
         />
         <TextField
-          label="Weekly Cost ($)"
+          label="Cost Per Week ($)"
           type="number"
           size="small"
           disabled={locked}
@@ -722,7 +786,11 @@ function JuiceTab({
   );
 }
 
-function InfoTab({ league, isAdmin: admin, onChangeOwner }: { league: LeagueInfoDto; isAdmin: boolean; onChangeOwner: () => void }) {
+function InfoTab({
+  league, isAdmin: admin, canDelete, onChangeOwner, onDeleteLeague,
+}: {
+  league: LeagueInfoDto; isAdmin: boolean; canDelete: boolean; onChangeOwner: () => void; onDeleteLeague: () => void;
+}) {
   return (
     <Box sx={{ maxWidth: 400 }}>
       <Stack spacing={1.5} divider={<Divider />}>
@@ -742,6 +810,13 @@ function InfoTab({ league, isAdmin: admin, onChangeOwner }: { league: LeagueInfo
           <Stack direction="row" justifyContent="flex-end">
             <Button size="small" variant="outlined" onClick={onChangeOwner}>
               Change Owner
+            </Button>
+          </Stack>
+        )}
+        {canDelete && (
+          <Stack direction="row" justifyContent="flex-end">
+            <Button size="small" color="error" startIcon={<DeleteIcon />} onClick={onDeleteLeague}>
+              Delete League
             </Button>
           </Stack>
         )}

--- a/Server.UnitTests/DemoDataSeederLeaguePurgeTests.cs
+++ b/Server.UnitTests/DemoDataSeederLeaguePurgeTests.cs
@@ -71,4 +71,62 @@ public class DemoDataSeederLeaguePurgeTests {
 
         Assert.Equal(2, await db.LeagueInfo.CountAsync());
     }
+
+    // frizat: DemoDataSeeder's class doc comment promises "Idempotent — safe to call on every
+    // startup." Before soft-delete, a removed member's row was hard-deleted, so a bare
+    // AnyAsync-then-Add self-healed on reseed. Now the row persists with IsActive=false, so a
+    // naive AnyAsync check sees it as "already exists" and never reactivates it — permanently
+    // excluding a demo user from the league the moment anyone exercises the new Remove Member
+    // feature against the demo stack, contradicting the seeder's own idempotency contract.
+    [Fact]
+    public async Task EnsureActiveLeagueMemberAsync_ReactivatesExistingInactiveRow() {
+        await using var db = BuildDb(nameof(EnsureActiveLeagueMemberAsync_ReactivatesExistingInactiveRow));
+        var league = new LeagueInfo { LeagueName = "Demo League", OwnerUserId = "admin-1" };
+        db.LeagueInfo.Add(league);
+        await db.SaveChangesAsync();
+        var originalJoinDate = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        db.LeagueUserMapping.Add(new LeagueUserMapping {
+            LeagueId = league.Id, UserId = "eve-1", IsActive = false,
+            RemovedAt = DateTimeOffset.UtcNow, DateCreated = originalJoinDate,
+        });
+        await db.SaveChangesAsync();
+
+        var seeder = new DemoDataSeeder(db, BuildUserManager(), BuildConfiguration());
+        await seeder.EnsureActiveLeagueMemberAsync(league.Id, "eve-1");
+
+        var mappings = await db.LeagueUserMapping.Where(m => m.LeagueId == league.Id && m.UserId == "eve-1").ToListAsync();
+        Assert.Single(mappings);
+        Assert.True(mappings[0].IsActive);
+        Assert.Null(mappings[0].RemovedAt);
+        Assert.Equal(originalJoinDate, mappings[0].DateCreated);
+    }
+
+    [Fact]
+    public async Task EnsureActiveLeagueMemberAsync_InsertsNewRow_WhenNoneExists() {
+        await using var db = BuildDb(nameof(EnsureActiveLeagueMemberAsync_InsertsNewRow_WhenNoneExists));
+        var league = new LeagueInfo { LeagueName = "Demo League", OwnerUserId = "admin-1" };
+        db.LeagueInfo.Add(league);
+        await db.SaveChangesAsync();
+
+        var seeder = new DemoDataSeeder(db, BuildUserManager(), BuildConfiguration());
+        await seeder.EnsureActiveLeagueMemberAsync(league.Id, "eve-1");
+
+        var mapping = await db.LeagueUserMapping.SingleAsync(m => m.LeagueId == league.Id && m.UserId == "eve-1");
+        Assert.True(mapping.IsActive);
+    }
+
+    [Fact]
+    public async Task EnsureActiveLeagueMemberAsync_IsANoOp_WhenAlreadyActive() {
+        await using var db = BuildDb(nameof(EnsureActiveLeagueMemberAsync_IsANoOp_WhenAlreadyActive));
+        var league = new LeagueInfo { LeagueName = "Demo League", OwnerUserId = "admin-1" };
+        db.LeagueInfo.Add(league);
+        await db.SaveChangesAsync();
+        db.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = league.Id, UserId = "eve-1" });
+        await db.SaveChangesAsync();
+
+        var seeder = new DemoDataSeeder(db, BuildUserManager(), BuildConfiguration());
+        await seeder.EnsureActiveLeagueMemberAsync(league.Id, "eve-1");
+
+        Assert.Single(await db.LeagueUserMapping.Where(m => m.LeagueId == league.Id && m.UserId == "eve-1").ToListAsync());
+    }
 }

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -223,6 +223,42 @@ public class LeagueOwnershipTests
     }
 
     [Fact]
+    public async Task DeleteLeague_ReturnsForbid_WhenCallerIsNotOwnerOrAdmin()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
+
+        var result = await ctrl.DeleteLeague(1);
+
+        Assert.IsType<ForbidResult>(result);
+        await repo.DidNotReceive().DeleteLeagueAsync(Arg.Any<int>());
+    }
+
+    [Fact]
+    public async Task DeleteLeague_ReturnsNoContent_WhenCallerIsOwner()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
+
+        var result = await ctrl.DeleteLeague(1);
+
+        Assert.IsType<NoContentResult>(result);
+        await repo.Received(1).DeleteLeagueAsync(1);
+    }
+
+    [Fact]
+    public async Task DeleteLeague_ReturnsNoContent_WhenCallerIsAdmin()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId, isAdmin: true));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
+
+        var result = await ctrl.DeleteLeague(1);
+
+        Assert.IsType<NoContentResult>(result);
+        await repo.Received(1).DeleteLeagueAsync(1);
+    }
+
+    [Fact]
     public async Task GetLeagueCost_ReturnsCorrectCostForBaseTier()
     {
         var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -222,6 +222,24 @@ public class LeagueOwnershipTests
         await repo.Received(1).RemoveLeagueUserMappingAsync(1, "victim-003");
     }
 
+    // frizat: GetLeagueInfoAsync's real (non-mocked) implementation uses FirstAsync(), which
+    // throws InvalidOperationException rather than returning null for a missing league — a
+    // double-submitted delete (slow network, already-deleted league) would otherwise 500 instead
+    // of a clean 404. This is realistic specifically for a delete endpoint, unlike the read/update
+    // endpoints elsewhere in this controller that share the same GetLeagueInfoAsync-then-use
+    // pattern against a league the frontend already has loaded.
+    [Fact]
+    public async Task DeleteLeague_ReturnsNotFound_WhenLeagueDoesNotExist()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(999).Returns(Task.FromException<LeagueInfo>(new InvalidOperationException("Sequence contains no elements")));
+
+        var result = await ctrl.DeleteLeague(999);
+
+        Assert.IsType<NotFoundResult>(result);
+        await repo.DidNotReceive().DeleteLeagueAsync(Arg.Any<int>());
+    }
+
     [Fact]
     public async Task DeleteLeague_ReturnsForbid_WhenCallerIsNotOwnerOrAdmin()
     {

--- a/Server.UnitTests/LeagueRepositoryTests.cs
+++ b/Server.UnitTests/LeagueRepositoryTests.cs
@@ -1,3 +1,6 @@
+using FourPlayWebApp.Server.Models;
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Repositories;
 using FourPlayWebApp.Shared.Models.Data;
 using Microsoft.EntityFrameworkCore;
@@ -39,5 +42,163 @@ public class LeagueRepositoryTests
 
         Assert.Contains((2026, 3), weeksWithData);
         Assert.DoesNotContain((2026, 4), weeksWithData);
+    }
+
+    // ── DeleteLeagueAsync ──────────────────────────────────────────────────────
+
+    // frizat: mirrors DemoDataSeeder.PurgeUnknownLeaguesAsync's explicit ordered RemoveRange —
+    // every FK off LeagueInfo is DB-level Cascade already, but deleting explicitly (not relying
+    // solely on cascade) keeps this correct against the in-memory provider too, which doesn't
+    // enforce relational FK cascade the way real Postgres does.
+    [Fact]
+    public async Task DeleteLeagueAsync_RemovesLeagueAndAllDependentRows()
+    {
+        var factory = new DbContextFactoryStub(nameof(DeleteLeagueAsync_RemovesLeagueAndAllDependentRows));
+        var seedDb = factory.CreateDbContext();
+
+        var league = new LeagueInfo { LeagueName = "Doomed League", OwnerUserId = "owner-1" };
+        var otherLeague = new LeagueInfo { LeagueName = "Untouched League", OwnerUserId = "owner-2" };
+        seedDb.LeagueInfo.AddRange(league, otherLeague);
+        await seedDb.SaveChangesAsync();
+
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = league.Id, UserId = "owner-1" });
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = otherLeague.Id, UserId = "owner-2" });
+        seedDb.LeagueJuiceMapping.Add(new LeagueJuiceMapping {
+            LeagueId = league.Id, Season = 2025, Juice = 13, JuiceDivisional = 10, JuiceConference = 6, WeeklyCost = 5,
+        });
+        seedDb.NflPicks.Add(new NflPicks { LeagueId = league.Id, UserId = "owner-1", Team = "BUF", NflWeek = 1, Season = 2025 });
+        seedDb.CfbPicks.Add(new CfbPicks { LeagueId = league.Id, UserId = "owner-1", Team = "MICH", CfbSlateId = 1, Season = 2025 });
+        seedDb.Invitations.Add(new Invitation { Email = "friend@example.com", LeagueId = league.Id, InvitedByUserId = "owner-1" });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        await repo.DeleteLeagueAsync(league.Id);
+
+        var db = factory.CreateDbContext();
+        Assert.False(await db.LeagueInfo.AnyAsync(l => l.Id == league.Id));
+        Assert.False(await db.LeagueUserMapping.AnyAsync(m => m.LeagueId == league.Id));
+        Assert.False(await db.LeagueJuiceMapping.AnyAsync(m => m.LeagueId == league.Id));
+        Assert.False(await db.NflPicks.AnyAsync(p => p.LeagueId == league.Id));
+        Assert.False(await db.CfbPicks.AnyAsync(p => p.LeagueId == league.Id));
+        Assert.False(await db.Invitations.AnyAsync(i => i.LeagueId == league.Id));
+
+        // Unrelated league and its own mapping survive untouched.
+        Assert.True(await db.LeagueInfo.AnyAsync(l => l.Id == otherLeague.Id));
+        Assert.True(await db.LeagueUserMapping.AnyAsync(m => m.LeagueId == otherLeague.Id));
+    }
+
+    // ── Soft-delete league membership ───────────────────────────────────────────
+    // frizat: removing a member must keep their pick history for audit purposes — flip IsActive
+    // instead of hard-deleting the LeagueUserMapping row.
+
+    [Fact]
+    public async Task RemoveLeagueUserMappingAsync_SetsInactive_DoesNotDeleteRow()
+    {
+        var factory = new DbContextFactoryStub(nameof(RemoveLeagueUserMappingAsync_SetsInactive_DoesNotDeleteRow));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = 1, UserId = "user-1" });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        await repo.RemoveLeagueUserMappingAsync(1, "user-1");
+
+        var db = factory.CreateDbContext();
+        var mapping = await db.LeagueUserMapping.SingleAsync(m => m.LeagueId == 1 && m.UserId == "user-1");
+        Assert.False(mapping.IsActive);
+        Assert.NotNull(mapping.RemovedAt);
+    }
+
+    // frizat: (LeagueId, UserId) is unique — a removed-then-re-added user must reactivate their
+    // existing row, not insert a second one (would violate the unique index against real Postgres).
+    [Fact]
+    public async Task AddLeagueUserMappingAsync_ReactivatesExistingInactiveRow_InsteadOfInserting()
+    {
+        var factory = new DbContextFactoryStub(nameof(AddLeagueUserMappingAsync_ReactivatesExistingInactiveRow_InsteadOfInserting));
+        var seedDb = factory.CreateDbContext();
+        var originalJoinDate = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping {
+            LeagueId = 1, UserId = "user-1", IsActive = false,
+            RemovedAt = DateTimeOffset.UtcNow, DateCreated = originalJoinDate,
+        });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        await repo.AddLeagueUserMappingAsync(new LeagueUserMapping { LeagueId = 1, UserId = "user-1" });
+
+        var db = factory.CreateDbContext();
+        var mappings = await db.LeagueUserMapping.Where(m => m.LeagueId == 1 && m.UserId == "user-1").ToListAsync();
+        Assert.Single(mappings);
+        Assert.True(mappings[0].IsActive);
+        Assert.Null(mappings[0].RemovedAt);
+        Assert.Equal(originalJoinDate, mappings[0].DateCreated); // original join date preserved, not clobbered
+    }
+
+    [Fact]
+    public async Task GetLeagueUserMappingsAsync_ByLeagueId_ExcludesInactiveMembers()
+    {
+        var factory = new DbContextFactoryStub(nameof(GetLeagueUserMappingsAsync_ByLeagueId_ExcludesInactiveMembers));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueInfo.Add(new LeagueInfo { Id = 1, LeagueName = "L", OwnerUserId = "active-user" });
+        seedDb.Users.AddRange(
+            new ApplicationUser { Id = "active-user", UserName = "active-user" },
+            new ApplicationUser { Id = "removed-user", UserName = "removed-user" });
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = 1, UserId = "active-user" });
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = 1, UserId = "removed-user", IsActive = false, RemovedAt = DateTimeOffset.UtcNow });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        var mappings = await repo.GetLeagueUserMappingsAsync(1);
+
+        Assert.Single(mappings);
+        Assert.Equal("active-user", mappings[0].UserId);
+    }
+
+    [Fact]
+    public async Task GetLeagueUserMappingsAsync_ByUser_ExcludesInactiveMemberships()
+    {
+        var factory = new DbContextFactoryStub(nameof(GetLeagueUserMappingsAsync_ByUser_ExcludesInactiveMemberships));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueInfo.AddRange(
+            new LeagueInfo { Id = 1, LeagueName = "L1", OwnerUserId = "user-1" },
+            new LeagueInfo { Id = 2, LeagueName = "L2", OwnerUserId = "user-1" });
+        seedDb.Users.Add(new ApplicationUser { Id = "user-1", UserName = "user-1" });
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = 1, UserId = "user-1" });
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = 2, UserId = "user-1", IsActive = false, RemovedAt = DateTimeOffset.UtcNow });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        var mappings = await repo.GetLeagueUserMappingsAsync(new ApplicationUser { Id = "user-1" });
+
+        Assert.Single(mappings);
+        Assert.Equal(1, mappings[0].LeagueId);
+    }
+
+    [Fact]
+    public async Task GetLeagueMemberCountAsync_ExcludesInactiveMembers()
+    {
+        var factory = new DbContextFactoryStub(nameof(GetLeagueMemberCountAsync_ExcludesInactiveMembers));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = 1, UserId = "active-user" });
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = 1, UserId = "removed-user", IsActive = false, RemovedAt = DateTimeOffset.UtcNow });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        var count = await repo.GetLeagueMemberCountAsync(1);
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task UserExistsInLeagueAsync_ReturnsFalse_ForInactiveMember()
+    {
+        var factory = new DbContextFactoryStub(nameof(UserExistsInLeagueAsync_ReturnsFalse_ForInactiveMember));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = 1, UserId = "removed-user", IsActive = false, RemovedAt = DateTimeOffset.UtcNow });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        var exists = await repo.UserExistsInLeagueAsync("removed-user", 1);
+
+        Assert.False(exists);
     }
 }

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -804,8 +804,17 @@ public class LeagueController(
     [HttpDelete("{leagueId:int}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> DeleteLeague(int leagueId) {
-        var league = await repo.GetLeagueInfoAsync(leagueId);
+        LeagueInfo league;
+        try {
+            league = await repo.GetLeagueInfoAsync(leagueId);
+        } catch (InvalidOperationException) {
+            // GetLeagueInfoAsync's real implementation throws (FirstAsync) rather than returning
+            // null for a missing league — realistic here specifically: a double-submitted delete
+            // (slow network, already-deleted league) should 404, not 500.
+            return NotFound();
+        }
         var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
             return Forbid();

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -798,6 +798,21 @@ public class LeagueController(
         return NoContent();
     }
 
+    // Every FK off LeagueInfo is DB-level Cascade (see LeagueRepository.DeleteLeagueAsync) — this
+    // permanently removes the league's members, juice settings, picks (NFL + CFB), and
+    // invitations along with it. The UI requires typing the league name to confirm.
+    [HttpDelete("{leagueId:int}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> DeleteLeague(int leagueId) {
+        var league = await repo.GetLeagueInfoAsync(leagueId);
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
+            return Forbid();
+        await repo.DeleteLeagueAsync(leagueId);
+        return NoContent();
+    }
+
     [HttpPost("{leagueId:int}/invite")]
     [ProducesResponseType(typeof(InvitationDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]

--- a/Server/Data/LeagueCascadeDelete.cs
+++ b/Server/Data/LeagueCascadeDelete.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace FourPlayWebApp.Server.Data;
+
+/// <summary>
+/// Shared by LeagueRepository.DeleteLeagueAsync (single league, owner/admin-initiated) and
+/// DemoDataSeeder.PurgeUnknownLeaguesAsync (bulk, startup hygiene) — one place for the ordered
+/// multi-table cascade so a future FK added off LeagueInfo only needs updating here, not in two
+/// independently-drifting copies. Explicit RemoveRange rather than relying solely on the DB's own
+/// Cascade FKs, so this stays correct against providers that don't enforce them (e.g. EF Core's
+/// UseInMemoryDatabase in tests).
+/// </summary>
+internal static class LeagueCascadeDelete {
+    public static void RemoveLeaguesAndDependents(ApplicationDbContext db, IReadOnlyCollection<int> leagueIds) {
+        if (leagueIds.Count == 0) return;
+        db.NflPicks.RemoveRange(db.NflPicks.Where(p => leagueIds.Contains(p.LeagueId)));
+        db.CfbPicks.RemoveRange(db.CfbPicks.Where(p => leagueIds.Contains(p.LeagueId)));
+        db.Invitations.RemoveRange(db.Invitations.Where(i => i.LeagueId != null && leagueIds.Contains(i.LeagueId.Value)));
+        db.LeagueJuiceMapping.RemoveRange(db.LeagueJuiceMapping.Where(m => leagueIds.Contains(m.LeagueId)));
+        db.LeagueUserMapping.RemoveRange(db.LeagueUserMapping.Where(m => leagueIds.Contains(m.LeagueId)));
+        db.LeagueInfo.RemoveRange(db.LeagueInfo.Where(l => leagueIds.Contains(l.Id)));
+    }
+}

--- a/Server/Migrations/20260815155826_AddIsActiveToLeagueUserMapping.Designer.cs
+++ b/Server/Migrations/20260815155826_AddIsActiveToLeagueUserMapping.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260815155826_AddIsActiveToLeagueUserMapping")]
+    partial class AddIsActiveToLeagueUserMapping
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/20260815155826_AddIsActiveToLeagueUserMapping.cs
+++ b/Server/Migrations/20260815155826_AddIsActiveToLeagueUserMapping.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsActiveToLeagueUserMapping : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // defaultValue: true (not EF's inferred `false` for bool) — every existing
+            // LeagueUserMapping row is a currently-active member; defaulting to false would
+            // silently soft-remove every real member in every league the moment this runs.
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                table: "LeagueUserMapping",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "RemovedAt",
+                table: "LeagueUserMapping",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                table: "LeagueUserMapping");
+
+            migrationBuilder.DropColumn(
+                name: "RemovedAt",
+                table: "LeagueUserMapping");
+        }
+    }
+}

--- a/Server/Models/Data/LeagueUserMapping.cs
+++ b/Server/Models/Data/LeagueUserMapping.cs
@@ -9,4 +9,9 @@ public class LeagueUserMapping {
     public string UserId { get; set; }
     public ApplicationUser User { get; set; } // Navigation property
     public DateTimeOffset DateCreated { get; set; } = DateTimeOffset.UtcNow;
+    // Soft-delete: a removed member keeps their row (and their pick history stays intact for
+    // audit purposes) — they're just excluded from active-membership reads. See
+    // LeagueRepository.RemoveLeagueUserMappingAsync / AddLeagueUserMappingAsync.
+    public bool IsActive { get; set; } = true;
+    public DateTimeOffset? RemovedAt { get; set; }
 }

--- a/Server/Services/DemoDataSeeder.cs
+++ b/Server/Services/DemoDataSeeder.cs
@@ -137,6 +137,26 @@ public class DemoDataSeeder(
         Log.Information("DemoDataSeeder: purged {Count} stray league(s) not created by the seeder", strayLeagueIds.Count);
     }
 
+    // frizat: this class's own doc comment promises "Idempotent — safe to call on every startup."
+    // Before soft-delete, a removed member's row was hard-deleted, so a bare AnyAsync-then-Add
+    // self-healed on reseed. Now the row persists with IsActive=false, so every "ensure this demo
+    // member exists" call site must reactivate an existing inactive row (not just skip-if-any-row)
+    // to keep that promise once someone exercises the Remove Member feature against the demo
+    // stack — mirrors LeagueRepository.AddLeagueUserMappingAsync's reactivate-not-duplicate logic.
+    public async Task EnsureActiveLeagueMemberAsync(int leagueId, string userId)
+    {
+        var existing = await db.LeagueUserMapping
+            .FirstOrDefaultAsync(m => m.LeagueId == leagueId && m.UserId == userId);
+        if (existing is null) {
+            db.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = leagueId, UserId = userId });
+            await db.SaveChangesAsync();
+        } else if (!existing.IsActive) {
+            existing.IsActive = true;
+            existing.RemovedAt = null;
+            await db.SaveChangesAsync();
+        }
+    }
+
     private async Task SeedLeagueJuiceMappingAsync(LeagueInfo? league)
     {
         if (league == null) return;
@@ -344,11 +364,7 @@ public class DemoDataSeeder(
         var adminUser = await userManager.FindByEmailAsync(adminEmail);
         if (adminUser == null) return;
 
-        if (await db.LeagueUserMapping.AnyAsync(m => m.LeagueId == league.Id && m.UserId == adminUser.Id))
-            return;
-
-        db.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = league.Id, UserId = adminUser.Id });
-        await db.SaveChangesAsync();
+        await EnsureActiveLeagueMemberAsync(league.Id, adminUser.Id);
         Log.Information("DemoDataSeeder: added admin to Demo League");
     }
 
@@ -420,11 +436,7 @@ public class DemoDataSeeder(
         }
 
         // Ensure league membership
-        if (!await db.LeagueUserMapping.AnyAsync(m => m.LeagueId == league.Id && m.UserId == user.Id))
-        {
-            db.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = league.Id, UserId = user.Id });
-            await db.SaveChangesAsync();
-        }
+        await EnsureActiveLeagueMemberAsync(league.Id, user.Id);
 
         return user;
     }
@@ -970,21 +982,14 @@ public class DemoDataSeeder(
 
         var adminEmail = configuration["ADMIN_EMAIL"] ?? throw new InvalidOperationException("ADMIN_EMAIL required");
         var adminUser = await userManager.FindByEmailAsync(adminEmail);
-        if (adminUser != null && !await db.LeagueUserMapping.AnyAsync(m => m.LeagueId == league.Id && m.UserId == adminUser.Id))
-        {
-            db.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = league.Id, UserId = adminUser.Id });
-            await db.SaveChangesAsync();
-        }
+        if (adminUser != null)
+            await EnsureActiveLeagueMemberAsync(league.Id, adminUser.Id);
 
         foreach (var (_, email) in DemoUsers)
         {
             var user = await userManager.FindByEmailAsync(email);
             if (user == null) continue;
-            if (!await db.LeagueUserMapping.AnyAsync(m => m.LeagueId == league.Id && m.UserId == user.Id))
-            {
-                db.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = league.Id, UserId = user.Id });
-                await db.SaveChangesAsync();
-            }
+            await EnsureActiveLeagueMemberAsync(league.Id, user.Id);
         }
         Log.Information("DemoDataSeeder: added all demo users to CFB Demo League");
     }

--- a/Server/Services/DemoDataSeeder.cs
+++ b/Server/Services/DemoDataSeeder.cs
@@ -131,12 +131,7 @@ public class DemoDataSeeder(
 
         if (strayLeagueIds.Count == 0) return;
 
-        db.NflPicks.RemoveRange(db.NflPicks.Where(p => strayLeagueIds.Contains(p.LeagueId)));
-        db.CfbPicks.RemoveRange(db.CfbPicks.Where(p => strayLeagueIds.Contains(p.LeagueId)));
-        db.Invitations.RemoveRange(db.Invitations.Where(i => i.LeagueId != null && strayLeagueIds.Contains(i.LeagueId.Value)));
-        db.LeagueJuiceMapping.RemoveRange(db.LeagueJuiceMapping.Where(m => strayLeagueIds.Contains(m.LeagueId)));
-        db.LeagueUserMapping.RemoveRange(db.LeagueUserMapping.Where(m => strayLeagueIds.Contains(m.LeagueId)));
-        db.LeagueInfo.RemoveRange(db.LeagueInfo.Where(l => strayLeagueIds.Contains(l.Id)));
+        LeagueCascadeDelete.RemoveLeaguesAndDependents(db, strayLeagueIds);
         await db.SaveChangesAsync();
 
         Log.Information("DemoDataSeeder: purged {Count} stray league(s) not created by the seeder", strayLeagueIds.Count);

--- a/Server/Services/Repositories/Interfaces/ILeagueRepository.cs
+++ b/Server/Services/Repositories/Interfaces/ILeagueRepository.cs
@@ -38,6 +38,7 @@ public interface ILeagueRepository : ISpreadRepository<NflSpreads> {
     Task UpdateLeagueJuiceMappingAsync(LeagueJuiceMapping mapping);
     Task RemoveLeagueUserMappingAsync(int leagueId, string userId);
     Task<int> GetLeagueMemberCountAsync(int leagueId);
+    Task DeleteLeagueAsync(int leagueId);
 
     // Add operations
     Task AddLeagueUserMappingAsync(LeagueUserMapping mapping);

--- a/Server/Services/Repositories/LeagueRepository.cs
+++ b/Server/Services/Repositories/LeagueRepository.cs
@@ -12,7 +12,7 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
     public async Task<List<LeagueUserMapping>> GetLeagueUserMappingsAsync(int leagueId) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
         return await db.LeagueUserMapping
-            .Where(lum => lum.LeagueId == leagueId)
+            .Where(lum => lum.LeagueId == leagueId && lum.IsActive)
             .Include(lum => lum.User)
             .Include(lum => lum.League)
             .ToListAsync();
@@ -21,7 +21,7 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
     public async Task<List<LeagueUserMapping>> GetLeagueUserMappingsAsync(ApplicationUser user) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
         return await db.LeagueUserMapping
-            .Where(lum => lum.UserId == user.Id)
+            .Where(lum => lum.UserId == user.Id && lum.IsActive)
             .Include(lum => lum.User)
             .Include(lum => lum.League)
             .ToListAsync();
@@ -260,25 +260,46 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
         await db.SaveChangesAsync();
     }
 
+    // Soft-delete — keeps the row (and the member's pick history) for audit purposes, just
+    // excluded from active-membership reads (see the IsActive filters throughout this class).
     public async Task RemoveLeagueUserMappingAsync(int leagueId, string userId) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
         var mapping = await db.LeagueUserMapping
             .FirstOrDefaultAsync(m => m.LeagueId == leagueId && m.UserId == userId);
         if (mapping is not null) {
-            db.LeagueUserMapping.Remove(mapping);
+            mapping.IsActive = false;
+            mapping.RemovedAt = DateTimeOffset.UtcNow;
             await db.SaveChangesAsync();
         }
     }
 
+    // Shared with DemoDataSeeder.PurgeUnknownLeaguesAsync via LeagueCascadeDelete — one place for
+    // the ordered multi-table cascade instead of two independently-drifting copies.
+    public async Task DeleteLeagueAsync(int leagueId) {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+        LeagueCascadeDelete.RemoveLeaguesAndDependents(db, [leagueId]);
+        await db.SaveChangesAsync();
+    }
+
     public async Task<int> GetLeagueMemberCountAsync(int leagueId) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
-        return await db.LeagueUserMapping.CountAsync(m => m.LeagueId == leagueId);
+        return await db.LeagueUserMapping.CountAsync(m => m.LeagueId == leagueId && m.IsActive);
     }
 
     // Add operations
+    // (LeagueId, UserId) is unique — a removed-then-re-added user must reactivate their existing
+    // (soft-deleted) row rather than insert a second one, or this throws a unique-index violation
+    // against real Postgres. Preserves the original DateCreated (join date), not a re-join date.
     public async Task AddLeagueUserMappingAsync(LeagueUserMapping mapping) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
-        await db.LeagueUserMapping.AddAsync(mapping);
+        var existing = await db.LeagueUserMapping
+            .FirstOrDefaultAsync(m => m.LeagueId == mapping.LeagueId && m.UserId == mapping.UserId);
+        if (existing is not null) {
+            existing.IsActive = true;
+            existing.RemovedAt = null;
+        } else {
+            await db.LeagueUserMapping.AddAsync(mapping);
+        }
         await db.SaveChangesAsync();
     }
 
@@ -349,6 +370,6 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
     public async Task<bool> UserExistsInLeagueAsync(string userId, int leagueId) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
         return await db.LeagueUserMapping
-            .AnyAsync(lum => lum.UserId == userId && lum.LeagueId == leagueId);
+            .AnyAsync(lum => lum.UserId == userId && lum.LeagueId == leagueId && lum.IsActive);
     }
 }


### PR DESCRIPTION
## Summary

Three bundled admin fixes (same file/area, one review pass):

- **Rename**: "Juice Settings" -> "League Payouts", "Weekly Cost" -> "Cost Per Week ($)".
- **Delete League**: owner-or-admin guard, type-the-league-name-to-confirm dialog, removes the league's members/payout settings/picks (NFL+CFB)/invitations.
- **Soft-delete Remove Member**: adds `IsActive`/`RemovedAt` to `LeagueUserMapping` — removing a member now flips a flag instead of deleting the row, keeping pick history for audit. Re-adding a removed member reactivates the existing row (no duplicate, `(LeagueId, UserId)` is unique). Filtering to active-only in the four repo read methods transparently fixes leaderboards, missing-picks emails, the member list, and pick-submission auth, since all of those already funnel through those methods.

**Caught during review, fixed before merge:**
- The generated EF migration defaulted `IsActive` to `false` for existing rows (EF's inferred bool default) — would have silently deactivated every real league member in dev/prod the instant it ran. Fixed to default `true`; verified against a local DB with pre-existing rows that they retrofit correctly.
- `DeleteLeagueAsync` and `DemoDataSeeder.PurgeUnknownLeaguesAsync` were hand-rolling the identical cascade-delete logic — pulled into a shared `LeagueCascadeDelete` helper during `/simplify`.

## Test plan
- [x] TDD throughout, confirmed RED before each implementation
- [x] `dotnet test` — 528 passed
- [x] `npm run test -- --run` — 308 passed
- [x] `npm run test:e2e -- --project=chromium` — 53 passed
- [x] `npm run test:e2e:demo` — 46 passed (mandatory: this PR touches `DemoDataSeeder.cs`)
- [x] `npx tsc -b` clean
- [x] `/simplify` — shared cascade-delete helper extracted; one efficiency suggestion (bulk `ExecuteDeleteAsync`) judged an acceptable trade-off since Delete League is a rare, deliberate admin action, not a hot path
- [x] Manual, local demo stack: removed a member (confirmed they drop off the list, pick history stays queryable in the DB), re-added them (confirmed reactivation, not a duplicate row, original join date preserved), verified against the leaderboard once its existing 10-minute cache expired
- [x] Verified the migration against a local DB with pre-existing `LeagueUserMapping` rows (not just a fresh DB) — all retrofit to `IsActive = true` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)