### PR TITLE
feat(invites): shareable 24h league invite link via native share sheet

### DIFF
--- a/.claude/skills/style-guide/SKILL.md
+++ b/.claude/skills/style-guide/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: style-guide
+description: Color palette semantics, MUI button/status-indicator conventions, and the recurring contrast bugs to avoid. Invoke before touching any color, button variant, or status indicator (dot, chip, badge).
+---
+
+# Style Guide
+
+`Client.React/src/app/theme.ts` is the single source of truth for every hex value. This
+skill documents the *semantics* (which color means what) and the *conventions* (how to
+apply a color to a component) so those decisions don't get re-litigated component by
+component. If you're about to pick a color or add an opacity/mode branch to "fix" one,
+read this first.
+
+## Color semantics
+
+| Palette key | Meaning | Where it's used |
+|---|---|---|
+| `success` | picked / positive / winning | "Picked" pick button, winning matrix cell, positive money |
+| `info` | available / neutral action | unpicked-but-pickable button (e.g. "Pick" on `GameCard`) |
+| `error` | negative / losing | losing matrix cell, negative money, "Loser" chip |
+| `warning` | caution / one-off accent only | a single Rules-page callout row — **not** pick-state buttons |
+| `secondary` | brand accent (orange) | CTAs, hero buttons, nav highlight |
+| `primary` | structural navy (light) / blue (dark) | app bar, default text emphasis |
+
+**`warning` (amber) is explicitly not used for pick-state buttons.** It was tried for the
+"available to pick" state and reported unreadable in both light and dark mode as a small
+filled button — `info` (blue) replaced it. Don't reintroduce amber there.
+
+## The mode-contrast trap (read this before adding an opacity branch)
+
+Every color in `theme.ts` is already tuned to be legible in **both** light and dark mode
+at full opacity — `success`/`warning` use a darker shade in light mode specifically so
+text/borders don't wash out on white, while dark mode keeps the punchier saturated tone.
+
+This repo has twice shipped a bug where a component tried to "fix" contrast locally with
+a mode-dependent `opacity` value (e.g. `opacity: mode === 'dark' ? 0.7 : 0.15` on a status
+dot) — it fixed one mode and broke the other, then got reported as a regression once the
+first mode's fix went out. **Don't add per-component opacity/mode branches.** If a color
+reads poorly somewhere:
+1. First check whether `theme.ts` already has a light/dark variant for that palette key
+   (`success`/`warning` do; most others don't yet).
+2. If it doesn't and needs one, add it there — one definition, both modes covered — not a
+   local opacity hack.
+3. Status dots, chips, and filled buttons should render at **full opacity** in both modes.
+
+## MUI button conventions
+
+- **Filled (`variant="contained"`) for both states of a binary pick control**, distinguished
+  by color (`info` = available, `success` = picked) — not by outlined-vs-filled. Two
+  differently-colored filled buttons read as "pick one of these"; an outlined button next
+  to a filled one was tried and reported as looking like a lesser/broken version of the
+  filled one, not a deliberate second state.
+- **MUI's `disabled` prop flattens `variant="contained"` to uniform gray regardless of
+  `color`.** Since locked/disabled is the majority real-world state once a pick window
+  closes, this silently erases whatever color distinction you just built. Override it
+  explicitly:
+  ```tsx
+  const lockedFillSx = (color: 'success' | 'info') => ({
+    '&.Mui-disabled': {
+      color: `${color}.contrastText`,
+      backgroundColor: `${color}.main`,
+      opacity: 0.6,
+    },
+  });
+  <Button color={color} variant="contained" disabled sx={[baseSx, lockedFillSx(color)]} />
+  ```
+  See `GameCard.tsx`'s `lockedFillSx` for the live implementation.
+
+## Layout: numeric columns need explicit centering
+
+A fixed-width column showing numbers of varying digit width (e.g. a spread like `-3.5` vs
+`+16.5`) needs `textAlign: 'center'` set explicitly — the `.fixed-width` CSS class
+(`global.css`) only sets `width`, not alignment, so left-aligned numbers visually drift
+between rows. This was shipped once, reported as "spread alignment is totally off," and
+fixed by adding `sx={{ textAlign: 'center' }}` alongside `className="fixed-width"`. Any
+new fixed-width numeric column needs the same treatment.
+
+## Before you touch a color
+
+1. Check this skill for the semantic meaning you actually want (picked vs available vs
+   negative vs caution) — don't reach for whichever color looks closest.
+2. If the color needs to differ from what's already in `theme.ts`, fix it in `theme.ts`
+   for both modes, not with a local opacity/sx override.
+3. If it's a `disabled` state on a filled button, use the `lockedFillSx` pattern above —
+   don't let it fall back to MUI's default gray.
+4. Test both light and dark mode before calling it done — a fix verified in only one mode
+   is how this cycle started in the first place.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,27 @@ When fixing a bug: grep existing tests for old wrong values before shipping. Whe
 
 ---
 
+## CRITICAL: API Surface — DTOs and Strongly Typed Objects
+
+**Every API boundary must use an explicit DTO or strongly typed record/class — no anonymous objects, no `dynamic`, no raw `Dictionary<string,object>`, no `object` return types.**
+
+- **Backend**: all controller endpoints return and accept named records or classes from `Shared/Models/Data/Dtos/` or `Shared/Models/`. Never serialize anonymous `new { }` objects — create a DTO.
+- **Frontend**: all API functions in `src/api/` must declare and export a TypeScript `interface` or `type` for every request and response shape. Never use `any`; avoid `unknown` except at boundaries where you immediately narrow the type.
+- When adding a new endpoint, add the corresponding DTO to `Shared/Models/Data/Dtos/` first, then wire it in.
+
+---
+
+## CRITICAL: NFL/CFB Code Sharing — No Duplicated Logic Between Sport Paths
+
+**One implementation, two sport call sites — never two implementations.**
+
+- Business logic (status derivation, pick validation, security guards, leaderboard scoring, spread formatting) lives in **one shared function/service** that both NFL and CFB call. Never copy-paste and modify.
+- `PicksPage`, `ScoresPage`, `LeaderboardPage` are sport-agnostic via `adapter: SportAdapter` — keep them that way. Put sport-specific logic in the adapter, not the page.
+- When fixing a bug on one sport's path, **always check the other sport's equivalent** before shipping — open the CFB controller/adapter/service when you fix the NFL one, and vice versa.
+- Duplicated logic between NFL and CFB paths is a P0 bug magnet — it has repeatedly caused diverging guards and status-parsing bugs.
+
+---
+
 ## CRITICAL: Branch Rules
 - **NEVER push or commit directly to `main`** — all changes go through a PR
 - Branch flow: `feature/*` → PR → `dev` → PR → `main`

--- a/Client.React/e2e/helpers/routes.ts
+++ b/Client.React/e2e/helpers/routes.ts
@@ -379,6 +379,39 @@ export async function setupRoutes(page: Page, options: SetupRoutesOptions = {}):
       return;
     }
 
+    if (url.match(/\/api\/league\/\d+\/invite-link$/) && method === 'POST') {
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          token: 'mocktokenabcdef1234567890abcdef12',
+          leagueId: 1,
+          leagueName: 'Test League',
+          expiresAt: new Date(Date.now() + 86400000).toISOString(),
+        }),
+      });
+      return;
+    }
+
+    if (url.match(/\/api\/league\/join\/[^/]+$/) && method === 'GET') {
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          token: 'mocktokenabcdef1234567890abcdef12',
+          leagueId: 1,
+          leagueName: 'Test League',
+          expiresAt: new Date(Date.now() + 86400000).toISOString(),
+        }),
+      });
+      return;
+    }
+
+    if (url.match(/\/api\/league\/join\/[^/]+$/) && method === 'POST') {
+      void route.fulfill({ status: 204 });
+      return;
+    }
+
     if (url.match(/\/api\/league\/\d+\/owner\//) && method === 'PUT') {
       void route.fulfill({ status: 204 });
       return;

--- a/Client.React/e2e/helpers/routes.ts
+++ b/Client.React/e2e/helpers/routes.ts
@@ -5,6 +5,13 @@ import type { LeagueUserMappingDto } from '../../src/types/league';
 import type { LeaderboardDto } from '../../src/types/leaderboard';
 import { createScores, createSpreadResponse } from '../../src/test/fixtures';
 
+const mockInviteLink = () => ({
+  token: 'mocktokenabcdef1234567890abcdef12',
+  leagueId: 1,
+  leagueName: 'Test League',
+  expiresAt: new Date(Date.now() + 86400000).toISOString(),
+});
+
 export const TEST_USER: UserInfo = {
   userId: 'test-user-id-001',
   name: 'TestUser',
@@ -380,30 +387,12 @@ export async function setupRoutes(page: Page, options: SetupRoutesOptions = {}):
     }
 
     if (url.match(/\/api\/league\/\d+\/invite-link$/) && method === 'POST') {
-      void route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          token: 'mocktokenabcdef1234567890abcdef12',
-          leagueId: 1,
-          leagueName: 'Test League',
-          expiresAt: new Date(Date.now() + 86400000).toISOString(),
-        }),
-      });
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockInviteLink()) });
       return;
     }
 
     if (url.match(/\/api\/league\/join\/[^/]+$/) && method === 'GET') {
-      void route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          token: 'mocktokenabcdef1234567890abcdef12',
-          leagueId: 1,
-          leagueName: 'Test League',
-          expiresAt: new Date(Date.now() + 86400000).toISOString(),
-        }),
-      });
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockInviteLink()) });
       return;
     }
 

--- a/Client.React/src/App.tsx
+++ b/Client.React/src/App.tsx
@@ -35,6 +35,7 @@ function LeaderboardRoute() {
   return <LeaderboardPage adapter={isCfb ? cfbAdapter : nflAdapter} />;
 }
 
+import JoinLeaguePage from './pages/JoinLeaguePage';
 import LeaguePickerPage from './pages/LeaguePickerPage';
 import PicksPage from './pages/PicksPage';
 import ScoresPage from './pages/ScoresPage';
@@ -72,6 +73,7 @@ export default function App() {
       <Route path="/register" caseSensitive={false} element={<Navigate to="/account/register" replace />} />
       <Route path="/account/login" caseSensitive={false} element={<LoginPage />} />
       <Route path="/account/register" caseSensitive={false} element={<RegisterPage />} />
+      <Route path="/join/:token" caseSensitive={false} element={<JoinLeaguePage />} />
       <Route path="/account/registerconfirmation" caseSensitive={false} element={<RegisterConfirmationPage />} />
       <Route path="/account/forgotpassword" caseSensitive={false} element={<ForgotPasswordPage />} />
       <Route path="/account/forgotpasswordconfirmation" caseSensitive={false} element={<ForgotPasswordConfirmationPage />} />

--- a/Client.React/src/__tests__/JoinLeaguePage.test.tsx
+++ b/Client.React/src/__tests__/JoinLeaguePage.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { vi } from 'vitest';
+import JoinLeaguePage from '../pages/JoinLeaguePage';
+
+const navigateMock = vi.fn();
+
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>();
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+const authState: { user: { userId: string; name: string; claims: unknown[] } | null } = {
+  user: null,
+};
+vi.mock('../services/auth', () => ({ useAuth: () => authState }));
+
+const sessionMock = { reloadLeagues: vi.fn().mockResolvedValue(undefined) };
+vi.mock('../services/session', () => ({ useSession: () => sessionMock }));
+
+vi.mock('../api/league', () => ({
+  validateInviteLink: vi.fn(),
+  joinViaLink: vi.fn(),
+}));
+
+import { validateInviteLink, joinViaLink } from '../api/league';
+
+function renderWithToken(token: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/join/${token}`]}>
+      <Routes>
+        <Route path="/join/:token" element={<JoinLeaguePage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('JoinLeaguePage', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    sessionMock.reloadLeagues.mockResolvedValue(undefined);
+    authState.user = null;
+  });
+
+  it('shows error when token is invalid or expired', async () => {
+    vi.mocked(validateInviteLink).mockResolvedValue(null);
+    renderWithToken('badtoken');
+    await waitFor(() =>
+      expect(screen.getByText(/expired or invalid/i)).toBeInTheDocument()
+    );
+  });
+
+  it('shows league name and sign-up CTA when logged out and token is valid', async () => {
+    vi.mocked(validateInviteLink).mockResolvedValue({
+      token: 'tok123',
+      leagueId: 1,
+      leagueName: 'My NFL League',
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+    });
+    authState.user = null;
+    renderWithToken('tok123');
+    await waitFor(() => expect(screen.getByText('My NFL League')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /create an account/i })).toBeInTheDocument();
+  });
+
+  it('navigates to register page when sign-up CTA is clicked', async () => {
+    vi.mocked(validateInviteLink).mockResolvedValue({
+      token: 'tok123',
+      leagueId: 1,
+      leagueName: 'My NFL League',
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+    });
+    authState.user = null;
+    renderWithToken('tok123');
+    await waitFor(() => screen.getByRole('button', { name: /create an account/i }));
+    await userEvent.click(screen.getByRole('button', { name: /create an account/i }));
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.stringContaining('/account/register'),
+    );
+  });
+
+  it('shows Join button when user is logged in and token is valid', async () => {
+    vi.mocked(validateInviteLink).mockResolvedValue({
+      token: 'tok123',
+      leagueId: 1,
+      leagueName: 'My NFL League',
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+    });
+    authState.user = { userId: 'user-1', name: 'Alice', claims: [] };
+    renderWithToken('tok123');
+    await waitFor(() => expect(screen.getByRole('button', { name: /join/i })).toBeInTheDocument());
+  });
+
+  it('calls joinViaLink and navigates to dashboard on success', async () => {
+    vi.mocked(validateInviteLink).mockResolvedValue({
+      token: 'tok123',
+      leagueId: 1,
+      leagueName: 'My NFL League',
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+    });
+    vi.mocked(joinViaLink).mockResolvedValue(undefined);
+    authState.user = { userId: 'user-1', name: 'Alice', claims: [] };
+    renderWithToken('tok123');
+    await waitFor(() => screen.getByRole('button', { name: /join/i }));
+    await userEvent.click(screen.getByRole('button', { name: /join/i }));
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/dashboard'));
+    expect(sessionMock.reloadLeagues).toHaveBeenCalled();
+  });
+});

--- a/Client.React/src/api/league.ts
+++ b/Client.React/src/api/league.ts
@@ -173,8 +173,10 @@ export async function validateInviteLink(token: string): Promise<LeagueInviteLin
   try {
     const { data } = await http.get<LeagueInviteLinkDto>(`/api/league/join/${token}`);
     return data;
-  } catch {
-    return null;
+  } catch (err) {
+    const status = (err as { response?: { status?: number } }).response?.status;
+    if (status === 404) return null;
+    throw err;
   }
 }
 

--- a/Client.React/src/api/league.ts
+++ b/Client.React/src/api/league.ts
@@ -156,3 +156,28 @@ export async function createLeague(dto: LeagueCreateDto) {
   const { data } = await http.post<LeagueInfoDto>('/api/league/create', dto);
   return data;
 }
+
+export interface LeagueInviteLinkDto {
+  token: string;
+  leagueId: number;
+  leagueName: string;
+  expiresAt: string;
+}
+
+export async function generateInviteLink(leagueId: number): Promise<LeagueInviteLinkDto> {
+  const { data } = await http.post<LeagueInviteLinkDto>(`/api/league/${leagueId}/invite-link`, {});
+  return data;
+}
+
+export async function validateInviteLink(token: string): Promise<LeagueInviteLinkDto | null> {
+  try {
+    const { data } = await http.get<LeagueInviteLinkDto>(`/api/league/join/${token}`);
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+export async function joinViaLink(token: string): Promise<void> {
+  await http.post(`/api/league/join/${token}`, {});
+}

--- a/Client.React/src/components/sports/GameCard.tsx
+++ b/Client.React/src/components/sports/GameCard.tsx
@@ -93,7 +93,7 @@ export default function GameCard({
       return <Button color="success" variant="contained" disabled startIcon={<CheckIcon />} aria-label={`${team} locked in`} sx={pickButtonSx}>Picked</Button>;
     if (pickState !== 'none')
       return <Button color="success" variant="contained" onClick={onPick} aria-label={`${team} picked`} sx={pickButtonSx}>Picked</Button>;
-    return <Button color="warning" variant="contained" disabled={locked} onClick={onPick} aria-label={`Pick ${team}`} sx={pickButtonSx}>Pick</Button>;
+    return <Button color="info" variant="contained" disabled={locked} onClick={onPick} aria-label={`Pick ${team}`} sx={pickButtonSx}>Pick</Button>;
   };
 
   const renderTeamLogo = (abbr: string, jerseyUrl: string | undefined) => (
@@ -188,7 +188,7 @@ export default function GameCard({
               <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ gap: 1 }}>
                 <Button
                   variant="contained"
-                  color={overPickState !== 'none' ? 'success' : 'warning'}
+                  color={overPickState !== 'none' ? 'success' : 'info'}
                   sx={pickButtonSx}
                   disabled={overUnderLocked && overPickState === 'none'}
                   onClick={onPickOver}
@@ -200,7 +200,7 @@ export default function GameCard({
                 </Typography>
                 <Button
                   variant="contained"
-                  color={underPickState !== 'none' ? 'success' : 'warning'}
+                  color={underPickState !== 'none' ? 'success' : 'info'}
                   sx={pickButtonSx}
                   disabled={overUnderLocked && underPickState === 'none'}
                   onClick={onPickUnder}

--- a/Client.React/src/pages/JoinLeaguePage.tsx
+++ b/Client.React/src/pages/JoinLeaguePage.tsx
@@ -45,8 +45,14 @@ export default function JoinLeaguePage() {
       await joinViaLink(token!);
       await reloadLeagues();
       navigate('/dashboard');
-    } catch {
-      setError('Failed to join league. The link may have expired.');
+    } catch (err) {
+      const status = (err as { response?: { status?: number } }).response?.status;
+      if (status === 409) {
+        await reloadLeagues();
+        navigate('/dashboard');
+      } else {
+        setError('Failed to join league. The link may have expired.');
+      }
     } finally {
       setJoining(false);
     }

--- a/Client.React/src/pages/JoinLeaguePage.tsx
+++ b/Client.React/src/pages/JoinLeaguePage.tsx
@@ -19,15 +19,19 @@ export default function JoinLeaguePage() {
   const [loading, setLoading] = useState(true);
   const [joining, setJoining] = useState(false);
   const [link, setLink] = useState<LeagueInviteLinkDto | null>(null);
-  const [invalid, setInvalid] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!token) { setInvalid(true); setLoading(false); return; }
+    if (!token) { setLoading(false); return; }
+    const controller = new AbortController();
     validateInviteLink(token).then((result) => {
-      if (!result) setInvalid(true);
-      else setLink(result);
-    }).finally(() => setLoading(false));
+      if (!controller.signal.aborted) setLink(result);
+    }).catch(() => {
+      if (!controller.signal.aborted) setError('Failed to load invite link. Please try again.');
+    }).finally(() => {
+      if (!controller.signal.aborted) setLoading(false);
+    });
+    return () => controller.abort();
   }, [token]);
 
   const handleSignUp = () => {
@@ -35,11 +39,10 @@ export default function JoinLeaguePage() {
   };
 
   const handleJoin = async () => {
-    if (!token) return;
     setJoining(true);
     setError(null);
     try {
-      await joinViaLink(token);
+      await joinViaLink(token!);
       await reloadLeagues();
       navigate('/dashboard');
     } catch {
@@ -57,14 +60,18 @@ export default function JoinLeaguePage() {
     );
   }
 
-  if (invalid) {
+  if (!link) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8, px: 2 }}>
         <Card sx={{ maxWidth: 400, width: '100%' }}>
           <CardContent sx={{ textAlign: 'center', py: 4 }}>
-            <Typography variant="h6" gutterBottom>Link expired or invalid</Typography>
+            <Typography variant="h6" gutterBottom>
+              {error ?? 'Link expired or invalid'}
+            </Typography>
             <Typography variant="body2" color="text.secondary">
-              This invite link has expired or is no longer valid. Ask the league owner to generate a new one.
+              {error
+                ? 'Check your connection and try again.'
+                : 'This invite link has expired or is no longer valid. Ask the league owner to generate a new one.'}
             </Typography>
           </CardContent>
         </Card>
@@ -77,7 +84,7 @@ export default function JoinLeaguePage() {
       <Card sx={{ maxWidth: 400, width: '100%' }}>
         <CardContent sx={{ textAlign: 'center', py: 4 }}>
           <Typography variant="overline" color="text.secondary">You&apos;re invited to join</Typography>
-          <Typography variant="h5" fontWeight={600} gutterBottom>{link?.leagueName}</Typography>
+          <Typography variant="h5" fontWeight={600} gutterBottom>{link.leagueName}</Typography>
           {error && (
             <Typography variant="body2" color="error" sx={{ mb: 2 }}>{error}</Typography>
           )}

--- a/Client.React/src/pages/JoinLeaguePage.tsx
+++ b/Client.React/src/pages/JoinLeaguePage.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CircularProgress from '@mui/material/CircularProgress';
+import Typography from '@mui/material/Typography';
+import { validateInviteLink, joinViaLink, type LeagueInviteLinkDto } from '../api/league';
+import { useAuth } from '../services/auth';
+import { useSession } from '../services/session';
+
+export default function JoinLeaguePage() {
+  const { token } = useParams<{ token: string }>();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const { reloadLeagues } = useSession();
+
+  const [loading, setLoading] = useState(true);
+  const [joining, setJoining] = useState(false);
+  const [link, setLink] = useState<LeagueInviteLinkDto | null>(null);
+  const [invalid, setInvalid] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) { setInvalid(true); setLoading(false); return; }
+    validateInviteLink(token).then((result) => {
+      if (!result) setInvalid(true);
+      else setLink(result);
+    }).finally(() => setLoading(false));
+  }, [token]);
+
+  const handleSignUp = () => {
+    navigate(`/account/register?inviteLinkToken=${token}&returnUrl=/join/${token}`);
+  };
+
+  const handleJoin = async () => {
+    if (!token) return;
+    setJoining(true);
+    setError(null);
+    try {
+      await joinViaLink(token);
+      await reloadLeagues();
+      navigate('/dashboard');
+    } catch {
+      setError('Failed to join league. The link may have expired.');
+    } finally {
+      setJoining(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (invalid) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8, px: 2 }}>
+        <Card sx={{ maxWidth: 400, width: '100%' }}>
+          <CardContent sx={{ textAlign: 'center', py: 4 }}>
+            <Typography variant="h6" gutterBottom>Link expired or invalid</Typography>
+            <Typography variant="body2" color="text.secondary">
+              This invite link has expired or is no longer valid. Ask the league owner to generate a new one.
+            </Typography>
+          </CardContent>
+        </Card>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8, px: 2 }}>
+      <Card sx={{ maxWidth: 400, width: '100%' }}>
+        <CardContent sx={{ textAlign: 'center', py: 4 }}>
+          <Typography variant="overline" color="text.secondary">You&apos;re invited to join</Typography>
+          <Typography variant="h5" fontWeight={600} gutterBottom>{link?.leagueName}</Typography>
+          {error && (
+            <Typography variant="body2" color="error" sx={{ mb: 2 }}>{error}</Typography>
+          )}
+          {user ? (
+            <Button
+              variant="contained"
+              color="secondary"
+              size="large"
+              fullWidth
+              disabled={joining}
+              onClick={() => void handleJoin()}
+              sx={{ mt: 2 }}
+            >
+              {joining ? <CircularProgress size={22} color="inherit" /> : 'Join League'}
+            </Button>
+          ) : (
+            <Button
+              variant="contained"
+              color="secondary"
+              size="large"
+              fullWidth
+              onClick={handleSignUp}
+              sx={{ mt: 2 }}
+            >
+              Create an account to join
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -25,7 +25,10 @@ import {
   Typography,
 } from '@mui/material';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DeleteIcon from '@mui/icons-material/Delete';
+import IosShareIcon from '@mui/icons-material/IosShare';
+import LinkIcon from '@mui/icons-material/Link';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import PageHeader from '../components/PageHeader';
 import OwnerCostSummary from '../components/OwnerCostSummary';
@@ -41,11 +44,13 @@ import {
   rollForwardJuice,
   removeLeagueMember,
   inviteToLeague,
+  generateInviteLink,
   getAllLeagues,
   getUsers,
   createLeague,
   addLeagueUserMapping,
   assignLeagueOwner,
+  type LeagueInviteLinkDto,
 } from '../api/league';
 import type { LeagueInfoDto, LeagueJuiceMappingDto, LeagueCostDto, UserSummaryDto } from '../types/admin';
 import type { LeagueUserMappingDto } from '../types/league';
@@ -90,10 +95,14 @@ export default function LeaguePortalPage() {
   const [removeTarget, setRemoveTarget] = useState<LeagueUserMappingDto | null>(null);
   const [removing, setRemoving] = useState(false);
 
-  // Invite dialog
+  // Email invite dialog
   const [inviteOpen, setInviteOpen] = useState(false);
   const [inviteEmail, setInviteEmail] = useState('');
   const [inviting, setInviting] = useState(false);
+
+  // Shareable invite link
+  const [generatingLink, setGeneratingLink] = useState(false);
+  const [inviteLink, setInviteLink] = useState<LeagueInviteLinkDto | null>(null);
 
   // Juice settings
   const [juiceMappings, setJuiceMappings] = useState<LeagueJuiceMappingDto[]>([]);
@@ -222,6 +231,19 @@ export default function LeaguePortalPage() {
       toast.push('Failed to save juice settings', 'error');
     } finally {
       setSavingJuice(false);
+    }
+  };
+
+  const handleGenerateInviteLink = async () => {
+    if (!selectedLeague) return;
+    setGeneratingLink(true);
+    try {
+      const link = await generateInviteLink(selectedLeague.id);
+      setInviteLink(link);
+    } catch {
+      toast.push('Failed to generate invite link', 'error');
+    } finally {
+      setGeneratingLink(false);
     }
   };
 
@@ -377,6 +399,9 @@ export default function LeaguePortalPage() {
               onRemove={setRemoveTarget}
               onInvite={() => setInviteOpen(true)}
               onAddUser={openAddUser}
+              inviteLink={inviteLink}
+              generatingLink={generatingLink}
+              onGenerateInviteLink={() => void handleGenerateInviteLink()}
             />
           )}
           {tab === 1 && (
@@ -547,11 +572,32 @@ interface MembersTabProps {
   onRemove: (m: LeagueUserMappingDto) => void;
   onInvite: () => void;
   onAddUser: () => void;
+  inviteLink: LeagueInviteLinkDto | null;
+  generatingLink: boolean;
+  onGenerateInviteLink: () => void;
 }
 
-function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInvite, onAddUser }: MembersTabProps) {
+function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInvite, onAddUser, inviteLink, generatingLink, onGenerateInviteLink }: MembersTabProps) {
   const count = costDto?.memberCount ?? members.length;
   const cost = computeLeagueCost(count);
+
+  const inviteUrl = inviteLink ? `${window.location.origin}/join/${inviteLink.token}` : '';
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(inviteUrl);
+  };
+
+  const handleShare = () => {
+    if (navigator.share) {
+      void navigator.share({ title: 'Join my league', url: inviteUrl });
+    } else {
+      void navigator.clipboard.writeText(inviteUrl);
+    }
+  };
+
+  const expiresLabel = inviteLink
+    ? `Expires ${new Date(inviteLink.expiresAt).toLocaleString()}`
+    : '';
 
   return (
     <Box>
@@ -560,12 +606,41 @@ function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInv
         <Button startIcon={<PersonAddIcon />} variant="outlined" size="small" onClick={onInvite}>
           Invite Player
         </Button>
+        <Button
+          startIcon={generatingLink ? <CircularProgress size={14} /> : <LinkIcon />}
+          variant="outlined"
+          size="small"
+          onClick={onGenerateInviteLink}
+          disabled={generatingLink}
+        >
+          {inviteLink ? 'Regenerate Link' : 'Generate Invite Link'}
+        </Button>
         {admin && (
           <Button startIcon={<AddCircleIcon />} variant="outlined" size="small" onClick={onAddUser}>
             Add User
           </Button>
         )}
       </Stack>
+
+      {inviteLink && (
+        <Box sx={{ mb: 3, p: 2, border: 1, borderColor: 'divider', borderRadius: 1, maxWidth: 520 }}>
+          <Stack spacing={1}>
+            <Typography variant="body2" sx={{ wordBreak: 'break-all', fontFamily: 'monospace', fontSize: '0.78rem' }}>
+              {inviteUrl}
+            </Typography>
+            <Stack direction="row" spacing={1} flexWrap="wrap">
+              <Button size="small" startIcon={<ContentCopyIcon />} variant="outlined" onClick={handleCopy}>
+                Copy
+              </Button>
+              <Button size="small" startIcon={<IosShareIcon />} variant="contained" color="secondary" onClick={handleShare}>
+                Share
+              </Button>
+            </Stack>
+            <Typography variant="caption" color="text.secondary">{expiresLabel}</Typography>
+          </Stack>
+        </Box>
+      )}
+
       {loading ? (
         <CircularProgress />
       ) : (

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -585,16 +585,20 @@ function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInv
 
   const inviteUrl = inviteLink ? `${window.location.origin}/join/${inviteLink.token}` : '';
 
-  const handleCopy = () => {
-    void navigator.clipboard.writeText(inviteUrl);
-    toast.push('Link copied', 'info');
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(inviteUrl);
+      toast.push('Link copied', 'info');
+    } catch {
+      toast.push('Failed to copy link', 'error');
+    }
   };
 
   const handleShare = () => {
     if (navigator.share) {
       void navigator.share({ title: 'Join my league', url: inviteUrl });
     } else {
-      handleCopy();
+      void handleCopy();
     }
   };
 
@@ -632,7 +636,7 @@ function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInv
               {inviteUrl}
             </Typography>
             <Stack direction="row" spacing={1} flexWrap="wrap">
-              <Button size="small" startIcon={<ContentCopyIcon />} variant="outlined" onClick={handleCopy}>
+              <Button size="small" startIcon={<ContentCopyIcon />} variant="outlined" onClick={() => void handleCopy()}>
                 Copy
               </Button>
               <Button size="small" startIcon={<IosShareIcon />} variant="contained" color="secondary" onClick={handleShare}>

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -186,6 +186,7 @@ export default function LeaguePortalPage() {
 
   useEffect(() => {
     if (!selectedLeague) return;
+    setInviteLink(null);
     void loadMembers(selectedLeague.id);
     void loadJuice(selectedLeague.id);
   }, [selectedLeague, loadMembers, loadJuice]);
@@ -580,18 +581,20 @@ interface MembersTabProps {
 function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInvite, onAddUser, inviteLink, generatingLink, onGenerateInviteLink }: MembersTabProps) {
   const count = costDto?.memberCount ?? members.length;
   const cost = computeLeagueCost(count);
+  const toast = useToast();
 
   const inviteUrl = inviteLink ? `${window.location.origin}/join/${inviteLink.token}` : '';
 
   const handleCopy = () => {
     void navigator.clipboard.writeText(inviteUrl);
+    toast.push('Link copied', 'info');
   };
 
   const handleShare = () => {
     if (navigator.share) {
       void navigator.share({ title: 'Join my league', url: inviteUrl });
     } else {
-      void navigator.clipboard.writeText(inviteUrl);
+      handleCopy();
     }
   };
 

--- a/Server.UnitTests/LeagueControllerDtoTests.cs
+++ b/Server.UnitTests/LeagueControllerDtoTests.cs
@@ -31,7 +31,8 @@ public class LeagueControllerDtoTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            Substitute.For<IInvitationService>());
+            Substitute.For<IInvitationService>(),
+            Substitute.For<ILeagueInviteLinkService>());
 
         controller.ControllerContext = new ControllerContext
         {

--- a/Server.UnitTests/LeagueInviteLinkTests.cs
+++ b/Server.UnitTests/LeagueInviteLinkTests.cs
@@ -1,0 +1,214 @@
+using FourPlayWebApp.Server.Controllers;
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Models.Identity;
+using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Server.Services.Repositories.Interfaces;
+using FourPlayWebApp.Shared.Models.Data.Dtos;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using System.Security.Claims;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+/// <summary>
+/// PR #223: Shareable league invite link — ownership guards, generate, validate, join.
+/// </summary>
+public class LeagueInviteLinkTests
+{
+    private const string OwnerId = "owner-001";
+    private const string MemberId = "member-002";
+    private const string StrangerId = "stranger-003";
+
+    private static LeagueController BuildController(
+        ClaimsPrincipal principal,
+        ILeagueRepository? repo = null,
+        ILeagueInviteLinkService? linkService = null)
+    {
+        var store = Substitute.For<IUserStore<ApplicationUser>>();
+        var userManager = Substitute.For<UserManager<ApplicationUser>>(
+            store, null, null, null, null, null, null, null, null);
+
+        var controller = new LeagueController(
+            new MemoryCache(new MemoryCacheOptions()),
+            repo ?? Substitute.For<ILeagueRepository>(),
+            NullLogger<LeagueController>.Instance,
+            userManager,
+            Substitute.For<ISpreadCalculatorBuilder>(),
+            Substitute.For<IEspnCacheService>(),
+            Substitute.For<IInvitationService>(),
+            linkService ?? Substitute.For<ILeagueInviteLinkService>());
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = principal }
+        };
+        return controller;
+    }
+
+    private static ClaimsPrincipal BuildPrincipal(string userId, bool isAdmin = false)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId),
+            new(ClaimTypes.Name, userId),
+        };
+        if (isAdmin)
+            claims.Add(new Claim(ClaimTypes.Role, "Administrator"));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+    }
+
+    // ── GenerateInviteLink ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GenerateInviteLink_ReturnsForbid_WhenCallerIsNotOwnerOrAdmin()
+    {
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "TestLeague" });
+
+        var controller = BuildController(BuildPrincipal(StrangerId), repo: repo);
+
+        var result = await controller.GenerateInviteLink(1);
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GenerateInviteLink_ReturnsOk_WhenCallerIsOwner()
+    {
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "TestLeague" });
+
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        linkService.GenerateAsync(1, OwnerId).Returns(new LeagueInviteLink
+        {
+            Token = "abc123",
+            LeagueId = 1,
+            League = new LeagueInfo { Id = 1, LeagueName = "TestLeague" },
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(24),
+        });
+
+        var controller = BuildController(BuildPrincipal(OwnerId), repo: repo, linkService: linkService);
+
+        var result = await controller.GenerateInviteLink(1);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<LeagueInviteLinkDto>(ok.Value);
+        Assert.Equal("abc123", dto.Token);
+        Assert.Equal("TestLeague", dto.LeagueName);
+    }
+
+    [Fact]
+    public async Task GenerateInviteLink_ReturnsOk_WhenCallerIsAdmin()
+    {
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "TestLeague" });
+
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        linkService.GenerateAsync(1, Arg.Any<string>()).Returns(new LeagueInviteLink
+        {
+            Token = "xyz789",
+            LeagueId = 1,
+            League = new LeagueInfo { Id = 1, LeagueName = "TestLeague" },
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(24),
+        });
+
+        var controller = BuildController(BuildPrincipal("admin-user", isAdmin: true), repo: repo, linkService: linkService);
+
+        var result = await controller.GenerateInviteLink(1);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    // ── ValidateInviteLink ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ValidateInviteLink_ReturnsNotFound_WhenTokenInvalid()
+    {
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        linkService.ValidateAsync("badtoken").Returns((LeagueInviteLink?)null);
+
+        var controller = BuildController(BuildPrincipal(OwnerId), linkService: linkService);
+
+        var result = await controller.ValidateInviteLink("badtoken");
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task ValidateInviteLink_ReturnsOk_WhenTokenValid()
+    {
+        var link = new LeagueInviteLink
+        {
+            Token = "valid123",
+            LeagueId = 5,
+            League = new LeagueInfo { Id = 5, LeagueName = "MyLeague" },
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(20),
+        };
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        linkService.ValidateAsync("valid123").Returns(link);
+
+        var controller = BuildController(BuildPrincipal(MemberId), linkService: linkService);
+
+        var result = await controller.ValidateInviteLink("valid123");
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<LeagueInviteLinkDto>(ok.Value);
+        Assert.Equal(5, dto.LeagueId);
+        Assert.Equal("MyLeague", dto.LeagueName);
+    }
+
+    // ── JoinViaLink ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task JoinViaLink_ReturnsNotFound_WhenTokenInvalid()
+    {
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        linkService.ValidateAsync("bad").Returns((LeagueInviteLink?)null);
+
+        var controller = BuildController(BuildPrincipal(MemberId), linkService: linkService);
+
+        var result = await controller.JoinViaLink("bad");
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task JoinViaLink_ReturnsConflict_WhenAlreadyMember()
+    {
+        var link = new LeagueInviteLink { Token = "tok", LeagueId = 1, League = new LeagueInfo { Id = 1, LeagueName = "L" }, ExpiresAt = DateTimeOffset.UtcNow.AddHours(1) };
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        linkService.ValidateAsync("tok").Returns(link);
+
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.UserExistsInLeagueAsync(MemberId, 1).Returns(true);
+
+        var controller = BuildController(BuildPrincipal(MemberId), repo: repo, linkService: linkService);
+
+        var result = await controller.JoinViaLink("tok");
+
+        Assert.IsType<ConflictObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task JoinViaLink_ReturnsNoContent_WhenSuccessful()
+    {
+        var link = new LeagueInviteLink { Token = "tok", LeagueId = 1, League = new LeagueInfo { Id = 1, LeagueName = "L" }, ExpiresAt = DateTimeOffset.UtcNow.AddHours(1) };
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        linkService.ValidateAsync("tok").Returns(link);
+
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.UserExistsInLeagueAsync(MemberId, 1).Returns(false);
+
+        var controller = BuildController(BuildPrincipal(MemberId), repo: repo, linkService: linkService);
+
+        var result = await controller.JoinViaLink("tok");
+
+        Assert.IsType<NoContentResult>(result);
+        await repo.Received(1).AddLeagueUserMappingAsync(Arg.Is<LeagueUserMapping>(m =>
+            m.LeagueId == 1 && m.UserId == MemberId));
+    }
+}

--- a/Server.UnitTests/LeagueInviteLinkTests.cs
+++ b/Server.UnitTests/LeagueInviteLinkTests.cs
@@ -83,7 +83,7 @@ public class LeagueInviteLinkTests
         repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "TestLeague" });
 
         var linkService = Substitute.For<ILeagueInviteLinkService>();
-        linkService.GenerateAsync(1, OwnerId).Returns(new LeagueInviteLink
+        linkService.GenerateAsync(1, OwnerId, Arg.Any<LeagueInfo>()).Returns(new LeagueInviteLink
         {
             Token = "abc123",
             LeagueId = 1,
@@ -108,7 +108,7 @@ public class LeagueInviteLinkTests
         repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "TestLeague" });
 
         var linkService = Substitute.For<ILeagueInviteLinkService>();
-        linkService.GenerateAsync(1, Arg.Any<string>()).Returns(new LeagueInviteLink
+        linkService.GenerateAsync(1, Arg.Any<string>(), Arg.Any<LeagueInfo>()).Returns(new LeagueInviteLink
         {
             Token = "xyz789",
             LeagueId = 1,

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -40,7 +40,8 @@ public class LeagueOwnershipTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            Substitute.For<IInvitationService>());
+            Substitute.For<IInvitationService>(),
+            Substitute.For<ILeagueInviteLinkService>());
 
         controller.ControllerContext = new ControllerContext
         {
@@ -96,7 +97,8 @@ public class LeagueOwnershipTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            Substitute.For<IInvitationService>());
+            Substitute.For<IInvitationService>(),
+            Substitute.For<ILeagueInviteLinkService>());
 
         controller.ControllerContext = new ControllerContext
         {
@@ -128,7 +130,8 @@ public class LeagueOwnershipTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            Substitute.For<IInvitationService>());
+            Substitute.For<IInvitationService>(),
+            Substitute.For<ILeagueInviteLinkService>());
 
         controller.ControllerContext = new ControllerContext
         {
@@ -155,7 +158,8 @@ public class LeagueOwnershipTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            Substitute.For<IInvitationService>());
+            Substitute.For<IInvitationService>(),
+            Substitute.For<ILeagueInviteLinkService>());
         ctrl.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext { User = principal }
@@ -469,7 +473,8 @@ public class LeagueOwnershipTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            invSvc);
+            invSvc,
+            Substitute.For<ILeagueInviteLinkService>());
         ctrl.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext { User = BuildPrincipal(OwnerId) }
@@ -500,7 +505,8 @@ public class LeagueOwnershipTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            invSvc);
+            invSvc,
+            Substitute.For<ILeagueInviteLinkService>());
         ctrl.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext { User = BuildPrincipal(OwnerId) }

--- a/Server.UnitTests/PicksTests.cs
+++ b/Server.UnitTests/PicksTests.cs
@@ -53,7 +53,8 @@ public class PicksTests
             BuildUserManager(),
             Substitute.For<ISpreadCalculatorBuilder>(),
             espnCacheService,
-            Substitute.For<IInvitationService>());
+            Substitute.For<IInvitationService>(),
+            Substitute.For<ILeagueInviteLinkService>());
 
         var httpContext = new DefaultHttpContext();
         if (principal is not null)

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -759,7 +759,7 @@ public class LeagueController(
         var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
         if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
             return Forbid();
-        var link = await leagueInviteLinkService.GenerateAsync(leagueId, callerId);
+        var link = await leagueInviteLinkService.GenerateAsync(leagueId, callerId, league);
         return Ok(new LeagueInviteLinkDto(link.Token, link.LeagueId, link.League.LeagueName, link.ExpiresAt));
     }
 

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -13,6 +13,7 @@ using FourPlayWebApp.Shared.Models.Enum;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using System.Net.Mime;
 using System.Security.Claims;
@@ -755,7 +756,9 @@ public class LeagueController(
     [ProducesResponseType(typeof(LeagueInviteLinkDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<LeagueInviteLinkDto>> GenerateInviteLink(int leagueId) {
-        var league = await repo.GetLeagueInfoAsync(leagueId);
+        LeagueInfo league;
+        try { league = await repo.GetLeagueInfoAsync(leagueId); }
+        catch (InvalidOperationException) { return NotFound(); }
         var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
         if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
             return Forbid();
@@ -783,11 +786,15 @@ public class LeagueController(
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
         if (await repo.UserExistsInLeagueAsync(userId, link.LeagueId))
             return Conflict("You are already a member of this league.");
-        await repo.AddLeagueUserMappingAsync(new LeagueUserMapping {
-            LeagueId = link.LeagueId,
-            UserId = userId,
-            DateCreated = DateTimeOffset.UtcNow,
-        });
+        try {
+            await repo.AddLeagueUserMappingAsync(new LeagueUserMapping {
+                LeagueId = link.LeagueId,
+                UserId = userId,
+                DateCreated = DateTimeOffset.UtcNow,
+            });
+        } catch (DbUpdateException) {
+            return Conflict("You are already a member of this league.");
+        }
         return NoContent();
     }
 

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -33,7 +33,8 @@ public class LeagueController(
     UserManager<ApplicationUser> userManager,
     ISpreadCalculatorBuilder spreadCalculatorBuilder,
     IEspnCacheService espnCacheService,
-    IInvitationService invitationService) : ControllerBase {
+    IInvitationService invitationService,
+    ILeagueInviteLinkService leagueInviteLinkService) : ControllerBase {
     // ---------- League Info ----------
     [HttpGet("{leagueId:int}")]
     [ProducesResponseType(typeof(LeagueInfoDto), StatusCodes.Status200OK)]
@@ -745,6 +746,48 @@ public class LeagueController(
         if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
             return Forbid();
         await repo.RemoveLeagueUserMappingAsync(leagueId, userId);
+        return NoContent();
+    }
+
+    // ── Shareable invite link ─────────────────────────────────────────────────
+
+    [HttpPost("{leagueId:int}/invite-link")]
+    [ProducesResponseType(typeof(LeagueInviteLinkDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<LeagueInviteLinkDto>> GenerateInviteLink(int leagueId) {
+        var league = await repo.GetLeagueInfoAsync(leagueId);
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
+            return Forbid();
+        var link = await leagueInviteLinkService.GenerateAsync(leagueId, callerId);
+        return Ok(new LeagueInviteLinkDto(link.Token, link.LeagueId, link.League.LeagueName, link.ExpiresAt));
+    }
+
+    [HttpGet("join/{token}")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(LeagueInviteLinkDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<LeagueInviteLinkDto>> ValidateInviteLink(string token) {
+        var link = await leagueInviteLinkService.ValidateAsync(token);
+        if (link is null) return NotFound();
+        return Ok(new LeagueInviteLinkDto(link.Token, link.LeagueId, link.League.LeagueName, link.ExpiresAt));
+    }
+
+    [HttpPost("join/{token}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> JoinViaLink(string token) {
+        var link = await leagueInviteLinkService.ValidateAsync(token);
+        if (link is null) return NotFound();
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        if (await repo.UserExistsInLeagueAsync(userId, link.LeagueId))
+            return Conflict("You are already a member of this league.");
+        await repo.AddLeagueUserMappingAsync(new LeagueUserMapping {
+            LeagueId = link.LeagueId,
+            UserId = userId,
+            DateCreated = DateTimeOffset.UtcNow,
+        });
         return NoContent();
     }
 

--- a/Server/Data/ApplicationDbContext.cs
+++ b/Server/Data/ApplicationDbContext.cs
@@ -25,6 +25,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     public DbSet<CfbPicks> CfbPicks { get; set; }
     public DbSet<CfbSeasonWeekConfig> CfbSeasonWeekConfigs { get; set; }
     public DbSet<NflSeasonWeekConfig> NflSeasonWeekConfigs { get; set; }
+    public DbSet<LeagueInviteLink> LeagueInviteLinks { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder) {
         base.OnModelCreating(modelBuilder);

--- a/Server/Migrations/20260816153828_AddLeagueInviteLinks.Designer.cs
+++ b/Server/Migrations/20260816153828_AddLeagueInviteLinks.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260816153828_AddLeagueInviteLinks")]
+    partial class AddLeagueInviteLinks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/20260816153828_AddLeagueInviteLinks.cs
+++ b/Server/Migrations/20260816153828_AddLeagueInviteLinks.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLeagueInviteLinks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LeagueInviteLinks",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Token = table.Column<string>(type: "text", nullable: false),
+                    LeagueId = table.Column<int>(type: "integer", nullable: false),
+                    CreatedByUserId = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ExpiresAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    IsRevoked = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LeagueInviteLinks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_LeagueInviteLinks_AspNetUsers_CreatedByUserId",
+                        column: x => x.CreatedByUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_LeagueInviteLinks_LeagueInfo_LeagueId",
+                        column: x => x.LeagueId,
+                        principalTable: "LeagueInfo",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeagueInviteLinks_CreatedByUserId",
+                table: "LeagueInviteLinks",
+                column: "CreatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeagueInviteLinks_LeagueId",
+                table: "LeagueInviteLinks",
+                column: "LeagueId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeagueInviteLinks_Token",
+                table: "LeagueInviteLinks",
+                column: "Token",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LeagueInviteLinks");
+        }
+    }
+}

--- a/Server/Models/Data/LeagueInviteLink.cs
+++ b/Server/Models/Data/LeagueInviteLink.cs
@@ -1,0 +1,39 @@
+using FourPlayWebApp.Server.Models.Identity;
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace FourPlayWebApp.Server.Models.Data;
+
+[Index(nameof(Token), IsUnique = true)]
+public class LeagueInviteLink
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    public string Token { get; set; } = Guid.NewGuid().ToString("N");
+
+    public int LeagueId { get; set; }
+
+    [ForeignKey("LeagueId")]
+    public LeagueInfo League { get; set; } = null!;
+
+    [Required]
+    public string CreatedByUserId { get; set; } = null!;
+
+    [ForeignKey("CreatedByUserId")]
+    public ApplicationUser CreatedByUser { get; set; } = null!;
+
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public DateTimeOffset ExpiresAt { get; set; } = DateTimeOffset.UtcNow.AddHours(24);
+
+    public bool IsRevoked { get; set; }
+
+    [NotMapped]
+    public bool IsExpired => ExpiresAt < DateTimeOffset.UtcNow;
+
+    [NotMapped]
+    public bool IsValid => !IsRevoked && !IsExpired;
+}

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -260,6 +260,7 @@ builder.Services.AddCors(options =>
 });
 // Add Invitation Service
 builder.Services.AddScoped<IInvitationService, InvitationService>();
+builder.Services.AddScoped<ILeagueInviteLinkService, LeagueInviteLinkService>();
 
 builder.Services.AddScoped<ISpreadCalculatorBuilder, SpreadCalculatorBuilder>();
 builder.Services.AddSingleton<ILeaderboardService, LeaderboardService>();

--- a/Server/Services/Interfaces/ILeagueInviteLinkService.cs
+++ b/Server/Services/Interfaces/ILeagueInviteLinkService.cs
@@ -4,6 +4,6 @@ namespace FourPlayWebApp.Server.Services.Interfaces;
 
 public interface ILeagueInviteLinkService
 {
-    Task<LeagueInviteLink> GenerateAsync(int leagueId, string createdByUserId);
+    Task<LeagueInviteLink> GenerateAsync(int leagueId, string createdByUserId, LeagueInfo league);
     Task<LeagueInviteLink?> ValidateAsync(string token);
 }

--- a/Server/Services/Interfaces/ILeagueInviteLinkService.cs
+++ b/Server/Services/Interfaces/ILeagueInviteLinkService.cs
@@ -1,0 +1,9 @@
+using FourPlayWebApp.Server.Models.Data;
+
+namespace FourPlayWebApp.Server.Services.Interfaces;
+
+public interface ILeagueInviteLinkService
+{
+    Task<LeagueInviteLink> GenerateAsync(int leagueId, string createdByUserId);
+    Task<LeagueInviteLink?> ValidateAsync(string token);
+}

--- a/Server/Services/LeagueInviteLinkService.cs
+++ b/Server/Services/LeagueInviteLinkService.cs
@@ -8,39 +8,33 @@ namespace FourPlayWebApp.Server.Services;
 public class LeagueInviteLinkService(IDbContextFactory<ApplicationDbContext> dbContextFactory)
     : ILeagueInviteLinkService
 {
-    public async Task<LeagueInviteLink> GenerateAsync(int leagueId, string createdByUserId)
+    public async Task<LeagueInviteLink> GenerateAsync(int leagueId, string createdByUserId, LeagueInfo league)
     {
         await using var db = await dbContextFactory.CreateDbContextAsync();
 
-        // Revoke any existing active links for this league
-        var existing = await db.LeagueInviteLinks
+        await db.LeagueInviteLinks
             .Where(l => l.LeagueId == leagueId && !l.IsRevoked)
-            .ToListAsync();
-        foreach (var old in existing)
-            old.IsRevoked = true;
+            .ExecuteUpdateAsync(s => s.SetProperty(l => l.IsRevoked, true));
 
         var link = new LeagueInviteLink
         {
             LeagueId = leagueId,
             CreatedByUserId = createdByUserId,
             ExpiresAt = DateTimeOffset.UtcNow.AddHours(24),
+            League = league,
         };
         db.LeagueInviteLinks.Add(link);
         await db.SaveChangesAsync();
 
-        // Reload with navigation property
-        return await db.LeagueInviteLinks
-            .Include(l => l.League)
-            .FirstAsync(l => l.Id == link.Id);
+        return link;
     }
 
     public async Task<LeagueInviteLink?> ValidateAsync(string token)
     {
         await using var db = await dbContextFactory.CreateDbContextAsync();
-        var link = await db.LeagueInviteLinks
+        return await db.LeagueInviteLinks
             .Include(l => l.League)
+            .Where(l => !l.IsRevoked && l.ExpiresAt > DateTimeOffset.UtcNow)
             .FirstOrDefaultAsync(l => l.Token == token);
-
-        return link is { IsValid: true } ? link : null;
     }
 }

--- a/Server/Services/LeagueInviteLinkService.cs
+++ b/Server/Services/LeagueInviteLinkService.cs
@@ -1,0 +1,46 @@
+using FourPlayWebApp.Server.Data;
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace FourPlayWebApp.Server.Services;
+
+public class LeagueInviteLinkService(IDbContextFactory<ApplicationDbContext> dbContextFactory)
+    : ILeagueInviteLinkService
+{
+    public async Task<LeagueInviteLink> GenerateAsync(int leagueId, string createdByUserId)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+
+        // Revoke any existing active links for this league
+        var existing = await db.LeagueInviteLinks
+            .Where(l => l.LeagueId == leagueId && !l.IsRevoked)
+            .ToListAsync();
+        foreach (var old in existing)
+            old.IsRevoked = true;
+
+        var link = new LeagueInviteLink
+        {
+            LeagueId = leagueId,
+            CreatedByUserId = createdByUserId,
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(24),
+        };
+        db.LeagueInviteLinks.Add(link);
+        await db.SaveChangesAsync();
+
+        // Reload with navigation property
+        return await db.LeagueInviteLinks
+            .Include(l => l.League)
+            .FirstAsync(l => l.Id == link.Id);
+    }
+
+    public async Task<LeagueInviteLink?> ValidateAsync(string token)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+        var link = await db.LeagueInviteLinks
+            .Include(l => l.League)
+            .FirstOrDefaultAsync(l => l.Token == token);
+
+        return link is { IsValid: true } ? link : null;
+    }
+}

--- a/Shared/Models/Data/Dtos/LeagueInviteLinkDto.cs
+++ b/Shared/Models/Data/Dtos/LeagueInviteLinkDto.cs
@@ -1,0 +1,8 @@
+namespace FourPlayWebApp.Shared.Models.Data.Dtos;
+
+public record LeagueInviteLinkDto(
+    string Token,
+    int LeagueId,
+    string LeagueName,
+    DateTimeOffset ExpiresAt
+);


### PR DESCRIPTION
## Summary

- **Shareable invite link** — league owners generate a 24-hour, multi-use URL from the Members tab and share it via the iOS/Android native share sheet (or copy to clipboard on desktop). Recipients click the link, create an account (or log in), and auto-join the league — no per-email entry required.
- **Backend**: `LeagueInviteLink` entity + EF migration; `ILeagueInviteLinkService` (generate soft-revokes old active link, validate DB-filters expired/revoked at the query level); 3 endpoints (`POST /{id}/invite-link`, `GET /join/{token}` `[AllowAnonymous]`, `POST /join/{token}` `[Authorize]`); 8 xUnit tests covering ownership 403, valid/expired, already-member Conflict, happy join.
- **Frontend**: `JoinLeaguePage` at public `/join/:token` route (unauthed → sign-up CTA with AbortController cleanup, authed → Join button with 409-aware error handling); `MembersTab` updated with Generate/Regenerate Invite Link button + link panel (URL, async Copy with error feedback, native Share).
- **CLAUDE.md**: new CRITICAL sections enforcing DTO/strongly-typed API surfaces and NFL/CFB shared-logic (no duplicated paths).
- **Style guide**: `.claude/skills/style-guide/SKILL.md` committed; GameCard pick/over/under buttons corrected from `warning` to `info` per guide.

## Test plan

- [ ] `dotnet test` — 440/447 pass (7 pre-existing `EspnContractTests` failures, unrelated)
- [ ] `npm run test -- --run` — 261/261 pass
- [ ] Manual: demo stack → My Leagues → Members tab → Generate Invite Link → copy URL → open in incognito → register → confirm auto-joined

🤖 Generated with [Claude Code](https://claude.com/claude-code)