### PR TITLE
Release: Gmail API email, invite link share, Settings tab rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,27 @@ When fixing a bug: grep existing tests for old wrong values before shipping. Whe
 
 ---
 
+## CRITICAL: API Surface — DTOs and Strongly Typed Objects
+
+**Every API boundary must use an explicit DTO or strongly typed record/class — no anonymous objects, no `dynamic`, no raw `Dictionary<string,object>`, no `object` return types.**
+
+- **Backend**: all controller endpoints return and accept named records or classes from `Shared/Models/Data/Dtos/` or `Shared/Models/`. Never serialize anonymous `new { }` objects — create a DTO.
+- **Frontend**: all API functions in `src/api/` must declare and export a TypeScript `interface` or `type` for every request and response shape. Never use `any`; avoid `unknown` except at boundaries where you immediately narrow the type.
+- When adding a new endpoint, add the corresponding DTO to `Shared/Models/Data/Dtos/` first, then wire it in.
+
+---
+
+## CRITICAL: NFL/CFB Code Sharing — No Duplicated Logic Between Sport Paths
+
+**One implementation, two sport call sites — never two implementations.**
+
+- Business logic (status derivation, pick validation, security guards, leaderboard scoring, spread formatting) lives in **one shared function/service** that both NFL and CFB call. Never copy-paste and modify.
+- `PicksPage`, `ScoresPage`, `LeaderboardPage` are sport-agnostic via `adapter: SportAdapter` — keep them that way. Put sport-specific logic in the adapter, not the page.
+- When fixing a bug on one sport's path, **always check the other sport's equivalent** before shipping — open the CFB controller/adapter/service when you fix the NFL one, and vice versa.
+- Duplicated logic between NFL and CFB paths is a P0 bug magnet — it has repeatedly caused diverging guards and status-parsing bugs.
+
+---
+
 ## CRITICAL: Branch Rules
 - **NEVER push or commit directly to `main`** — all changes go through a PR
 - Branch flow: `feature/*` → PR → `dev` → PR → `main`

--- a/Client.React/e2e/helpers/routes.ts
+++ b/Client.React/e2e/helpers/routes.ts
@@ -5,6 +5,13 @@ import type { LeagueUserMappingDto } from '../../src/types/league';
 import type { LeaderboardDto } from '../../src/types/leaderboard';
 import { createScores, createSpreadResponse } from '../../src/test/fixtures';
 
+const mockInviteLink = () => ({
+  token: 'mocktokenabcdef1234567890abcdef12',
+  leagueId: 1,
+  leagueName: 'Test League',
+  expiresAt: new Date(Date.now() + 86400000).toISOString(),
+});
+
 export const TEST_USER: UserInfo = {
   userId: 'test-user-id-001',
   name: 'TestUser',
@@ -376,6 +383,21 @@ export async function setupRoutes(page: Page, options: SetupRoutesOptions = {}):
 
     if (url.match(/\/api\/league\/\d+\/invite$/) && method === 'POST') {
       void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+      return;
+    }
+
+    if (url.match(/\/api\/league\/\d+\/invite-link$/) && method === 'POST') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockInviteLink()) });
+      return;
+    }
+
+    if (url.match(/\/api\/league\/join\/[^/]+$/) && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockInviteLink()) });
+      return;
+    }
+
+    if (url.match(/\/api\/league\/join\/[^/]+$/) && method === 'POST') {
+      void route.fulfill({ status: 204 });
       return;
     }
 

--- a/Client.React/e2e/leaguePortal.spec.ts
+++ b/Client.React/e2e/leaguePortal.spec.ts
@@ -45,11 +45,11 @@ test.describe('Commissioner portal (/league/manage)', () => {
     await expect(page.getByText(/members.*\$100\/season/)).toBeVisible({ timeout: 5000 });
   });
 
-  test('Juice Settings tab loads existing juice values', async ({ page }) => {
+  test('League Payouts tab loads existing juice values', async ({ page }) => {
     await ownerAuth(page);
     await waitForSpinner(page);
 
-    await page.getByRole('tab', { name: /juice settings/i }).click();
+    await page.getByRole('tab', { name: /league payouts/i }).click();
     await waitForSpinner(page);
 
     // Mocked juice: 13 pts tease — "Tease Pts (Regular Season)" label should be visible

--- a/Client.React/e2e/leaguePortal.spec.ts
+++ b/Client.React/e2e/leaguePortal.spec.ts
@@ -45,11 +45,11 @@ test.describe('Commissioner portal (/league/manage)', () => {
     await expect(page.getByText(/members.*\$100\/season/)).toBeVisible({ timeout: 5000 });
   });
 
-  test('League Payouts tab loads existing juice values', async ({ page }) => {
+  test('Settings tab loads existing juice values', async ({ page }) => {
     await ownerAuth(page);
     await waitForSpinner(page);
 
-    await page.getByRole('tab', { name: /league payouts/i }).click();
+    await page.getByRole('tab', { name: /settings/i }).click();
     await waitForSpinner(page);
 
     // Mocked juice: 13 pts tease — "Tease Pts (Regular Season)" label should be visible

--- a/Client.React/src/App.tsx
+++ b/Client.React/src/App.tsx
@@ -35,6 +35,7 @@ function LeaderboardRoute() {
   return <LeaderboardPage adapter={isCfb ? cfbAdapter : nflAdapter} />;
 }
 
+import JoinLeaguePage from './pages/JoinLeaguePage';
 import LeaguePickerPage from './pages/LeaguePickerPage';
 import PicksPage from './pages/PicksPage';
 import ScoresPage from './pages/ScoresPage';
@@ -71,6 +72,7 @@ export default function App() {
       <Route path="/register" caseSensitive={false} element={<Navigate to="/account/register" replace />} />
       <Route path="/account/login" caseSensitive={false} element={<LoginPage />} />
       <Route path="/account/register" caseSensitive={false} element={<RegisterPage />} />
+      <Route path="/join/:token" caseSensitive={false} element={<JoinLeaguePage />} />
       <Route path="/account/registerconfirmation" caseSensitive={false} element={<RegisterConfirmationPage />} />
       <Route path="/account/forgotpassword" caseSensitive={false} element={<ForgotPasswordPage />} />
       <Route path="/account/forgotpasswordconfirmation" caseSensitive={false} element={<ForgotPasswordConfirmationPage />} />

--- a/Client.React/src/__tests__/JoinLeaguePage.test.tsx
+++ b/Client.React/src/__tests__/JoinLeaguePage.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { vi } from 'vitest';
+import JoinLeaguePage from '../pages/JoinLeaguePage';
+
+const navigateMock = vi.fn();
+
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>();
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+const authState: { user: { userId: string; name: string; claims: unknown[] } | null } = {
+  user: null,
+};
+vi.mock('../services/auth', () => ({ useAuth: () => authState }));
+
+const sessionMock = { reloadLeagues: vi.fn().mockResolvedValue(undefined) };
+vi.mock('../services/session', () => ({ useSession: () => sessionMock }));
+
+vi.mock('../api/league', () => ({
+  validateInviteLink: vi.fn(),
+  joinViaLink: vi.fn(),
+}));
+
+import { validateInviteLink, joinViaLink } from '../api/league';
+
+function renderWithToken(token: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/join/${token}`]}>
+      <Routes>
+        <Route path="/join/:token" element={<JoinLeaguePage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('JoinLeaguePage', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    sessionMock.reloadLeagues.mockResolvedValue(undefined);
+    authState.user = null;
+  });
+
+  it('shows error when token is invalid or expired', async () => {
+    vi.mocked(validateInviteLink).mockResolvedValue(null);
+    renderWithToken('badtoken');
+    await waitFor(() =>
+      expect(screen.getByText(/expired or invalid/i)).toBeInTheDocument()
+    );
+  });
+
+  it('shows league name and sign-up CTA when logged out and token is valid', async () => {
+    vi.mocked(validateInviteLink).mockResolvedValue({
+      token: 'tok123',
+      leagueId: 1,
+      leagueName: 'My NFL League',
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+    });
+    authState.user = null;
+    renderWithToken('tok123');
+    await waitFor(() => expect(screen.getByText('My NFL League')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /create an account/i })).toBeInTheDocument();
+  });
+
+  it('navigates to register page when sign-up CTA is clicked', async () => {
+    vi.mocked(validateInviteLink).mockResolvedValue({
+      token: 'tok123',
+      leagueId: 1,
+      leagueName: 'My NFL League',
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+    });
+    authState.user = null;
+    renderWithToken('tok123');
+    await waitFor(() => screen.getByRole('button', { name: /create an account/i }));
+    await userEvent.click(screen.getByRole('button', { name: /create an account/i }));
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.stringContaining('/account/register'),
+    );
+  });
+
+  it('shows Join button when user is logged in and token is valid', async () => {
+    vi.mocked(validateInviteLink).mockResolvedValue({
+      token: 'tok123',
+      leagueId: 1,
+      leagueName: 'My NFL League',
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+    });
+    authState.user = { userId: 'user-1', name: 'Alice', claims: [] };
+    renderWithToken('tok123');
+    await waitFor(() => expect(screen.getByRole('button', { name: /join/i })).toBeInTheDocument());
+  });
+
+  it('calls joinViaLink and navigates to dashboard on success', async () => {
+    vi.mocked(validateInviteLink).mockResolvedValue({
+      token: 'tok123',
+      leagueId: 1,
+      leagueName: 'My NFL League',
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+    });
+    vi.mocked(joinViaLink).mockResolvedValue(undefined);
+    authState.user = { userId: 'user-1', name: 'Alice', claims: [] };
+    renderWithToken('tok123');
+    await waitFor(() => screen.getByRole('button', { name: /join/i }));
+    await userEvent.click(screen.getByRole('button', { name: /join/i }));
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/dashboard'));
+    expect(sessionMock.reloadLeagues).toHaveBeenCalled();
+  });
+});

--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -49,6 +49,7 @@ vi.mock('../api/league', () => ({
   createLeague: vi.fn(),
   addLeagueUserMapping: vi.fn(),
   assignLeagueOwner: vi.fn(),
+  deleteLeague: vi.fn(),
 }));
 import {
   getLeagueUserMappings,
@@ -58,6 +59,7 @@ import {
   getUsers,
   createLeague,
   addLeagueUserMapping,
+  deleteLeague,
 } from '../api/league';
 
 const mockedGetMappings = vi.mocked(getLeagueUserMappings);
@@ -67,6 +69,7 @@ const mockedGetAllLeagues = vi.mocked(getAllLeagues);
 const mockedGetUsers = vi.mocked(getUsers);
 const mockedCreateLeague = vi.mocked(createLeague);
 const mockedAddLeagueUserMapping = vi.mocked(addLeagueUserMapping);
+const mockedDeleteLeague = vi.mocked(deleteLeague);
 
 const CURRENT_SEASON = new Date().getFullYear();
 
@@ -126,6 +129,7 @@ beforeEach(() => {
   mockedGetUsers.mockResolvedValue([makeUser()]);
   mockedCreateLeague.mockResolvedValue(makeLeague({ id: 99, leagueName: 'New League' }));
   mockedAddLeagueUserMapping.mockResolvedValue(undefined);
+  mockedDeleteLeague.mockResolvedValue(undefined);
   sessionState.reloadLeagues.mockClear();
   toastPush.mockClear();
 });
@@ -139,7 +143,7 @@ describe('LeaguePortalPage (owner, non-admin)', () => {
 
   it('locks juice fields for a past season and keeps them editable for the current season', async () => {
     renderPage();
-    await userEvent.click(await screen.findByRole('tab', { name: 'Juice Settings' }));
+    await userEvent.click(await screen.findByRole('tab', { name: 'League Payouts' }));
 
     const seasonSelect = screen.getAllByRole('combobox')[0];
     await userEvent.click(seasonSelect);
@@ -154,6 +158,16 @@ describe('LeaguePortalPage (owner, non-admin)', () => {
 
     await waitFor(() => expect(screen.getByLabelText(/Tease Pts \(Regular Season\)/i)).not.toBeDisabled());
     expect(screen.getByRole('button', { name: /save/i })).not.toBeDisabled();
+  });
+
+  // frizat: "Juice Settings"/"Weekly Cost" read as gambling jargon to a general audience —
+  // renamed to plain language. Locking in the new copy so this doesn't silently regress.
+  it('shows the League Payouts tab and Cost Per Week field with plain-language labels', async () => {
+    renderPage();
+    await userEvent.click(await screen.findByRole('tab', { name: 'League Payouts' }));
+    expect(await screen.findByLabelText(/cost per week/i)).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: /juice settings/i })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/weekly cost/i)).not.toBeInTheDocument();
   });
 
   it('does not show a raw owner id on the Info tab', async () => {
@@ -195,6 +209,42 @@ describe('LeaguePortalPage (owner, non-admin)', () => {
       expect.objectContaining({ leagueName: 'New League', ownerUserId: 'owner-1' })
     ));
     expect(sessionState.reloadLeagues).toHaveBeenCalled();
+  });
+
+  // frizat: Remove Member is now a soft-delete (kept for audit/history, can be re-added) — the
+  // dialog copy must say so, not "cannot be undone", which stopped being true.
+  it('tells the admin a removed member can be re-added, not that it cannot be undone', async () => {
+    renderPage();
+    await userEvent.click(await screen.findByRole('button', { name: /remove/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(/re-added/i)).toBeInTheDocument();
+    expect(within(dialog).queryByText(/cannot be undone/i)).not.toBeInTheDocument();
+  });
+
+  // frizat: deleting an entire league (all picks, members, payout history) is a much bigger
+  // blast radius than removing one member, so a plain Cancel/Confirm click is too easy to
+  // mis-click — the confirm button stays disabled until the league name is typed exactly.
+  it('gates Delete League behind typing the exact league name, then deletes it', async () => {
+    renderPage();
+    await userEvent.click(await screen.findByRole('tab', { name: 'Info' }));
+    await userEvent.click(await screen.findByRole('button', { name: /delete league/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    const confirmButton = within(dialog).getByRole('button', { name: /^delete league$/i });
+    expect(confirmButton).toBeDisabled();
+
+    const confirmInput = within(dialog).getByLabelText(/league name/i);
+    await userEvent.type(confirmInput, 'Demo Leagu');
+    expect(confirmButton).toBeDisabled();
+
+    await userEvent.type(confirmInput, 'e');
+    expect(confirmButton).not.toBeDisabled();
+
+    await userEvent.click(confirmButton);
+
+    await waitFor(() => expect(mockedDeleteLeague).toHaveBeenCalledWith(1));
+    expect(toastPush).toHaveBeenCalledWith(expect.stringMatching(/deleted/i), 'success');
   });
 });
 

--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { vi } from 'vitest';
@@ -29,11 +29,12 @@ const ADMIN_USER: UserInfo = { userId: 'admin-1', name: 'Admin', claims: [{ type
 
 const authState = { user: OWNER_USER as UserInfo | null };
 const sportContext = { sport: 'NFL' as 'NFL' | 'CFB', isCfb: false, isNfl: true };
+const toastPush = vi.fn();
 
 vi.mock('../services/session', () => ({ useSession: () => sessionState }));
 vi.mock('../services/sport', () => ({ useSportContext: () => sportContext }));
 vi.mock('../services/auth', () => ({ useAuth: () => authState }));
-vi.mock('../services/toast', () => ({ useToast: () => ({ push: vi.fn() }) }));
+vi.mock('../services/toast', () => ({ useToast: () => ({ push: toastPush }) }));
 
 vi.mock('../api/league', () => ({
   getLeagueUserMappings: vi.fn(),
@@ -56,6 +57,7 @@ import {
   getAllLeagues,
   getUsers,
   createLeague,
+  addLeagueUserMapping,
 } from '../api/league';
 
 const mockedGetMappings = vi.mocked(getLeagueUserMappings);
@@ -64,6 +66,7 @@ const mockedGetCost = vi.mocked(getLeagueCost);
 const mockedGetAllLeagues = vi.mocked(getAllLeagues);
 const mockedGetUsers = vi.mocked(getUsers);
 const mockedCreateLeague = vi.mocked(createLeague);
+const mockedAddLeagueUserMapping = vi.mocked(addLeagueUserMapping);
 
 const CURRENT_SEASON = new Date().getFullYear();
 
@@ -122,7 +125,9 @@ beforeEach(() => {
   mockedGetAllLeagues.mockResolvedValue([]);
   mockedGetUsers.mockResolvedValue([makeUser()]);
   mockedCreateLeague.mockResolvedValue(makeLeague({ id: 99, leagueName: 'New League' }));
+  mockedAddLeagueUserMapping.mockResolvedValue(undefined);
   sessionState.reloadLeagues.mockClear();
+  toastPush.mockClear();
 });
 
 describe('LeaguePortalPage (owner, non-admin)', () => {
@@ -298,5 +303,29 @@ describe('LeaguePortalPage (site admin)', () => {
     expect(screen.getByRole('button', { name: /add user/i })).toBeInTheDocument();
     await userEvent.click(screen.getByRole('tab', { name: 'Info' }));
     expect(screen.getByRole('button', { name: /change owner/i })).toBeInTheDocument();
+  });
+
+  // frizat: getUsers() backs Add User, Create League's owner picker, and Assign Owner —
+  // a failed fetch previously left all three silently empty forever (no catch, no toast,
+  // no retry). This proves the failure is now surfaced instead of invisible.
+  it('shows an error toast when the platform user list fails to load', async () => {
+    mockedGetUsers.mockRejectedValue(new Error('network down'));
+    renderPage();
+    await screen.findByText('frizat@example.com');
+    await waitFor(() => expect(toastPush).toHaveBeenCalledWith(expect.stringMatching(/failed to load users/i), 'error'));
+  });
+
+  it('adds a selected user to the league via the Add User dialog', async () => {
+    renderPage();
+    await userEvent.click(await screen.findByRole('button', { name: /add user/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    const userSelect = within(dialog).getByLabelText(/^user$/i);
+    await userEvent.selectOptions(userSelect, 'bob@example.com');
+    await userEvent.click(within(dialog).getByRole('button', { name: /^add user$/i }));
+
+    await waitFor(() => expect(mockedAddLeagueUserMapping).toHaveBeenCalledWith(1, 'user-2'));
+    expect(toastPush).toHaveBeenCalledWith('bob@example.com added to league', 'success');
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
 });

--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -143,7 +143,7 @@ describe('LeaguePortalPage (owner, non-admin)', () => {
 
   it('locks juice fields for a past season and keeps them editable for the current season', async () => {
     renderPage();
-    await userEvent.click(await screen.findByRole('tab', { name: 'League Payouts' }));
+    await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
 
     const seasonSelect = screen.getAllByRole('combobox')[0];
     await userEvent.click(seasonSelect);
@@ -162,9 +162,9 @@ describe('LeaguePortalPage (owner, non-admin)', () => {
 
   // frizat: "Juice Settings"/"Weekly Cost" read as gambling jargon to a general audience —
   // renamed to plain language. Locking in the new copy so this doesn't silently regress.
-  it('shows the League Payouts tab and Cost Per Week field with plain-language labels', async () => {
+  it('shows the Settings tab with plain-language labels (no gambling jargon)', async () => {
     renderPage();
-    await userEvent.click(await screen.findByRole('tab', { name: 'League Payouts' }));
+    await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
     expect(await screen.findByLabelText(/cost per week/i)).toBeInTheDocument();
     expect(screen.queryByRole('tab', { name: /juice settings/i })).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/weekly cost/i)).not.toBeInTheDocument();

--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -328,4 +328,30 @@ describe('LeaguePortalPage (site admin)', () => {
     expect(toastPush).toHaveBeenCalledWith('bob@example.com added to league', 'success');
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
+
+  // frizat: Create League's Sport field used to be a free-choice dropdown regardless of which
+  // subdomain the admin was on — an admin browsing cfb.* could create an NFL league and vice
+  // versa. The site you're on IS the sport you're creating for, so the field should show the
+  // current sport and not offer the other one at all.
+  it('locks the Create League sport field to the current subdomain, not an editable choice', async () => {
+    sportContext.sport = 'CFB';
+    sportContext.isCfb = true;
+    sportContext.isNfl = false;
+    renderPage();
+    await userEvent.click(await screen.findByRole('button', { name: /create league/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    const sportField = within(dialog).getByLabelText(/^sport$/i);
+    expect(sportField).toHaveValue('CFB');
+    expect(sportField).toBeDisabled();
+    expect(within(dialog).queryByRole('option', { name: /^nfl$/i })).not.toBeInTheDocument();
+  });
+
+  it('locks the Create League sport field to NFL on the NFL subdomain', async () => {
+    renderPage();
+    await userEvent.click(await screen.findByRole('button', { name: /create league/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByLabelText(/^sport$/i)).toHaveValue('NFL');
+  });
 });

--- a/Client.React/src/__tests__/RulesPage.test.tsx
+++ b/Client.React/src/__tests__/RulesPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 import { useSportContext } from '../services/sport';
@@ -86,15 +86,16 @@ describe('RulesPage — NFL', () => {
 
   it('shows all four NFL playoff rounds', () => {
     renderPage();
-    expect(screen.getByText(/wild card/i)).toBeInTheDocument();
-    expect(screen.getByText(/divisional/i)).toBeInTheDocument();
-    expect(screen.getByText(/championship/i)).toBeInTheDocument();
-    expect(screen.getByText(/super bowl/i)).toBeInTheDocument();
+    const grid = within(screen.getByTestId('playoff-grid'));
+    expect(grid.getByText(/wild card/i)).toBeInTheDocument();
+    expect(grid.getByText(/divisional/i)).toBeInTheDocument();
+    expect(grid.getByText(/championship/i)).toBeInTheDocument();
+    expect(grid.getByText(/super bowl/i)).toBeInTheDocument();
   });
 
   it('shows correct Wild Card required picks (3)', () => {
     renderPage();
-    const wildCardSection = screen.getByText(/wild card/i).closest('div');
+    const wildCardSection = within(screen.getByTestId('playoff-grid')).getByText(/wild card/i).closest('div');
     expect(wildCardSection).toHaveTextContent('3');
   });
 
@@ -107,6 +108,35 @@ describe('RulesPage — NFL', () => {
   it('mentions server-side enforcement of deadlines', () => {
     renderPage();
     expect(screen.getByText(/enforced server-side/i)).toBeInTheDocument();
+  });
+});
+
+describe('RulesPage — Over/Under in the postseason', () => {
+  it('explains Over/Under replaces a pick rather than adding one (NFL)', () => {
+    vi.mocked(useSportContext).mockReturnValue({ sport: 'NFL', isCfb: false, isNfl: true });
+    renderPage();
+    expect(screen.getByText(/over\/under in the postseason/i)).toBeInTheDocument();
+    expect(screen.getByText(/replaces/i)).toBeInTheDocument();
+    expect(screen.getByText(/not 4/i)).toBeInTheDocument();
+  });
+
+  it('shows an NFL example with exactly one Over/Under pick among the required picks', () => {
+    vi.mocked(useSportContext).mockReturnValue({ sport: 'NFL', isCfb: false, isNfl: true });
+    renderPage();
+    const example = within(screen.getByTestId('over-under-example'));
+    expect(example.getByText(/wild card · 3 picks required/i)).toBeInTheDocument();
+    expect(example.getAllByText('Spread')).toHaveLength(2);
+    expect(example.getAllByText('Over/Under')).toHaveLength(1);
+  });
+
+  it('shows a CFB example with exactly one Over/Under pick among the required picks', () => {
+    vi.mocked(useSportContext).mockReturnValue({ sport: 'CFB', isCfb: true, isNfl: false });
+    renderPage();
+    const example = within(screen.getByTestId('over-under-example'));
+    expect(example.getByText(/cfp first round · 3 picks required/i)).toBeInTheDocument();
+    expect(example.getAllByText('Spread')).toHaveLength(2);
+    expect(example.getAllByText('Over/Under')).toHaveLength(1);
+    expect(screen.getByText(/not 4/i)).toBeInTheDocument();
   });
 });
 
@@ -128,7 +158,7 @@ describe('RulesPage — CFB playoff grid', () => {
 
   it('shows First Round with 3 picks', () => {
     renderPage();
-    const section = screen.getByText(/first round/i).closest('div');
+    const section = within(screen.getByTestId('playoff-grid')).getByText(/first round/i).closest('div');
     expect(section).toHaveTextContent('3');
   });
 
@@ -148,11 +178,12 @@ describe('RulesPage — CFB playoff grid', () => {
 
   it('shows 5 CFB rounds, not 4 NFL rounds', () => {
     renderPage();
-    expect(screen.getByText(/conf\. championships/i)).toBeInTheDocument();
-    expect(screen.getByText(/first round/i)).toBeInTheDocument();
-    expect(screen.getByText(/quarterfinals/i)).toBeInTheDocument();
-    expect(screen.getByText(/semifinals/i)).toBeInTheDocument();
-    // NFL-specific rounds should not appear
+    const grid = within(screen.getByTestId('playoff-grid'));
+    expect(grid.getByText(/conf\. championships/i)).toBeInTheDocument();
+    expect(grid.getByText(/first round/i)).toBeInTheDocument();
+    expect(grid.getByText(/quarterfinals/i)).toBeInTheDocument();
+    expect(grid.getByText(/semifinals/i)).toBeInTheDocument();
+    // NFL-specific rounds should not appear anywhere on the page
     expect(screen.queryByText(/wild card/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/super bowl/i)).not.toBeInTheDocument();
   });

--- a/Client.React/src/__tests__/cfbAdapter.test.ts
+++ b/Client.React/src/__tests__/cfbAdapter.test.ts
@@ -20,7 +20,7 @@ vi.mock('../api/espn', () => ({
   getCfbLiveGames: vi.fn(),
 }));
 
-import { getCfbCurrentSlate, getCfbSlates, getCfbSpreads, getCfbScores, getCfbUserPicks } from '../api/cfb';
+import { getCfbCurrentSlate, getCfbSlates, getCfbSpreads, getCfbScores, getCfbUserPicks, addCfbPicks } from '../api/cfb';
 import { loadCfbScoresWithRetry, getCfbLiveGames } from '../api/espn';
 
 const slate: CfbSlateDto = {
@@ -28,7 +28,7 @@ const slate: CfbSlateDto = {
   slateType: 'RegularSeason', startDate: '2026-10-20', endDate: '2026-10-26',
 };
 const spread: CfbSpreadDto = {
-  id: 1, cfbSlateId: 10, espnEventId: 999, homeTeam: 'MICH', awayTeam: 'PSU',
+  id: 1, cfbSlateId: 10, homeTeam: 'MICH', awayTeam: 'PSU',
   homeTeamSpread: -3.5, awayTeamSpread: 3.5, overUnder: 44.5,
   gameTime: '2025-10-11T20:00:00Z', dateCreated: '2025-10-09T14:00:00Z',
 };
@@ -86,7 +86,7 @@ describe('cfbAdapter', () => {
       expect(game.homeScore).toBe(27);
       expect(game.awayScore).toBe(13);
       expect(game.gameStatus).toBe('final');
-      expect(game.id).toBe('999');
+      expect(game.id).toBe('MICH');
       expect(game.spreadPostedAt).toBe('2025-10-09T14:00:00Z');
     });
 
@@ -110,10 +110,10 @@ describe('cfbAdapter', () => {
       expect(result.hasOdds).toBe(false);
     });
 
-    it('maps CfbPickDto to PickView with stringified gameId', async () => {
+    it('maps a home-team CfbPickDto to PickView with gameId = homeTeam', async () => {
       const pick: CfbPickDto = {
         id: 1, userId: 'user1', userName: 'user1', leagueId: 1, cfbSlateId: 10,
-        espnEventId: 999, team: 'MICH', pickType: 'Spread', season: 2026,
+        team: 'MICH', pickType: 'Spread', season: 2026,
       };
       vi.mocked(getCfbSlates).mockResolvedValue([slate]);
       vi.mocked(getCfbSpreads).mockResolvedValue([spread]);
@@ -122,9 +122,29 @@ describe('cfbAdapter', () => {
 
       const result = await adapter.loadCurrentGames(1, 'user1');
       expect(result.userPicks).toHaveLength(1);
-      expect(result.userPicks[0].gameId).toBe('999');
+      expect(result.userPicks[0].gameId).toBe('MICH');
       expect(result.userPicks[0].team).toBe('MICH');
       expect(result.userPicks[0].pickType).toBe('Spread');
+    });
+
+    // frizat: CfbPicks.Team can be the AWAY side — since GameView.id is always the game's home
+    // team (a team plays at most one game per slate, so homeTeam alone is the join key), a pick
+    // on the away side must still resolve gameId back to the home team, not to pick.team itself,
+    // or it would never match GameView.id in ScoresPage's pickCountForTeam/didUserPick lookups.
+    it('maps an away-team CfbPickDto to PickView with gameId = the game\'s homeTeam, not the picked team', async () => {
+      const pick: CfbPickDto = {
+        id: 2, userId: 'user1', userName: 'user1', leagueId: 1, cfbSlateId: 10,
+        team: 'PSU', pickType: 'Spread', season: 2026,
+      };
+      vi.mocked(getCfbSlates).mockResolvedValue([slate]);
+      vi.mocked(getCfbSpreads).mockResolvedValue([spread]);
+      vi.mocked(loadCfbScoresWithRetry).mockResolvedValue(espnFinalGame);
+      vi.mocked(getCfbUserPicks).mockResolvedValue([pick]);
+
+      const result = await adapter.loadCurrentGames(1, 'user1');
+      expect(result.userPicks).toHaveLength(1);
+      expect(result.userPicks[0].gameId).toBe('MICH');
+      expect(result.userPicks[0].team).toBe('PSU');
     });
 
     it('derives WeekState from slate slateNumber', async () => {
@@ -148,6 +168,23 @@ describe('cfbAdapter', () => {
       const result = await adapter.loadCurrentGames(1, 'user1');
       expect(result.games[0].gameStatus).toBe('scheduled');
       expect(result.games[0].homeScore).toBeNull();
+    });
+  });
+
+  describe('submitPicks', () => {
+    // frizat: the request payload no longer carries an ESPN event id — just team + pickType,
+    // matching NFL's submitPicks shape exactly (no per-pick game-id field at all).
+    it('sends only team and pickType, no espnEventId, per pick', async () => {
+      vi.mocked(getCfbSlates).mockResolvedValue([slate]);
+      vi.mocked(addCfbPicks).mockResolvedValue({ added: 1 });
+
+      await adapter.submitPicks(1, { season: 2026, week: 8, isPostSeason: false }, [
+        { gameId: 'MICH', team: 'MICH', pickType: 'Spread' },
+      ]);
+
+      expect(addCfbPicks).toHaveBeenCalledWith(1, slate.id, 2026, [
+        { team: 'MICH', pickType: 'Spread' },
+      ]);
     });
   });
 

--- a/Client.React/src/__tests__/leaderboard.test.tsx
+++ b/Client.React/src/__tests__/leaderboard.test.tsx
@@ -1,9 +1,11 @@
 import { render, screen } from '@testing-library/react';
+import { alpha, ThemeProvider } from '@mui/material';
 import LeaderboardPage from '../pages/LeaderboardPage';
 import { vi } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { createLeaderboardEntry, createLeaderboardWeekResult } from '../test/fixtures';
 import type { SportAdapter } from '../services/sportAdapter';
+import { createAppTheme } from '../app/theme';
 
 const sessionState = {
   currentLeague: 1 as number | null,
@@ -37,14 +39,16 @@ const mockAdapter: SportAdapter = {
   weekSelectorConfig: { maxRegularSeasonWeek: 18, minSeason: 2020 },
 };
 
-function renderPage() {
+function renderPage(mode: 'light' | 'dark' = 'light') {
   return render(
-    <MemoryRouter initialEntries={['/leaderboard']}>
-      <Routes>
-        <Route path="/leaderboard" element={<LeaderboardPage adapter={mockAdapter} />} />
-        <Route path="/leaguepicker" element={<div>League Picker</div>} />
-      </Routes>
-    </MemoryRouter>
+    <ThemeProvider theme={createAppTheme(mode)}>
+      <MemoryRouter initialEntries={['/leaderboard']}>
+        <Routes>
+          <Route path="/leaderboard" element={<LeaderboardPage adapter={mockAdapter} />} />
+          <Route path="/leaguepicker" element={<div>League Picker</div>} />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>
   );
 }
 
@@ -94,5 +98,42 @@ describe('LeaderboardPage', () => {
     sessionState.currentLeague = null;
     renderPage();
     await screen.findByText(/League Picker/i);
+  });
+});
+
+describe('LeaderboardPage — week-cell colors', () => {
+  beforeEach(() => {
+    sessionState.currentLeague = 1;
+    mockedGetLeaderboard.mockReset();
+    vi.mocked(mockAdapter.currentSeasonYear).mockResolvedValue(2023);
+  });
+
+  // frizat: getWeekSx used to hardcode literal rgba() constants (e.g. rgba(22, 163, 74, 0.12) for
+  // "Won") that don't match theme.ts's actual success/error/warning/info hex values at all, and
+  // stayed fixed at the same opacity in both light and dark mode — reported as hard to read.
+  // Deriving the background via alpha(theme.palette.X.main, ...) guarantees it always matches the
+  // theme's own already-mode-tuned color, in both themes.
+  it.each([
+    ['light', 'Won', 'success'] as const,
+    ['dark', 'Won', 'success'] as const,
+    ['light', 'MissingPicks', 'warning'] as const,
+    ['dark', 'MissingPicks', 'warning'] as const,
+    ['light', 'MissingGameResults', 'info'] as const,
+    ['dark', 'MissingGameResults', 'info'] as const,
+    ['light', 'Lost', 'error'] as const,
+    ['dark', 'Lost', 'error'] as const,
+  ])('%s mode: %s cell background is derived from theme.palette.%s.main', async (mode, weekResult, paletteKey) => {
+    mockedGetLeaderboard.mockResolvedValue([
+      createLeaderboardEntry({
+        userId: '123', userName: 'TestUser', rank: '1', total: 5,
+        weekResults: [createLeaderboardWeekResult({ week: 1, score: 25, weekResult })],
+      }),
+    ]);
+
+    renderPage(mode);
+    const cell = (await screen.findByText('25')).closest('td');
+    const theme = createAppTheme(mode);
+    const expected = alpha(theme.palette[paletteKey].main, 0.16);
+    expect(cell).toHaveStyle({ backgroundColor: expected });
   });
 });

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -381,7 +381,7 @@ describe('ScoresPage', () => {
     // cache entries" is that once CFB's OWN query settles, ITS data (MICH/PSU) is what renders,
     // not that NFL's cache entry got clobbered or that a spinner necessarily appears.
     const cfbSlate = { id: 1, season: 2025, slateNumber: 8, label: 'Week 8', slateType: 'RegularSeason', startDate: '2025-10-11', endDate: '2025-10-18' };
-    const cfbSpread = { id: 1, cfbSlateId: 1, espnEventId: 100, homeTeam: 'MICH', awayTeam: 'PSU', homeTeamSpread: -3.5, awayTeamSpread: 3.5, overUnder: 44.5, gameTime: '2025-10-11T20:00:00Z', dateCreated: '2025-10-09T14:00:00Z' };
+    const cfbSpread = { id: 1, cfbSlateId: 1, homeTeam: 'MICH', awayTeam: 'PSU', homeTeamSpread: -3.5, awayTeamSpread: 3.5, overUnder: 44.5, gameTime: '2025-10-11T20:00:00Z', dateCreated: '2025-10-09T14:00:00Z' };
     mockedGetCfbCurrentSlate.mockResolvedValue(cfbSlate);
     mockedGetCfbSlates.mockResolvedValue([cfbSlate]);
     mockedGetCfbSpreads.mockResolvedValue([cfbSpread]);

--- a/Client.React/src/__tests__/sharedPickLayout.test.tsx
+++ b/Client.React/src/__tests__/sharedPickLayout.test.tsx
@@ -90,7 +90,7 @@ import { getCfbCurrentSlate, getCfbSlates, getCfbSpreads, getCfbScores, getCfbUs
 import { loadCfbScoresWithRetry, getCfbLiveGames } from '../api/espn';
 
 const slate: CfbSlateDto = { id: 1, season: 2025, slateNumber: 8, label: 'Week 8', slateType: 'RegularSeason', startDate: '2025-10-11', endDate: '2025-10-18' };
-const spread: CfbSpreadDto = { id: 1, cfbSlateId: 1, espnEventId: 100, homeTeam: 'MICH', awayTeam: 'PSU', homeTeamSpread: -3.5, awayTeamSpread: 3.5, overUnder: 44.5, gameTime: '2030-10-11T20:00:00Z', dateCreated: '2030-10-09T14:00:00Z' };
+const spread: CfbSpreadDto = { id: 1, cfbSlateId: 1, homeTeam: 'MICH', awayTeam: 'PSU', homeTeamSpread: -3.5, awayTeamSpread: 3.5, overUnder: 44.5, gameTime: '2030-10-11T20:00:00Z', dateCreated: '2030-10-09T14:00:00Z' };
 
 describe('CFB PicksPage (via adapter) — GameCard layout regression', () => {
   beforeEach(() => {
@@ -128,7 +128,7 @@ describe('CFB PicksPage (via adapter) — GameCard layout regression', () => {
 
   it('shows Locked in when pick already submitted', async () => {
     vi.mocked(getCfbUserPicks).mockResolvedValue([
-      { id: 1, userId: 'u1', userName: 'u1', leagueId: 1, cfbSlateId: 1, espnEventId: 100, team: 'MICH', pickType: 'Spread', season: 2025 }
+      { id: 1, userId: 'u1', userName: 'u1', leagueId: 1, cfbSlateId: 1, team: 'MICH', pickType: 'Spread', season: 2025 }
     ]);
     renderWithClient(<PicksPage adapter={createCfbAdapter()} />);
     await waitFor(() => expect(screen.getByRole('button', { name: /MICH locked in/i })).toBeInTheDocument());

--- a/Client.React/src/api/cfb.ts
+++ b/Client.React/src/api/cfb.ts
@@ -48,7 +48,7 @@ export async function addCfbPicks(
   leagueId: number,
   cfbSlateId: number,
   season: number,
-  picks: { espnEventId: number; team: string; pickType: string }[]
+  picks: { team: string; pickType: string }[]
 ): Promise<{ added: number }> {
   const res = await fetch(`${BASE}/picks`, {
     method: 'POST',

--- a/Client.React/src/api/league.ts
+++ b/Client.React/src/api/league.ts
@@ -170,3 +170,30 @@ export async function createLeague(dto: LeagueCreateDto) {
   const { data } = await http.post<LeagueInfoDto>('/api/league/create', dto);
   return data;
 }
+
+export interface LeagueInviteLinkDto {
+  token: string;
+  leagueId: number;
+  leagueName: string;
+  expiresAt: string;
+}
+
+export async function generateInviteLink(leagueId: number): Promise<LeagueInviteLinkDto> {
+  const { data } = await http.post<LeagueInviteLinkDto>(`/api/league/${leagueId}/invite-link`, {});
+  return data;
+}
+
+export async function validateInviteLink(token: string): Promise<LeagueInviteLinkDto | null> {
+  try {
+    const { data } = await http.get<LeagueInviteLinkDto>(`/api/league/join/${token}`);
+    return data;
+  } catch (err) {
+    const status = (err as { response?: { status?: number } }).response?.status;
+    if (status === 404) return null;
+    throw err;
+  }
+}
+
+export async function joinViaLink(token: string): Promise<void> {
+  await http.post(`/api/league/join/${token}`, {});
+}

--- a/Client.React/src/api/league.ts
+++ b/Client.React/src/api/league.ts
@@ -154,6 +154,10 @@ export async function removeLeagueMember(leagueId: number, userId: string) {
   await http.delete(`/api/league/${leagueId}/members/${encodeURIComponent(userId)}`);
 }
 
+export async function deleteLeague(leagueId: number) {
+  await http.delete(`/api/league/${leagueId}`);
+}
+
 export async function inviteToLeague(leagueId: number, email: string) {
   await http.post(`/api/league/${leagueId}/invite`, { email, baseUrl: window.location.origin });
 }

--- a/Client.React/src/components/WeekYearSelector.tsx
+++ b/Client.React/src/components/WeekYearSelector.tsx
@@ -110,13 +110,23 @@ export default function WeekYearSelector({
         border: '1px solid rgba(26, 40, 71, 0.1)',
       }}
     >
-      {/* Selects row */}
-      <Stack direction="row" alignItems="center" justifyContent="center" sx={{ flexWrap: 'wrap', gap: 1 }}>
+      {/* Selects row — frizat: flexWrap alone made mobile layout depend on content width: a short
+          label (e.g. "Super Bowl") left enough room for all three selects to share one row, a
+          long one ("Conference Championship") pushed to a stacked layout — same page, two
+          different arrangements depending on which week happened to be selected. Below `sm`,
+          always stack one-per-row (direction/width driven by breakpoint, not by wrap) so the
+          layout is consistent regardless of label length. */}
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        alignItems="center"
+        justifyContent="center"
+        sx={{ gap: 1 }}
+      >
         <Select
           value={season}
           onChange={(e) => onSeasonChange(Number(e.target.value))}
           size="small"
-          sx={{ minWidth: { xs: 90, sm: 100 } }}
+          sx={{ width: { xs: '100%', sm: 150 } }}
         >
           {seasonOptions.map((s) => (
             <MenuItem key={s} value={s}>
@@ -129,7 +139,13 @@ export default function WeekYearSelector({
           value={clampedWeek}
           onChange={(e) => onWeekChange(Number(e.target.value), { isPostSeason: isPostSeason })}
           size="small"
-          sx={{ minWidth: { xs: 120, sm: 140 } }}
+          // frizat: minWidth let MUI auto-size the box to whichever label happened to be
+          // selected — "Conference Championship" (the longest label across both sports) is
+          // ~117px wider than "Wild Card"/"Week 1", so the whole select row (centered via
+          // justifyContent) visibly shifted left/right depending which week was picked. A fixed
+          // width on sm+ keeps the row's total width constant regardless of week, so the centered
+          // group never moves; full-width on xs since mobile always stacks one-per-row now.
+          sx={{ width: { xs: '100%', sm: 260 } }}
         >
           {currentOptions.map((w) => (
             <MenuItem key={w} value={w}>
@@ -142,7 +158,7 @@ export default function WeekYearSelector({
           value={isPostSeason ? 'postseason' : 'regular'}
           onChange={(e) => handleSeasonTypeSelect(e.target.value as 'regular' | 'postseason')}
           size="small"
-          sx={{ minWidth: { xs: 120, sm: 140 } }}
+          sx={{ width: { xs: '100%', sm: 170 } }}
         >
           <MenuItem value="regular">Regular Season</MenuItem>
           <MenuItem value="postseason">Postseason</MenuItem>

--- a/Client.React/src/pages/JoinLeaguePage.tsx
+++ b/Client.React/src/pages/JoinLeaguePage.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CircularProgress from '@mui/material/CircularProgress';
+import Typography from '@mui/material/Typography';
+import { validateInviteLink, joinViaLink, type LeagueInviteLinkDto } from '../api/league';
+import { useAuth } from '../services/auth';
+import { useSession } from '../services/session';
+
+export default function JoinLeaguePage() {
+  const { token } = useParams<{ token: string }>();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const { reloadLeagues } = useSession();
+
+  const [loading, setLoading] = useState(true);
+  const [joining, setJoining] = useState(false);
+  const [link, setLink] = useState<LeagueInviteLinkDto | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) { setLoading(false); return; }
+    const controller = new AbortController();
+    validateInviteLink(token).then((result) => {
+      if (!controller.signal.aborted) setLink(result);
+    }).catch(() => {
+      if (!controller.signal.aborted) setError('Failed to load invite link. Please try again.');
+    }).finally(() => {
+      if (!controller.signal.aborted) setLoading(false);
+    });
+    return () => controller.abort();
+  }, [token]);
+
+  const handleSignUp = () => {
+    navigate(`/account/register?inviteLinkToken=${token}&returnUrl=/join/${token}`);
+  };
+
+  const handleJoin = async () => {
+    setJoining(true);
+    setError(null);
+    try {
+      await joinViaLink(token!);
+      await reloadLeagues();
+      navigate('/dashboard');
+    } catch (err) {
+      const status = (err as { response?: { status?: number } }).response?.status;
+      if (status === 409) {
+        await reloadLeagues();
+        navigate('/dashboard');
+      } else {
+        setError('Failed to join league. The link may have expired.');
+      }
+    } finally {
+      setJoining(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!link) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8, px: 2 }}>
+        <Card sx={{ maxWidth: 400, width: '100%' }}>
+          <CardContent sx={{ textAlign: 'center', py: 4 }}>
+            <Typography variant="h6" gutterBottom>
+              {error ?? 'Link expired or invalid'}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {error
+                ? 'Check your connection and try again.'
+                : 'This invite link has expired or is no longer valid. Ask the league owner to generate a new one.'}
+            </Typography>
+          </CardContent>
+        </Card>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8, px: 2 }}>
+      <Card sx={{ maxWidth: 400, width: '100%' }}>
+        <CardContent sx={{ textAlign: 'center', py: 4 }}>
+          <Typography variant="overline" color="text.secondary">You&apos;re invited to join</Typography>
+          <Typography variant="h5" fontWeight={600} gutterBottom>{link.leagueName}</Typography>
+          {error && (
+            <Typography variant="body2" color="error" sx={{ mb: 2 }}>{error}</Typography>
+          )}
+          {user ? (
+            <Button
+              variant="contained"
+              color="secondary"
+              size="large"
+              fullWidth
+              disabled={joining}
+              onClick={() => void handleJoin()}
+              sx={{ mt: 2 }}
+            >
+              {joining ? <CircularProgress size={22} color="inherit" /> : 'Join League'}
+            </Button>
+          ) : (
+            <Button
+              variant="contained"
+              color="secondary"
+              size="large"
+              fullWidth
+              onClick={handleSignUp}
+              sx={{ mt: 2 }}
+            >
+              Create an account to join
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Navigate } from 'react-router-dom';
 import {
+  alpha,
   Box,
   Card,
   CardContent,
@@ -12,6 +13,7 @@ import {
   TableHead,
   TableRow,
   Typography,
+  useTheme,
 } from '@mui/material';
 import PageHeader from '../components/PageHeader';
 import { useSession } from '../services/session';
@@ -26,6 +28,7 @@ interface LeaderboardPageProps {
 }
 
 export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
+  const theme = useTheme();
   const { currentLeague, leaguesLoaded } = useSession();
   const { user } = useAuth();
   const [loading, setLoading] = useState(true);
@@ -55,29 +58,39 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
     return 'text.primary';
   };
 
+  // frizat: these used literal hardcoded rgba() constants (e.g. rgba(22, 163, 74, 0.12) for
+  // "Won") that don't match theme.ts's actual success/warning/error hex values at all, and stay
+  // fixed at the same opacity in both light and dark mode — exactly the anti-pattern the style
+  // guide warns about (a literal color at fixed opacity reads fine against one background and
+  // washes out against the other). Deriving the tint from the theme's own already-mode-tuned
+  // palette color (via alpha()) guarantees the background always matches the text color exactly,
+  // in both themes, with one definition instead of four guessed constants. MissingGameResults
+  // moved from `primary` (structural navy — very dark in light mode, reads as a near-black smudge
+  // at low opacity) to `info` (this app's documented "neutral/informational" semantic), which is
+  // what "results not in yet" actually means.
   const getWeekSx = (result: string) => {
     switch (result) {
       case 'Won':
         return {
-          backgroundColor: 'rgba(22, 163, 74, 0.12)',
+          backgroundColor: alpha(theme.palette.success.main, 0.16),
           color: 'success.main',
           fontWeight: 500,
         };
       case 'MissingPicks':
         return {
-          backgroundColor: 'rgba(230, 126, 34, 0.12)',
+          backgroundColor: alpha(theme.palette.warning.main, 0.16),
           color: 'warning.main',
           fontWeight: 500,
         };
       case 'MissingGameResults':
         return {
-          backgroundColor: 'rgba(25, 103, 210, 0.12)',
-          color: 'primary.main',
+          backgroundColor: alpha(theme.palette.info.main, 0.16),
+          color: 'info.main',
           fontWeight: 500,
         };
       default:
         return {
-          backgroundColor: 'rgba(229, 57, 53, 0.12)',
+          backgroundColor: alpha(theme.palette.error.main, 0.16),
           color: 'error.main',
           fontWeight: 500,
         };
@@ -156,7 +169,7 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
 
               <Grid container spacing={2} justifyContent="center" sx={{ mt: 2 }}>
                 <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-                  <Card sx={{ backgroundColor: 'rgba(22, 163, 74, 0.12)' }}>
+                  <Card sx={{ backgroundColor: getWeekSx('Won').backgroundColor }}>
                     <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                       <Box
                         sx={{
@@ -171,14 +184,14 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
                   </Card>
                 </Grid>
                 <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-                  <Card sx={{ backgroundColor: 'rgba(25, 103, 210, 0.12)' }}>
+                  <Card sx={{ backgroundColor: getWeekSx('MissingGameResults').backgroundColor }}>
                     <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                       <Box
                         sx={{
                           width: 12,
                           height: 12,
                           borderRadius: 0.5,
-                          backgroundColor: 'primary.main',
+                          backgroundColor: 'info.main',
                         }}
                       />
                       <Typography>Games Incomplete</Typography>
@@ -186,7 +199,7 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
                   </Card>
                 </Grid>
                 <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-                  <Card sx={{ backgroundColor: 'rgba(230, 126, 34, 0.12)' }}>
+                  <Card sx={{ backgroundColor: getWeekSx('MissingPicks').backgroundColor }}>
                     <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                       <Box
                         sx={{
@@ -201,7 +214,7 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
                   </Card>
                 </Grid>
                 <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-                  <Card sx={{ backgroundColor: 'rgba(229, 57, 53, 0.12)' }}>
+                  <Card sx={{ backgroundColor: getWeekSx('Lost').backgroundColor }}>
                     <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                       <Box
                         sx={{

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -140,11 +140,18 @@ export default function LeaguePortalPage() {
   useEffect(() => { void loadAllLeagues(); }, [loadAllLeagues]);
 
   // Platform user list backs all three admin dialogs (Create League, Add User, Assign Owner) —
-  // fetched once per admin visit rather than on every dialog open.
+  // fetched once per admin visit rather than on every dialog open. Without a .catch(), a failed
+  // fetch left availableUsers at [] for the whole session with no error and no retry — all three
+  // pickers looked "broken" with nothing to select and no indication why.
   useEffect(() => {
     if (!admin) return;
-    void getUsers().then(setAvailableUsers);
-  }, [admin]);
+    getUsers()
+      .then(setAvailableUsers)
+      .catch((err) => {
+        console.error('Failed to load platform user list', err);
+        toast.push('Failed to load users — try reloading the page', 'error');
+      });
+  }, [admin, toast]);
 
   useEffect(() => {
     if (leagueOptions.length > 0 && !selectedLeague) {

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -25,7 +25,10 @@ import {
   Typography,
 } from '@mui/material';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DeleteIcon from '@mui/icons-material/Delete';
+import IosShareIcon from '@mui/icons-material/IosShare';
+import LinkIcon from '@mui/icons-material/Link';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import PageHeader from '../components/PageHeader';
 import OwnerCostSummary from '../components/OwnerCostSummary';
@@ -42,12 +45,14 @@ import {
   rollForwardJuice,
   removeLeagueMember,
   inviteToLeague,
+  generateInviteLink,
   getAllLeagues,
   getUsers,
   createLeague,
   addLeagueUserMapping,
   assignLeagueOwner,
   deleteLeague,
+  type LeagueInviteLinkDto,
 } from '../api/league';
 import type { LeagueInfoDto, LeagueJuiceMappingDto, LeagueCostDto, UserSummaryDto } from '../types/admin';
 import type { LeagueUserMappingDto } from '../types/league';
@@ -101,10 +106,14 @@ export default function LeaguePortalPage() {
   const [removeTarget, setRemoveTarget] = useState<LeagueUserMappingDto | null>(null);
   const [removing, setRemoving] = useState(false);
 
-  // Invite dialog
+  // Email invite dialog
   const [inviteOpen, setInviteOpen] = useState(false);
   const [inviteEmail, setInviteEmail] = useState('');
   const [inviting, setInviting] = useState(false);
+
+  // Shareable invite link
+  const [generatingLink, setGeneratingLink] = useState(false);
+  const [inviteLink, setInviteLink] = useState<LeagueInviteLinkDto | null>(null);
 
   // Juice settings
   const [juiceMappings, setJuiceMappings] = useState<LeagueJuiceMappingDto[]>([]);
@@ -207,6 +216,7 @@ export default function LeaguePortalPage() {
 
   useEffect(() => {
     if (!selectedLeague) return;
+    setInviteLink(null);
     void loadMembers(selectedLeague.id);
     void loadJuice(selectedLeague.id);
   }, [selectedLeague, loadMembers, loadJuice]);
@@ -252,6 +262,19 @@ export default function LeaguePortalPage() {
       toast.push('Failed to save juice settings', 'error');
     } finally {
       setSavingJuice(false);
+    }
+  };
+
+  const handleGenerateInviteLink = async () => {
+    if (!selectedLeague) return;
+    setGeneratingLink(true);
+    try {
+      const link = await generateInviteLink(selectedLeague.id);
+      setInviteLink(link);
+    } catch {
+      toast.push('Failed to generate invite link', 'error');
+    } finally {
+      setGeneratingLink(false);
     }
   };
 
@@ -431,6 +454,9 @@ export default function LeaguePortalPage() {
               onRemove={setRemoveTarget}
               onInvite={() => setInviteOpen(true)}
               onAddUser={openAddUser}
+              inviteLink={inviteLink}
+              generatingLink={generatingLink}
+              onGenerateInviteLink={() => void handleGenerateInviteLink()}
             />
           )}
           {tab === 1 && (
@@ -634,11 +660,38 @@ interface MembersTabProps {
   onRemove: (m: LeagueUserMappingDto) => void;
   onInvite: () => void;
   onAddUser: () => void;
+  inviteLink: LeagueInviteLinkDto | null;
+  generatingLink: boolean;
+  onGenerateInviteLink: () => void;
 }
 
-function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInvite, onAddUser }: MembersTabProps) {
+function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInvite, onAddUser, inviteLink, generatingLink, onGenerateInviteLink }: MembersTabProps) {
   const count = costDto?.memberCount ?? members.length;
   const cost = computeLeagueCost(count);
+  const toast = useToast();
+
+  const inviteUrl = inviteLink ? `${window.location.origin}/join/${inviteLink.token}` : '';
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(inviteUrl);
+      toast.push('Link copied', 'info');
+    } catch {
+      toast.push('Failed to copy link', 'error');
+    }
+  };
+
+  const handleShare = () => {
+    if (navigator.share) {
+      void navigator.share({ title: 'Join my league', url: inviteUrl });
+    } else {
+      void handleCopy();
+    }
+  };
+
+  const expiresLabel = inviteLink
+    ? `Expires ${new Date(inviteLink.expiresAt).toLocaleString()}`
+    : '';
 
   return (
     <Box>
@@ -647,12 +700,41 @@ function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInv
         <Button startIcon={<PersonAddIcon />} variant="outlined" size="small" onClick={onInvite}>
           Invite Player
         </Button>
+        <Button
+          startIcon={generatingLink ? <CircularProgress size={14} /> : <LinkIcon />}
+          variant="outlined"
+          size="small"
+          onClick={onGenerateInviteLink}
+          disabled={generatingLink}
+        >
+          {inviteLink ? 'Regenerate Link' : 'Generate Invite Link'}
+        </Button>
         {admin && (
           <Button startIcon={<AddCircleIcon />} variant="outlined" size="small" onClick={onAddUser}>
             Add User
           </Button>
         )}
       </Stack>
+
+      {inviteLink && (
+        <Box sx={{ mb: 3, p: 2, border: 1, borderColor: 'divider', borderRadius: 1, maxWidth: 520 }}>
+          <Stack spacing={1}>
+            <Typography variant="body2" sx={{ wordBreak: 'break-all', fontFamily: 'monospace', fontSize: '0.78rem' }}>
+              {inviteUrl}
+            </Typography>
+            <Stack direction="row" spacing={1} flexWrap="wrap">
+              <Button size="small" startIcon={<ContentCopyIcon />} variant="outlined" onClick={() => void handleCopy()}>
+                Copy
+              </Button>
+              <Button size="small" startIcon={<IosShareIcon />} variant="contained" color="secondary" onClick={handleShare}>
+                Share
+              </Button>
+            </Stack>
+            <Typography variant="caption" color="text.secondary">{expiresLabel}</Typography>
+          </Stack>
+        </Box>
+      )}
+
       {loading ? (
         <CircularProgress />
       ) : (

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -76,13 +76,16 @@ export default function LeaguePortalPage() {
   const { user } = useAuth();
   const admin = isAdmin(user);
   const toast = useToast();
+  // The wire-format LeagueType for whichever sport's subdomain we're currently on — shared by
+  // the platform-wide league filter below and Create League's locked Sport field.
+  const currentLeagueType = isCfb ? 'Cfb' : 'Nfl';
 
   const [allLeagues, setAllLeagues] = useState<LeagueInfoDto[]>([]);
   const [allLeaguesLoaded, setAllLeaguesLoaded] = useState(false);
   // Admins see every league platform-wide (allLeagues), but still only for the sport they're
   // currently on — ownedLeagues already applies this same filter for non-admins (session.tsx).
   const leagueOptions = admin
-    ? allLeagues.filter((l) => l.leagueType === (isCfb ? 'Cfb' : 'Nfl'))
+    ? allLeagues.filter((l) => l.leagueType === currentLeagueType)
     : ownedLeagues;
   // Guards the empty state against the pre-fetch window — without it, an admin with leagues
   // platform-wide would see a false "no leagues yet" flash while allLeagues is still [].
@@ -260,7 +263,7 @@ export default function LeaguePortalPage() {
   };
 
   const openCreateLeague = () => {
-    setNewLeagueForm({ leagueName: '', leagueType: 'Nfl', ownerUserId: user?.userId ?? '' });
+    setNewLeagueForm({ leagueName: '', leagueType: currentLeagueType, ownerUserId: user?.userId ?? '' });
     setCreateLeagueOpen(true);
   };
 
@@ -472,17 +475,14 @@ export default function LeaguePortalPage() {
               value={newLeagueForm.leagueName}
               onChange={(e) => setNewLeagueForm((f) => ({ ...f, leagueName: e.target.value }))}
             />
-            <FormControl size="small">
-              <InputLabel>Sport</InputLabel>
-              <Select
-                value={newLeagueForm.leagueType}
-                label="Sport"
-                onChange={(e) => setNewLeagueForm((f) => ({ ...f, leagueType: e.target.value }))}
-              >
-                <MenuItem value="Nfl">NFL</MenuItem>
-                <MenuItem value="Cfb">CFB</MenuItem>
-              </Select>
-            </FormControl>
+            {/* frizat: the site you're on IS the sport you're creating for — locked, not a
+                choice, so there's no way to accidentally create a CFB league from the NFL
+                site (or vice versa) the way the old editable dropdown allowed. */}
+            <TextField
+              label="Sport"
+              value={isCfb ? 'CFB' : 'NFL'}
+              disabled
+            />
             {admin && (
               <TextField
                 select

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -47,6 +47,7 @@ import {
   createLeague,
   addLeagueUserMapping,
   assignLeagueOwner,
+  deleteLeague,
 } from '../api/league';
 import type { LeagueInfoDto, LeagueJuiceMappingDto, LeagueCostDto, UserSummaryDto } from '../types/admin';
 import type { LeagueUserMappingDto } from '../types/league';
@@ -132,6 +133,12 @@ export default function LeaguePortalPage() {
   const [assignOwnerOpen, setAssignOwnerOpen] = useState(false);
   const [newOwnerId, setNewOwnerId] = useState('');
   const [assigningOwner, setAssigningOwner] = useState(false);
+
+  // Owner or admin: Delete League dialog (Info tab) — type-to-confirm since this permanently
+  // removes the league's members, payout settings, picks, and invitations along with it.
+  const [deleteLeagueOpen, setDeleteLeagueOpen] = useState(false);
+  const [deleteConfirmText, setDeleteConfirmText] = useState('');
+  const [deletingLeague, setDeletingLeague] = useState(false);
 
   const loadAllLeagues = useCallback(async () => {
     if (!admin) return;
@@ -336,6 +343,27 @@ export default function LeaguePortalPage() {
     }
   };
 
+  const openDeleteLeague = () => {
+    setDeleteConfirmText('');
+    setDeleteLeagueOpen(true);
+  };
+
+  const handleDeleteLeague = async () => {
+    if (!selectedLeague) return;
+    setDeletingLeague(true);
+    try {
+      await deleteLeague(selectedLeague.id);
+      toast.push(`League "${selectedLeague.leagueName}" deleted`, 'success');
+      setDeleteLeagueOpen(false);
+      setSelectedLeague(null);
+      await Promise.all([loadAllLeagues(), reloadLeagues()]);
+    } catch {
+      toast.push('Failed to delete league', 'error');
+    } finally {
+      setDeletingLeague(false);
+    }
+  };
+
   const currentJuiceMapping = juiceMappings.find((m) => m.season === selectedSeason);
   const availableSeasons = juiceMappings.map((m) => m.season).sort((a, b) => b - a);
   if (!availableSeasons.includes(CURRENT_SEASON)) availableSeasons.unshift(CURRENT_SEASON);
@@ -390,7 +418,7 @@ export default function LeaguePortalPage() {
         <>
           <Tabs value={tab} onChange={(_, v: number) => setTab(v)} sx={{ mb: 2 }}>
             <Tab label="Members" />
-            <Tab label="Juice Settings" />
+            <Tab label="League Payouts" />
             <Tab label="Info" />
           </Tabs>
 
@@ -421,7 +449,13 @@ export default function LeaguePortalPage() {
             />
           )}
           {tab === 2 && (
-            <InfoTab league={selectedLeague} isAdmin={admin} onChangeOwner={openAssignOwner} />
+            <InfoTab
+              league={selectedLeague}
+              isAdmin={admin}
+              canDelete={admin || selectedLeague.ownerUserId === user?.userId}
+              onChangeOwner={openAssignOwner}
+              onDeleteLeague={openDeleteLeague}
+            />
           )}
         </>
       )}
@@ -431,7 +465,8 @@ export default function LeaguePortalPage() {
         <DialogContent>
           <Typography>
             Remove <strong>{removeTarget?.userName ?? removeTarget?.userId}</strong> from{' '}
-            <strong>{selectedLeague?.leagueName}</strong>? This cannot be undone.
+            <strong>{selectedLeague?.leagueName}</strong>? Their pick history is kept, and they
+            can be re-added later.
           </Typography>
         </DialogContent>
         <DialogActions>
@@ -555,6 +590,35 @@ export default function LeaguePortalPage() {
           <Button onClick={() => setAssignOwnerOpen(false)}>Cancel</Button>
           <Button variant="contained" onClick={() => void handleAssignOwner()} disabled={assigningOwner || !newOwnerId}>
             {assigningOwner ? <CircularProgress size={18} /> : 'Assign'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={deleteLeagueOpen} onClose={() => setDeleteLeagueOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Delete League</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <Typography>
+              Deleting <strong>{selectedLeague?.leagueName}</strong> permanently removes its members,
+              payout settings, picks, and invitations. This cannot be undone.
+            </Typography>
+            <TextField
+              autoFocus
+              label="Type the league name to confirm"
+              value={deleteConfirmText}
+              onChange={(e) => setDeleteConfirmText(e.target.value)}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteLeagueOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={() => void handleDeleteLeague()}
+            disabled={deletingLeague || deleteConfirmText !== selectedLeague?.leagueName}
+          >
+            {deletingLeague ? <CircularProgress size={18} /> : 'Delete League'}
           </Button>
         </DialogActions>
       </Dialog>
@@ -707,7 +771,7 @@ function JuiceTab({
           onChange={(e) => onJuiceFormChange('juiceConference', Number(e.target.value))}
         />
         <TextField
-          label="Weekly Cost ($)"
+          label="Cost Per Week ($)"
           type="number"
           size="small"
           disabled={locked}
@@ -722,7 +786,11 @@ function JuiceTab({
   );
 }
 
-function InfoTab({ league, isAdmin: admin, onChangeOwner }: { league: LeagueInfoDto; isAdmin: boolean; onChangeOwner: () => void }) {
+function InfoTab({
+  league, isAdmin: admin, canDelete, onChangeOwner, onDeleteLeague,
+}: {
+  league: LeagueInfoDto; isAdmin: boolean; canDelete: boolean; onChangeOwner: () => void; onDeleteLeague: () => void;
+}) {
   return (
     <Box sx={{ maxWidth: 400 }}>
       <Stack spacing={1.5} divider={<Divider />}>
@@ -742,6 +810,13 @@ function InfoTab({ league, isAdmin: admin, onChangeOwner }: { league: LeagueInfo
           <Stack direction="row" justifyContent="flex-end">
             <Button size="small" variant="outlined" onClick={onChangeOwner}>
               Change Owner
+            </Button>
+          </Stack>
+        )}
+        {canDelete && (
+          <Stack direction="row" justifyContent="flex-end">
+            <Button size="small" color="error" startIcon={<DeleteIcon />} onClick={onDeleteLeague}>
+              Delete League
             </Button>
           </Stack>
         )}

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -418,7 +418,7 @@ export default function LeaguePortalPage() {
         <>
           <Tabs value={tab} onChange={(_, v: number) => setTab(v)} sx={{ mb: 2 }}>
             <Tab label="Members" />
-            <Tab label="League Payouts" />
+            <Tab label="Settings" />
             <Tab label="Info" />
           </Tabs>
 

--- a/Client.React/src/pages/RulesPage.tsx
+++ b/Client.React/src/pages/RulesPage.tsx
@@ -170,6 +170,80 @@ function MatchupExample() {
   );
 }
 
+// frizat: Over/Under is an alternate pick TYPE for one game, not an additional pick beyond
+// requiredPicks — AddPicks'/CfbPicksController's server-side validation caps total picks (any
+// type) at requiredPicks for that round. This example exists specifically because that rule was
+// once violated in seeded demo data (a user showing requiredPicks+1 total picks), which read as a
+// UI bug until traced back to the data itself — the Rules page should state the rule plainly so
+// it's never ambiguous again.
+function OverUnderExample() {
+  const { isCfb } = useSportContext();
+  const roundLabel = isCfb ? 'CFP First Round' : 'Wild Card';
+  const requiredPicks = isCfb ? getCfbRequiredPicks(15) : getEspnRequiredPicks(1, true);
+  const picks = isCfb
+    ? [
+        { type: 'spread' as const, label: 'Ohio State Buckeyes', detail: 'Teased line +8.5' },
+        { type: 'spread' as const, label: 'Michigan Wolverines', detail: 'Teased line +17.5' },
+        { type: 'overUnder' as const, label: 'Over 54.5', detail: 'Georgia @ Texas total' },
+      ]
+    : [
+        { type: 'spread' as const, label: 'Seattle Seahawks', detail: 'Teased line +8.5' },
+        { type: 'spread' as const, label: 'Chicago Bears', detail: 'Teased line +17.5' },
+        { type: 'overUnder' as const, label: 'Over 45.5', detail: 'Buffalo @ Kansas City total' },
+      ];
+
+  return (
+    <Paper variant="outlined" sx={{ overflow: 'hidden', borderRadius: 2 }} data-testid="over-under-example">
+      <Box
+        sx={{
+          px: 2,
+          py: 1,
+          bgcolor: 'action.hover',
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+        }}
+      >
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ letterSpacing: '0.06em', textTransform: 'uppercase' }}
+        >
+          {roundLabel} · {requiredPicks} picks required
+        </Typography>
+      </Box>
+      {picks.map((p, i) => (
+        <Box
+          key={p.label}
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            px: 2,
+            py: 1.25,
+            borderBottom: i < picks.length - 1 ? '1px solid' : 'none',
+            borderColor: 'divider',
+          }}
+        >
+          <Box>
+            <Typography variant="body2" fontWeight={500}>
+              Pick {i + 1}: {p.label}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {p.detail}
+            </Typography>
+          </Box>
+          <Chip
+            label={p.type === 'overUnder' ? 'Over/Under' : 'Spread'}
+            size="small"
+            color={p.type === 'overUnder' ? 'info' : 'default'}
+            variant="outlined"
+          />
+        </Box>
+      ))}
+    </Paper>
+  );
+}
+
 function ScenarioExample() {
   const { isCfb } = useSportContext();
   const rows = isCfb
@@ -276,7 +350,7 @@ function PlayoffGrid() {
       ];
 
   return (
-    <Grid container spacing={1}>
+    <Grid container spacing={1} data-testid="playoff-grid">
       {rounds.map(({ round, picks }) => (
         <Grid size={6} key={round}>
           <Box sx={{ bgcolor: 'action.hover', borderRadius: 1.5, p: 1.5 }}>
@@ -542,6 +616,35 @@ export function RulesContent() {
           Fewer games each round means fewer required picks.
         </Typography>
         <PlayoffGrid />
+      </Box>
+
+      <Divider />
+
+      {/* Over/Under in the postseason */}
+      <Box>
+        <SectionLabel>Over/Under in the postseason</SectionLabel>
+        <Paper variant="outlined" sx={{ borderRadius: 2, p: 1.5 }}>
+          <RuleRow color="info">
+            Starting in the postseason, one of your required picks each week can be an{' '}
+            <strong>Over/Under</strong> total on any game instead of a side of the spread — pick
+            whether the combined score finishes above or below the posted number.
+          </RuleRow>
+          <RuleRow color="secondary">
+            Over/Under <strong>replaces</strong> one of your spread picks — it&apos;s never an
+            extra pick added on top. Your total number of picks for the week never changes, no
+            matter how many of them are Over/Under.
+          </RuleRow>
+          <RuleRow color="error">
+            An Over/Under pick counts exactly like a spread pick toward winning the week — get it
+            wrong and it&apos;s the same as missing any other pick.
+          </RuleRow>
+        </Paper>
+        <OverUnderExample />
+        <InfoCallout>
+          {isCfb
+            ? 'CFP First Round needs 3 correct picks. Two spread picks plus one Over/Under is still 3 total picks — not 4.'
+            : 'Wild Card needs 3 correct picks. Two spread picks plus one Over/Under is still 3 total picks — not 4.'}
+        </InfoCallout>
       </Box>
     </Stack>
   );

--- a/Client.React/src/services/cfbAdapter.ts
+++ b/Client.React/src/services/cfbAdapter.ts
@@ -3,7 +3,7 @@ import { loadCfbScoresWithRetry, getCfbScoresForSlate, getCfbLiveGames } from '.
 import { cfbSlateNumberToWeek, cfbWeekToSlateNumber, getCfbWeekName, computeHomeCovers, computeOverWins, getCfbRequiredPicks } from '../utils/gameHelpers';
 import type { CfbSlateDto, CfbSpreadDto, CfbScoreDto, CfbPickDto } from '../types/league';
 import type { EspnScores } from '../types/espn';
-import { getHomeTeamScore, getAwayTeamScore, toGameStatus } from '../utils/gameHelpers';
+import { getHomeTeamScore, getAwayTeamScore, toGameStatus, isHomeAway } from '../utils/gameHelpers';
 import type { SportAdapter, GameView, GameStatusValue, PickView, WeekState } from './sportAdapter';
 import { revealPicksForStartedGames } from './sportAdapter';
 
@@ -36,7 +36,7 @@ function toCfbGameStatusFromString(s: string | null | undefined): GameStatusValu
 /**
  * Build GameView from spread data + live ESPN data.
  * ESPN is the primary source. Falls back to dbScores when ESPN has no event
- * for a given espnEventId (e.g. off-season, demo mode, or before game is created).
+ * for a given team (e.g. off-season, demo mode, or before game is created).
  */
 function buildGamesFromEspn(
   spreads: CfbSpreadDto[],
@@ -44,17 +44,24 @@ function buildGamesFromEspn(
   dbScores: CfbScoreDto[],
   situationMap: Map<string, import('../types/liveGame').GameSituation | null>,
 ): GameView[] {
-  const espnMap = new Map<number, import('../types/espn').Competition>();
+  // frizat: joined by home team abbreviation, not an ESPN event id — a team plays at most one
+  // game per slate (the scope every caller of this function already loads spreads/scores at), so
+  // homeTeam alone is an unambiguous join key. Matches CfbSpreads/CfbScores' own natural key.
+  const espnMap = new Map<string, import('../types/espn').Competition>();
   for (const event of espnData?.events ?? []) {
     for (const comp of event.competitions) {
-      espnMap.set(parseInt(comp.id), comp);
+      // isHomeAway handles both string ('home') and numeric (1) forms — our backend re-serializes
+      // the ESPN homeAway enum as a number (see toGameStatus's status.type.name comment above for
+      // the same pattern), so a bare `=== 'home'` string comparison never matches.
+      const home = comp.competitors.find(c => isHomeAway(c.homeAway, 'home'));
+      if (home) espnMap.set(home.team.abbreviation, comp);
     }
   }
-  const dbMap = new Map(dbScores.map(s => [s.espnEventId, s]));
+  const dbMap = new Map(dbScores.map(s => [s.homeTeam, s]));
 
   return spreads.map(sp => {
-    const comp = espnMap.get(sp.espnEventId);
-    const db = dbMap.get(sp.espnEventId);
+    const comp = espnMap.get(sp.homeTeam);
+    const db = dbMap.get(sp.homeTeam);
 
     let status: GameStatusValue;
     let hs: number | null;
@@ -81,7 +88,9 @@ function buildGamesFromEspn(
 
     const key = `${sp.homeTeam}-${sp.awayTeam}`;
     return {
-      id: sp.espnEventId.toString(),
+      // Unique within a single slate's spread list (the only scope this ever gets rendered in) —
+      // a team plays at most one game per slate, same reasoning as the espnMap/dbMap join keys.
+      id: sp.homeTeam,
       homeTeam: sp.homeTeam,
       awayTeam: sp.awayTeam,
       homeSpread: sp.homeTeamSpread,
@@ -102,9 +111,23 @@ function buildGamesFromEspn(
   });
 }
 
-function cfbPickToPickView(pick: CfbPickDto): PickView {
+// frizat: CfbPicks.Team is whichever side the user picked — it can be the home OR away team, but
+// GameView.id is always the game's home team (see buildGamesFromEspn). A pick on the away side
+// still needs its PickView.gameId to resolve to the game's home team so it matches GameView.id
+// (pickCountForTeam/didUserPick in ScoresPage.tsx key off exact gameId equality) — this map
+// resolves either side back to that game's homeTeam, built once per slate's spread list.
+function buildTeamToHomeTeamMap(spreads: CfbSpreadDto[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const sp of spreads) {
+    map.set(sp.homeTeam, sp.homeTeam);
+    map.set(sp.awayTeam, sp.homeTeam);
+  }
+  return map;
+}
+
+function cfbPickToPickView(pick: CfbPickDto, teamToHomeTeam: Map<string, string>): PickView {
   return {
-    gameId: pick.espnEventId.toString(),
+    gameId: teamToHomeTeam.get(pick.team) ?? pick.team,
     team: pick.team,
     pickType: pick.pickType as PickView['pickType'],
     userId: pick.userId,
@@ -133,9 +156,10 @@ async function loadSlate(leagueId: number, _userId: string, slateId: number, sla
     getCfbDbScores(slateId),
     fetchCfbEspnData(slate, isCurrent),
   ]);
+  const teamToHomeTeam = buildTeamToHomeTeamMap(spreads);
   return {
     games: buildGamesFromEspn(spreads, espn, dbScores, situations),
-    userPicks: picks.map(cfbPickToPickView),
+    userPicks: picks.map(p => cfbPickToPickView(p, teamToHomeTeam)),
   };
 }
 
@@ -166,7 +190,8 @@ export function createCfbAdapter(): SportAdapter {
       fetchCfbEspnData(slate, isCurrent),
     ]);
     const games = buildGamesFromEspn(spreads, espn, dbScores, situations);
-    const allPicks = allPickDtos.map(cfbPickToPickView);
+    const teamToHomeTeam = buildTeamToHomeTeamMap(spreads);
+    const allPicks = allPickDtos.map(p => cfbPickToPickView(p, teamToHomeTeam));
     const userPicks = allPicks.filter(p => p.userId === userId);
     return { games, allPicks: revealPicksForStartedGames(allPicks, games, userId), userPicks };
   }
@@ -223,7 +248,6 @@ export function createCfbAdapter(): SportAdapter {
       const slate = slates.find(s => s.slateNumber === slateNum);
       if (!slate) return;
       await addCfbPicks(leagueId, slate.id, season, picks.map(p => ({
-        espnEventId: parseInt(p.gameId),
         team: p.team,
         pickType: p.pickType,
       })));
@@ -235,8 +259,12 @@ export function createCfbAdapter(): SportAdapter {
       const slate = slates.find(s => s.slateNumber === slateNum);
       if (!slate) return [];
       await deleteCfbPicks(leagueId, slate.id);
-      const fresh = await getCfbUserPicks(leagueId, slate.id);
-      return fresh.map(cfbPickToPickView);
+      const [fresh, spreads] = await Promise.all([
+        getCfbUserPicks(leagueId, slate.id),
+        getCfbSpreads(slate.id),
+      ]);
+      const teamToHomeTeam = buildTeamToHomeTeamMap(spreads);
+      return fresh.map(p => cfbPickToPickView(p, teamToHomeTeam));
     },
 
     // ─── Scores ─────────────────────────────────────────────────────────────

--- a/Client.React/src/types/league.ts
+++ b/Client.React/src/types/league.ts
@@ -26,7 +26,6 @@ export interface CfbSlateDto {
 export interface CfbSpreadDto {
   id: number;
   cfbSlateId: number;
-  espnEventId: number;
   homeTeam: string;
   awayTeam: string;
   homeTeamSpread: number;
@@ -39,7 +38,6 @@ export interface CfbSpreadDto {
 export interface CfbScoreDto {
   id: number;
   cfbSlateId: number;
-  espnEventId: number;
   homeTeam: string;
   awayTeam: string;
   homeTeamScore: number;
@@ -57,7 +55,6 @@ export interface CfbPickDto {
   userName: string;
   leagueId: number;
   cfbSlateId: number;
-  espnEventId: number;
   team: string;
   pickType: string;
   season: number;

--- a/Client.React/src/utils/gameHelpers.ts
+++ b/Client.React/src/utils/gameHelpers.ts
@@ -266,7 +266,7 @@ export function computeOverWins(
   return (homeScore + awayScore) > overUnder;
 }
 
-function isHomeAway(value: HomeAway, expected: 'home' | 'away') {
+export function isHomeAway(value: HomeAway, expected: 'home' | 'away') {
   if (typeof value === 'number') {
     return expected === 'away' ? value === 0 : value === 1;
   }

--- a/Server.UnitTests/CfbLeaderboardServiceTests.cs
+++ b/Server.UnitTests/CfbLeaderboardServiceTests.cs
@@ -1,0 +1,54 @@
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Services;
+using Xunit;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+/// <summary>
+/// frizat-dcz: JuiceForSlate maps slate number to the correct tease amount.
+/// Slate 17 = CFB Semifinals → JuiceConference (6), NOT JuiceDivisional (10).
+/// </summary>
+public class CfbLeaderboardServiceTests
+{
+    private static LeagueJuiceMapping Juice() => new()
+    {
+        Juice = 13,          // regular season
+        JuiceDivisional = 10, // quarterfinals (slates 15–16)
+        JuiceConference = 6,  // semifinals (slate 17)
+        WeeklyCost = 5,
+    };
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(7)]
+    [InlineData(14)]
+    public void JuiceForSlate_RegularSlates_ReturnsJuice(int slateNumber)
+    {
+        var result = CfbLeaderboardService.JuiceForSlate(slateNumber, Juice());
+        Assert.Equal(13, result);
+    }
+
+    [Theory]
+    [InlineData(15)]
+    [InlineData(16)]
+    public void JuiceForSlate_QuarterfinalsSlates_ReturnsJuiceDivisional(int slateNumber)
+    {
+        var result = CfbLeaderboardService.JuiceForSlate(slateNumber, Juice());
+        Assert.Equal(10, result);
+    }
+
+    [Fact]
+    public void JuiceForSlate_Slate17_Semifinals_ReturnsJuiceConference()
+    {
+        // Bug: was <= 17 => JuiceDivisional, so Slate 17 returned 10 instead of 6.
+        var result = CfbLeaderboardService.JuiceForSlate(17, Juice());
+        Assert.Equal(6, result);
+    }
+
+    [Fact]
+    public void JuiceForSlate_Slate18_Championship_ReturnsJuiceConference()
+    {
+        var result = CfbLeaderboardService.JuiceForSlate(18, Juice());
+        Assert.Equal(6, result);
+    }
+}

--- a/Server.UnitTests/CfbPicksControllerTests.cs
+++ b/Server.UnitTests/CfbPicksControllerTests.cs
@@ -305,7 +305,7 @@ public class CfbPicksControllerTests
         Assert.Equal(2, returned.Count);
     }
 
-    // ── DeletePicks — admin-only ─────────────────────────────────────────────
+    // ── DeletePicks — admin-only, targets correct userId ─────────────────────
 
     [Fact]
     public void DeletePicks_IsRestrictedToAdministratorRole()
@@ -317,6 +317,19 @@ public class CfbPicksControllerTests
 
         Assert.NotNull(attr);
         Assert.Equal("Administrator", attr!.Roles);
+    }
+
+    [Fact]
+    public async Task DeletePicks_DeletesTargetUserId_NotAdminId()
+    {
+        const string targetUserId = "target-player-999";
+        _repo.DeletePicksAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string>()).Returns(Task.CompletedTask);
+
+        var result = await BuildController("admin-001", isAdmin: true).DeletePicks(1, 1, targetUserId);
+
+        Assert.IsType<OkResult>(result);
+        await _repo.Received(1).DeletePicksAsync(1, 1, targetUserId);
+        await _repo.DidNotReceive().DeletePicksAsync(1, 1, "admin-001");
     }
 
     // ── GetSpreads — serving-layer eligibility filter (frizat-9m0) ──────────

--- a/Server.UnitTests/CfbPicksControllerTests.cs
+++ b/Server.UnitTests/CfbPicksControllerTests.cs
@@ -47,9 +47,11 @@ public class CfbPicksControllerTests
         Id = id, Season = 2025, SlateNumber = slateNumber, Label = "Week 1", SlateType = "RegularSeason",
     };
 
-    private static CfbSpreads MakeSpread(int espnEventId, DateTimeOffset gameTime, string home = "ORE", string away = "OSU", bool isLeagueEligible = true) => new()
+    // frizat: a team plays at most one game per slate, so (CfbSlateId, HomeTeam) — not an ESPN id
+    // — is what uniquely identifies a game, mirroring NflSpreads' (Season, NflWeek, HomeTeam).
+    private static CfbSpreads MakeSpread(DateTimeOffset gameTime, string home = "ORE", string away = "OSU", bool isLeagueEligible = true) => new()
     {
-        CfbSlateId = 1, EspnEventId = espnEventId, HomeTeam = home, AwayTeam = away, GameTime = gameTime,
+        CfbSlateId = 1, HomeTeam = home, AwayTeam = away, GameTime = gameTime,
         IsLeagueEligible = isLeagueEligible,
     };
 
@@ -58,7 +60,7 @@ public class CfbPicksControllerTests
     {
         var picks = new List<CfbPicks>
         {
-            new() { Id = 1, UserId = UserId, LeagueId = 1, CfbSlateId = 1, Team = "ORE", EspnEventId = 401800001 }
+            new() { Id = 1, UserId = UserId, LeagueId = 1, CfbSlateId = 1, Team = "ORE" }
         };
         _repo.GetUserPicksAsync(1, 1, UserId).Returns(picks);
 
@@ -73,13 +75,13 @@ public class CfbPicksControllerTests
     public async Task AddPicks_ValidPicks_ReturnsCount()
     {
         _cfbRepo.GetSlateByIdAsync(1).Returns(MakeSlate());
-        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2))]);
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(2))]);
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1,
             CfbSlateId = 1,
             Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
         };
         _repo.GetUserPicksAsync(1, 1, UserId).Returns([]);
         _repo.AddPicksAsync(Arg.Any<IEnumerable<CfbPicks>>()).Returns(Task.CompletedTask);
@@ -94,17 +96,17 @@ public class CfbPicksControllerTests
     public async Task AddPicks_DuplicatePick_IsSkipped()
     {
         _cfbRepo.GetSlateByIdAsync(1).Returns(MakeSlate());
-        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2))]);
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(2))]);
         var existing = new List<CfbPicks>
         {
-            new() { UserId = UserId, LeagueId = 1, CfbSlateId = 1, Team = "ORE", EspnEventId = 401800001 }
+            new() { UserId = UserId, LeagueId = 1, CfbSlateId = 1, Team = "ORE" }
         };
         _repo.GetUserPicksAsync(1, 1, UserId).Returns(existing);
 
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -122,7 +124,7 @@ public class CfbPicksControllerTests
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -137,12 +139,12 @@ public class CfbPicksControllerTests
         // Regression: the required-pick-count cap must fail closed on a bad/stale CfbSlateId, not
         // silently skip enforcement — GetSlateByIdAsync returning null (default NSubstitute stub)
         // must reject the whole request before any picks are inserted.
-        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2))]);
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(2))]);
         _repo.GetUserPicksAsync(1, 1, UserId).Returns([]);
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -157,12 +159,12 @@ public class CfbPicksControllerTests
     public async Task AddPicks_WhenGameKickoffHasPassed_ReturnsBadRequest()
     {
         _cfbRepo.GetSlateByIdAsync(1).Returns(MakeSlate());
-        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(-2))]);
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(-2))]);
         _repo.GetUserPicksAsync(1, 1, UserId).Returns([]);
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -176,13 +178,13 @@ public class CfbPicksControllerTests
     public async Task AddPicks_WhenGameKickoffIsInFuture_ReturnsOk()
     {
         _cfbRepo.GetSlateByIdAsync(1).Returns(MakeSlate());
-        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2))]);
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(2))]);
         _repo.GetUserPicksAsync(1, 1, UserId).Returns([]);
         _repo.AddPicksAsync(Arg.Any<IEnumerable<CfbPicks>>()).Returns(Task.CompletedTask);
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -201,7 +203,7 @@ public class CfbPicksControllerTests
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -217,8 +219,8 @@ public class CfbPicksControllerTests
         // Slate 18 (Championship-style, > 17) requires exactly 1 pick.
         _cfbRepo.GetSlateByIdAsync(1).Returns(MakeSlate(slateNumber: 18));
         _cfbRepo.GetSpreadsForSlateAsync(1).Returns([
-            MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2), "ORE", "OSU"),
-            MakeSpread(401800002, DateTimeOffset.UtcNow.AddHours(2), "ALA", "UGA"),
+            MakeSpread(DateTimeOffset.UtcNow.AddHours(2), "ORE", "OSU"),
+            MakeSpread(DateTimeOffset.UtcNow.AddHours(2), "ALA", "UGA"),
         ]);
         _repo.GetUserPicksAsync(1, 1, UserId).Returns([]);
         var request = new AddCfbPicksRequest
@@ -226,8 +228,8 @@ public class CfbPicksControllerTests
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
             Picks =
             [
-                new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" },
-                new CfbPickItem { Team = "ALA", EspnEventId = 401800002, PickType = "Spread" },
+                new CfbPickItem { Team = "ORE", PickType = "Spread" },
+                new CfbPickItem { Team = "ALA", PickType = "Spread" },
             ]
         };
 
@@ -253,11 +255,11 @@ public class CfbPicksControllerTests
     [Fact]
     public async Task GetAllPicks_HidesOtherUsersPicksForNotYetStartedGames()
     {
-        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2))]);
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(2))]);
         _repo.GetAllPicksForSlateAsync(1, 1).Returns(
         [
-            new CfbPickDto { UserId = UserId, EspnEventId = 401800001, Team = "ORE" },
-            new CfbPickDto { UserId = OtherUserId, EspnEventId = 401800001, Team = "OSU" },
+            new CfbPickDto { UserId = UserId, Team = "ORE" },
+            new CfbPickDto { UserId = OtherUserId, Team = "OSU" },
         ]);
 
         var result = await BuildController().GetAllPicks(1, 1);
@@ -271,11 +273,11 @@ public class CfbPicksControllerTests
     [Fact]
     public async Task GetAllPicks_ShowsOtherUsersPicksForStartedGames()
     {
-        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(-1))]);
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(-1))]);
         _repo.GetAllPicksForSlateAsync(1, 1).Returns(
         [
-            new CfbPickDto { UserId = UserId, EspnEventId = 401800001, Team = "ORE" },
-            new CfbPickDto { UserId = OtherUserId, EspnEventId = 401800001, Team = "OSU" },
+            new CfbPickDto { UserId = UserId, Team = "ORE" },
+            new CfbPickDto { UserId = OtherUserId, Team = "OSU" },
         ]);
 
         var result = await BuildController().GetAllPicks(1, 1);
@@ -289,11 +291,11 @@ public class CfbPicksControllerTests
     public async Task GetAllPicks_AdminSeesAllPicksRegardlessOfGameStatus()
     {
         _leagueRepo.UserExistsInLeagueAsync(Arg.Any<string>(), 1).Returns(false); // admin not a member
-        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2))]);
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(2))]);
         _repo.GetAllPicksForSlateAsync(1, 1).Returns(
         [
-            new CfbPickDto { UserId = UserId, EspnEventId = 401800001, Team = "ORE" },
-            new CfbPickDto { UserId = OtherUserId, EspnEventId = 401800001, Team = "OSU" },
+            new CfbPickDto { UserId = UserId, Team = "ORE" },
+            new CfbPickDto { UserId = OtherUserId, Team = "OSU" },
         ]);
 
         var result = await BuildController("admin-001", isAdmin: true).GetAllPicks(1, 1);
@@ -323,8 +325,8 @@ public class CfbPicksControllerTests
     public async Task GetSpreads_ReturnsOnlyLeagueEligibleSpreads()
     {
         _cfbRepo.GetSpreadsForSlateAsync(1).Returns([
-            MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2), "ORE", "OSU", isLeagueEligible: true),
-            MakeSpread(401800002, DateTimeOffset.UtcNow.AddHours(2), "TOL", "BALLST", isLeagueEligible: false),
+            MakeSpread(DateTimeOffset.UtcNow.AddHours(2), "ORE", "OSU", isLeagueEligible: true),
+            MakeSpread(DateTimeOffset.UtcNow.AddHours(2), "TOL", "BALLST", isLeagueEligible: false),
         ]);
 
         var result = await BuildController().GetSpreads(1);
@@ -332,14 +334,14 @@ public class CfbPicksControllerTests
         var ok = Assert.IsType<OkObjectResult>(result);
         var returned = Assert.IsAssignableFrom<IEnumerable<CfbSpreads>>(ok.Value).ToList();
         Assert.Single(returned);
-        Assert.Equal(401800001, returned[0].EspnEventId);
+        Assert.Equal("ORE", returned[0].HomeTeam);
     }
 
     // ── GetScores — serving-layer eligibility filter (frizat-9m0) ───────────
 
-    private static CfbScores MakeScore(int espnEventId, string home = "ORE", string away = "OSU") => new()
+    private static CfbScores MakeScore(string home = "ORE", string away = "OSU") => new()
     {
-        CfbSlateId = 1, EspnEventId = espnEventId, HomeTeam = home, AwayTeam = away,
+        CfbSlateId = 1, HomeTeam = home, AwayTeam = away,
         HomeTeamScore = 24, AwayTeamScore = 17, GameStatus = "STATUS_FINAL",
     };
 
@@ -347,12 +349,12 @@ public class CfbPicksControllerTests
     public async Task GetScores_ExcludesScoresForKnownIneligibleEvents()
     {
         _cfbRepo.GetSpreadsForSlateAsync(1).Returns([
-            MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(-2), "ORE", "OSU", isLeagueEligible: true),
-            MakeSpread(401800002, DateTimeOffset.UtcNow.AddHours(-2), "TOL", "BALLST", isLeagueEligible: false),
+            MakeSpread(DateTimeOffset.UtcNow.AddHours(-2), "ORE", "OSU", isLeagueEligible: true),
+            MakeSpread(DateTimeOffset.UtcNow.AddHours(-2), "TOL", "BALLST", isLeagueEligible: false),
         ]);
         _cfbRepo.GetScoresForSlateAsync(1).Returns([
-            MakeScore(401800001, "ORE", "OSU"),
-            MakeScore(401800002, "TOL", "BALLST"),
+            MakeScore("ORE", "OSU"),
+            MakeScore("TOL", "BALLST"),
         ]);
 
         var result = await BuildController().GetScores(1);
@@ -360,7 +362,7 @@ public class CfbPicksControllerTests
         var ok = Assert.IsType<OkObjectResult>(result);
         var returned = Assert.IsAssignableFrom<IEnumerable<CfbScoreDto>>(ok.Value).ToList();
         Assert.Single(returned);
-        Assert.Equal(401800001, returned[0].EspnEventId);
+        Assert.Equal("ORE", returned[0].HomeTeam);
     }
 
     [Fact]
@@ -371,34 +373,34 @@ public class CfbPicksControllerTests
         // schedule change) should still show, not silently vanish — only games we POSITIVELY know
         // are ineligible get excluded.
         _cfbRepo.GetSpreadsForSlateAsync(1).Returns([]);
-        _cfbRepo.GetScoresForSlateAsync(1).Returns([MakeScore(401800001, "ORE", "OSU")]);
+        _cfbRepo.GetScoresForSlateAsync(1).Returns([MakeScore("ORE", "OSU")]);
 
         var result = await BuildController().GetScores(1);
 
         var ok = Assert.IsType<OkObjectResult>(result);
         var returned = Assert.IsAssignableFrom<IEnumerable<CfbScoreDto>>(ok.Value).ToList();
         Assert.Single(returned);
-        Assert.Equal(401800001, returned[0].EspnEventId);
+        Assert.Equal("ORE", returned[0].HomeTeam);
     }
 
-    // ── AddPicks — ineligible-event guard (frizat-9m0) ───────────────────────
-    // Rejects a pick for an event we KNOW is excluded (MAC Tue/Wed, unranked, etc.) — distinct
+    // ── AddPicks — ineligible-team guard (frizat-9m0) ────────────────────────
+    // Rejects a pick for a team we KNOW is excluded (MAC Tue/Wed, unranked, etc.) — distinct
     // from AddPicks_WhenNoMatchingSpread_AllowsPick above, which fails open when we have NO data
-    // for the event at all (e.g. ESPN cache gap). Positive knowledge of ineligibility rejects;
+    // for the game at all (e.g. ESPN cache gap). Positive knowledge of ineligibility rejects;
     // absence of knowledge does not.
 
     [Fact]
-    public async Task AddPicks_WhenEventIsKnownIneligible_ReturnsBadRequest()
+    public async Task AddPicks_WhenTeamIsKnownIneligible_ReturnsBadRequest()
     {
         _cfbRepo.GetSlateByIdAsync(1).Returns(MakeSlate());
         _cfbRepo.GetSpreadsForSlateAsync(1).Returns([
-            MakeSpread(401800001, DateTimeOffset.UtcNow.AddHours(2), isLeagueEligible: false),
+            MakeSpread(DateTimeOffset.UtcNow.AddHours(2), isLeagueEligible: false),
         ]);
         _repo.GetUserPicksAsync(1, 1, UserId).Returns([]);
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", EspnEventId = 401800001, PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
         };
 
         var result = await BuildController().AddPicks(request);

--- a/Server.UnitTests/CfbRepositoryTests.cs
+++ b/Server.UnitTests/CfbRepositoryTests.cs
@@ -7,62 +7,64 @@ using Xunit;
 namespace FourPlayWebApp.Server.UnitTests;
 
 // TDD, written RED first (frizat-pxy follow-on plan, Phase 1): CfbRepository.UpsertAsync must
-// dedupe by EspnEventId (no blind insert -> no duplicate rows on a re-fired spread job) and must
-// preserve the original DateCreated on update, since that's the "line first posted" timestamp
-// shown to users, not a re-fire timestamp.
+// dedupe by (CfbSlateId, HomeTeam) — a natural key mirroring NflSpreadsConfiguration's
+// (Season, NflWeek, HomeTeam), not an ESPN-specific id — (no blind insert -> no duplicate rows on
+// a re-fired spread job) and must preserve the original DateCreated on update, since that's the
+// "line first posted" timestamp shown to users, not a re-fire timestamp.
 public class CfbRepositoryTests
 {
     [Fact]
-    public async Task UpsertAsync_NewEspnEventId_Inserts()
+    public async Task UpsertAsync_NewGame_Inserts()
     {
-        var factory = new DbContextFactoryStub(nameof(UpsertAsync_NewEspnEventId_Inserts));
+        var factory = new DbContextFactoryStub(nameof(UpsertAsync_NewGame_Inserts));
         var repo = new CfbRepository(factory);
 
         await repo.UpsertAsync([
-            new CfbSpreads { CfbSlateId = 1, EspnEventId = 100, HomeTeam = "A", AwayTeam = "B", HomeTeamSpread = -3.5, AwayTeamSpread = 3.5 },
+            new CfbSpreads { CfbSlateId = 1, HomeTeam = "A", AwayTeam = "B", HomeTeamSpread = -3.5, AwayTeamSpread = 3.5 },
         ]);
 
-        var saved = await factory.CreateDbContext().CfbSpreads.SingleAsync(s => s.EspnEventId == 100);
+        var saved = await factory.CreateDbContext().CfbSpreads.SingleAsync(s => s.CfbSlateId == 1 && s.HomeTeam == "A");
         Assert.Equal("A", saved.HomeTeam);
         Assert.Equal(-3.5, saved.HomeTeamSpread);
     }
 
     [Fact]
-    public async Task UpsertAsync_ExistingEspnEventId_UpdatesInPlace_NoDuplicateRow()
+    public async Task UpsertAsync_ExistingGame_UpdatesInPlace_NoDuplicateRow()
     {
-        var factory = new DbContextFactoryStub(nameof(UpsertAsync_ExistingEspnEventId_UpdatesInPlace_NoDuplicateRow));
+        var factory = new DbContextFactoryStub(nameof(UpsertAsync_ExistingGame_UpdatesInPlace_NoDuplicateRow));
         var repo = new CfbRepository(factory);
 
         await repo.UpsertAsync([
-            new CfbSpreads { CfbSlateId = 1, EspnEventId = 100, HomeTeam = "A", AwayTeam = "B", HomeTeamSpread = -3.5, AwayTeamSpread = 3.5 },
+            new CfbSpreads { CfbSlateId = 1, HomeTeam = "A", AwayTeam = "B", HomeTeamSpread = -3.5, AwayTeamSpread = 3.5 },
         ]);
 
-        // Re-fire with the same EspnEventId (e.g. a catch-up run re-processing an already-saved week)
+        // Re-fire with the same (CfbSlateId, HomeTeam) (e.g. a catch-up run re-processing an
+        // already-saved week)
         await repo.UpsertAsync([
-            new CfbSpreads { CfbSlateId = 1, EspnEventId = 100, HomeTeam = "A", AwayTeam = "B", HomeTeamSpread = -4.0, AwayTeamSpread = 4.0 },
+            new CfbSpreads { CfbSlateId = 1, HomeTeam = "A", AwayTeam = "B", HomeTeamSpread = -4.0, AwayTeamSpread = 4.0 },
         ]);
 
-        var all = await factory.CreateDbContext().CfbSpreads.Where(s => s.EspnEventId == 100).ToListAsync();
+        var all = await factory.CreateDbContext().CfbSpreads.Where(s => s.CfbSlateId == 1 && s.HomeTeam == "A").ToListAsync();
         Assert.Single(all);
         Assert.Equal(-4.0, all[0].HomeTeamSpread);
     }
 
     [Fact]
-    public async Task UpsertAsync_ExistingEspnEventId_PreservesOriginalDateCreated()
+    public async Task UpsertAsync_ExistingGame_PreservesOriginalDateCreated()
     {
-        var factory = new DbContextFactoryStub(nameof(UpsertAsync_ExistingEspnEventId_PreservesOriginalDateCreated));
+        var factory = new DbContextFactoryStub(nameof(UpsertAsync_ExistingGame_PreservesOriginalDateCreated));
         var repo = new CfbRepository(factory);
         var originalPostTime = new DateTimeOffset(2026, 9, 1, 9, 0, 0, TimeSpan.Zero);
 
         await repo.UpsertAsync([
-            new CfbSpreads { CfbSlateId = 1, EspnEventId = 100, HomeTeam = "A", AwayTeam = "B", DateCreated = originalPostTime },
+            new CfbSpreads { CfbSlateId = 1, HomeTeam = "A", AwayTeam = "B", DateCreated = originalPostTime },
         ]);
 
         await repo.UpsertAsync([
-            new CfbSpreads { CfbSlateId = 1, EspnEventId = 100, HomeTeam = "A", AwayTeam = "B", HomeTeamSpread = -1, DateCreated = DateTimeOffset.UtcNow },
+            new CfbSpreads { CfbSlateId = 1, HomeTeam = "A", AwayTeam = "B", HomeTeamSpread = -1, DateCreated = DateTimeOffset.UtcNow },
         ]);
 
-        var saved = await factory.CreateDbContext().CfbSpreads.SingleAsync(s => s.EspnEventId == 100);
+        var saved = await factory.CreateDbContext().CfbSpreads.SingleAsync(s => s.CfbSlateId == 1 && s.HomeTeam == "A");
         Assert.Equal(originalPostTime, saved.DateCreated);
     }
 
@@ -77,7 +79,7 @@ public class CfbRepositoryTests
         var seedDb = factory.CreateDbContext();
         var slate = new CfbSlates { Id = 1, Season = 2026, SlateNumber = 3, Label = "Week 3", SlateType = "RegularSeason" };
         seedDb.CfbSlates.Add(slate);
-        seedDb.CfbSpreads.Add(new CfbSpreads { CfbSlateId = 1, EspnEventId = 100, HomeTeam = "A", AwayTeam = "B" });
+        seedDb.CfbSpreads.Add(new CfbSpreads { CfbSlateId = 1, HomeTeam = "A", AwayTeam = "B" });
         await seedDb.SaveChangesAsync();
         var repo = new CfbRepository(factory);
 
@@ -110,7 +112,7 @@ public class CfbRepositoryTests
         var seedDb = factory.CreateDbContext();
         seedDb.CfbSlates.Add(new CfbSlates { Id = 1, Season = 2026, SlateNumber = 3, Label = "Week 3", SlateType = "RegularSeason" });
         seedDb.CfbSlates.Add(new CfbSlates { Id = 2, Season = 2026, SlateNumber = 4, Label = "Week 4", SlateType = "RegularSeason" });
-        seedDb.CfbSpreads.Add(new CfbSpreads { CfbSlateId = 1, EspnEventId = 100, HomeTeam = "A", AwayTeam = "B" });
+        seedDb.CfbSpreads.Add(new CfbSpreads { CfbSlateId = 1, HomeTeam = "A", AwayTeam = "B" });
         await seedDb.SaveChangesAsync();
 
         var repo = new CfbRepository(factory);

--- a/Server.UnitTests/DemoDataSeederLeaguePurgeTests.cs
+++ b/Server.UnitTests/DemoDataSeederLeaguePurgeTests.cs
@@ -71,4 +71,62 @@ public class DemoDataSeederLeaguePurgeTests {
 
         Assert.Equal(2, await db.LeagueInfo.CountAsync());
     }
+
+    // frizat: DemoDataSeeder's class doc comment promises "Idempotent — safe to call on every
+    // startup." Before soft-delete, a removed member's row was hard-deleted, so a bare
+    // AnyAsync-then-Add self-healed on reseed. Now the row persists with IsActive=false, so a
+    // naive AnyAsync check sees it as "already exists" and never reactivates it — permanently
+    // excluding a demo user from the league the moment anyone exercises the new Remove Member
+    // feature against the demo stack, contradicting the seeder's own idempotency contract.
+    [Fact]
+    public async Task EnsureActiveLeagueMemberAsync_ReactivatesExistingInactiveRow() {
+        await using var db = BuildDb(nameof(EnsureActiveLeagueMemberAsync_ReactivatesExistingInactiveRow));
+        var league = new LeagueInfo { LeagueName = "Demo League", OwnerUserId = "admin-1" };
+        db.LeagueInfo.Add(league);
+        await db.SaveChangesAsync();
+        var originalJoinDate = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        db.LeagueUserMapping.Add(new LeagueUserMapping {
+            LeagueId = league.Id, UserId = "eve-1", IsActive = false,
+            RemovedAt = DateTimeOffset.UtcNow, DateCreated = originalJoinDate,
+        });
+        await db.SaveChangesAsync();
+
+        var seeder = new DemoDataSeeder(db, BuildUserManager(), BuildConfiguration());
+        await seeder.EnsureActiveLeagueMemberAsync(league.Id, "eve-1");
+
+        var mappings = await db.LeagueUserMapping.Where(m => m.LeagueId == league.Id && m.UserId == "eve-1").ToListAsync();
+        Assert.Single(mappings);
+        Assert.True(mappings[0].IsActive);
+        Assert.Null(mappings[0].RemovedAt);
+        Assert.Equal(originalJoinDate, mappings[0].DateCreated);
+    }
+
+    [Fact]
+    public async Task EnsureActiveLeagueMemberAsync_InsertsNewRow_WhenNoneExists() {
+        await using var db = BuildDb(nameof(EnsureActiveLeagueMemberAsync_InsertsNewRow_WhenNoneExists));
+        var league = new LeagueInfo { LeagueName = "Demo League", OwnerUserId = "admin-1" };
+        db.LeagueInfo.Add(league);
+        await db.SaveChangesAsync();
+
+        var seeder = new DemoDataSeeder(db, BuildUserManager(), BuildConfiguration());
+        await seeder.EnsureActiveLeagueMemberAsync(league.Id, "eve-1");
+
+        var mapping = await db.LeagueUserMapping.SingleAsync(m => m.LeagueId == league.Id && m.UserId == "eve-1");
+        Assert.True(mapping.IsActive);
+    }
+
+    [Fact]
+    public async Task EnsureActiveLeagueMemberAsync_IsANoOp_WhenAlreadyActive() {
+        await using var db = BuildDb(nameof(EnsureActiveLeagueMemberAsync_IsANoOp_WhenAlreadyActive));
+        var league = new LeagueInfo { LeagueName = "Demo League", OwnerUserId = "admin-1" };
+        db.LeagueInfo.Add(league);
+        await db.SaveChangesAsync();
+        db.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = league.Id, UserId = "eve-1" });
+        await db.SaveChangesAsync();
+
+        var seeder = new DemoDataSeeder(db, BuildUserManager(), BuildConfiguration());
+        await seeder.EnsureActiveLeagueMemberAsync(league.Id, "eve-1");
+
+        Assert.Single(await db.LeagueUserMapping.Where(m => m.LeagueId == league.Id && m.UserId == "eve-1").ToListAsync());
+    }
 }

--- a/Server.UnitTests/LeaderboardControllerTests.cs
+++ b/Server.UnitTests/LeaderboardControllerTests.cs
@@ -27,6 +27,8 @@ public class LeaderboardControllerTests
         _nflService  = Substitute.For<ILeaderboardService>();
         _cfbService  = Substitute.For<ICfbLeaderboardService>();
         _leagueRepo  = Substitute.For<ILeagueRepository>();
+        // Default: the test user ("user-1") is a member — tests that need Forbid override to false.
+        _leagueRepo.UserExistsInLeagueAsync("user-1", Arg.Any<int>()).Returns(true);
     }
 
     // Each test gets its own fresh MemoryCache so caching state doesn't bleed between tests.
@@ -166,6 +168,48 @@ public class LeaderboardControllerTests
         var result = await BuildController().GetLeaderboard(leagueId, seasonYear);
 
         Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    // ── Membership guard ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetLeaderboard_ReturnsForbid_WhenUserNotInLeague()
+    {
+        _leagueRepo.UserExistsInLeagueAsync("user-1", 99).Returns(false);
+
+        var result = await BuildController().GetLeaderboard(99, 2025);
+
+        Assert.IsType<ForbidResult>(result.Result);
+        await _nflService.DidNotReceive().BuildLeaderboard(Arg.Any<int>(), Arg.Any<long>());
+        await _cfbService.DidNotReceive().BuildLeaderboard(Arg.Any<int>(), Arg.Any<int>());
+    }
+
+    [Fact]
+    public async Task GetLeaderboard_ReturnsOk_WhenAdminIsNotInLeague()
+    {
+        const int leagueId = 98;
+        const long seasonYear = 2025;
+        var league = new LeagueInfo { Id = leagueId, LeagueType = LeagueType.Nfl, LeagueName = "NFL", OwnerUserId = "owner" };
+
+        _leagueRepo.UserExistsInLeagueAsync(Arg.Any<string>(), leagueId).Returns(false);
+        _leagueRepo.GetLeagueInfoAsync(leagueId).Returns(league);
+        _nflService.BuildLeaderboard(leagueId, seasonYear).Returns(BuildLeaderboard(2));
+
+        var controller = new LeaderboardController(
+            _nflService, _cfbService, _leagueRepo, new MemoryCache(new MemoryCacheOptions()));
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim(ClaimTypes.NameIdentifier, "admin-1"),
+                     new Claim(ClaimTypes.Role, "Administrator")], "Test"))
+            }
+        };
+
+        var result = await controller.GetLeaderboard(leagueId, seasonYear);
+
+        Assert.IsType<OkObjectResult>(result.Result);
     }
 
     // ── Memory cache — second call does NOT re-invoke service ─────────────────

--- a/Server.UnitTests/LeaderboardTests.cs
+++ b/Server.UnitTests/LeaderboardTests.cs
@@ -347,15 +347,15 @@ public class LeaderboardServiceTests {
         var cfbRepo = Substitute.For<ICfbRepository>();
         cfbRepo.GetSlatesForSeasonAsync(2025).Returns([slate]);
         cfbRepo.GetSpreadsForSlateAsync(slateId).Returns((IEnumerable<CfbSpreads>)[
-            new CfbSpreads { Id = 1, CfbSlateId = slateId, EspnEventId = 100, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -7, AwayTeamSpread = 7, OverUnder = 50, IsLeagueEligible = true }
+            new CfbSpreads { Id = 1, CfbSlateId = slateId, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -7, AwayTeamSpread = 7, OverUnder = 50, IsLeagueEligible = true }
         ]);
         cfbRepo.GetScoresForSlateAsync(slateId).Returns((IEnumerable<CfbScores>)[
-            new CfbScores { Id = 1, CfbSlateId = slateId, EspnEventId = 100, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "StatusFinal" }
+            new CfbScores { Id = 1, CfbSlateId = slateId, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "StatusFinal" }
         ]);
 
         var picksRepo = Substitute.For<ICfbPicksRepository>();
         picksRepo.GetUserPicksAsync(leagueId, slateId, userId).Returns((IEnumerable<CfbPicks>)[
-            new CfbPicks { UserId = userId, LeagueId = leagueId, CfbSlateId = slateId, EspnEventId = 100, Team = "IU", PickType = "Spread", Season = 2025 }
+            new CfbPicks { UserId = userId, LeagueId = leagueId, CfbSlateId = slateId, Team = "IU", PickType = "Spread", Season = 2025 }
         ]);
 
         return (leagueRepo, cfbRepo, picksRepo);
@@ -381,7 +381,7 @@ public class LeaderboardServiceTests {
 
         // Override scores: IU loses badly — 7 to 35, so IU 7 + (-7+5) = 5; 5 - 35 = -30 < 0 → loss
         cfbRepo.GetScoresForSlateAsync(1).Returns((IEnumerable<CfbScores>)[
-            new CfbScores { Id = 1, CfbSlateId = 1, EspnEventId = 100, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 7, AwayTeamScore = 35, GameStatus = "StatusFinal" }
+            new CfbScores { Id = 1, CfbSlateId = 1, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 7, AwayTeamScore = 35, GameStatus = "StatusFinal" }
         ]);
 
         var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo);
@@ -397,8 +397,8 @@ public class LeaderboardServiceTests {
 
         // Add a second game that the user did NOT pick
         cfbRepo.GetSpreadsForSlateAsync(1).Returns((IEnumerable<CfbSpreads>)[
-            new CfbSpreads { Id = 1, CfbSlateId = 1, EspnEventId = 100, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -7, AwayTeamSpread = 7, OverUnder = 50, IsLeagueEligible = true },
-            new CfbSpreads { Id = 2, CfbSlateId = 1, EspnEventId = 101, HomeTeam = "MIC", AwayTeam = "PSU", HomeTeamSpread = -3, AwayTeamSpread = 3, OverUnder = 47, IsLeagueEligible = true },
+            new CfbSpreads { Id = 1, CfbSlateId = 1, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -7, AwayTeamSpread = 7, OverUnder = 50, IsLeagueEligible = true },
+            new CfbSpreads { Id = 2, CfbSlateId = 1, HomeTeam = "MIC", AwayTeam = "PSU", HomeTeamSpread = -3, AwayTeamSpread = 3, OverUnder = 47, IsLeagueEligible = true },
         ]);
 
         var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo);
@@ -438,22 +438,20 @@ public class LeaderboardServiceTests {
         var cfbRepo = Substitute.For<ICfbRepository>();
         cfbRepo.GetSlatesForSeasonAsync(2025).Returns([slate]);
         cfbRepo.GetSpreadsForSlateAsync(slateId).Returns((IEnumerable<CfbSpreads>)[
-            new CfbSpreads { Id = 1, CfbSlateId = slateId, EspnEventId = 100,
-                HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -7, AwayTeamSpread = 7, OverUnder = 50, IsLeagueEligible = true }
+            new CfbSpreads { Id = 1, CfbSlateId = slateId, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -7, AwayTeamSpread = 7, OverUnder = 50, IsLeagueEligible = true }
         ]);
         cfbRepo.GetScoresForSlateAsync(slateId).Returns((IEnumerable<CfbScores>)[
-            new CfbScores { Id = 1, CfbSlateId = slateId, EspnEventId = 100,
-                HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "StatusFinal" }
+            new CfbScores { Id = 1, CfbSlateId = slateId, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "StatusFinal" }
         ]);
 
         var picksRepo = Substitute.For<ICfbPicksRepository>();
         picksRepo.GetUserPicksAsync(leagueId, slateId, Arg.Is<string>(uid => winnerIds.Contains(uid)))
             .Returns((IEnumerable<CfbPicks>)[
-                new CfbPicks { CfbSlateId = slateId, EspnEventId = 100, Team = "IU", PickType = "Spread", Season = 2025 }
+                new CfbPicks { CfbSlateId = slateId, Team = "IU", PickType = "Spread", Season = 2025 }
             ]);
         picksRepo.GetUserPicksAsync(leagueId, slateId, Arg.Is<string>(uid => loserIds.Contains(uid)))
             .Returns((IEnumerable<CfbPicks>)[
-                new CfbPicks { CfbSlateId = slateId, EspnEventId = 100, Team = "OSU", PickType = "Spread", Season = 2025 }
+                new CfbPicks { CfbSlateId = slateId, Team = "OSU", PickType = "Spread", Season = 2025 }
             ]);
 
         return (leagueRepo, cfbRepo, picksRepo);
@@ -470,12 +468,10 @@ public class LeaderboardServiceTests {
         var (leagueRepo, cfbRepo, picksRepo) = BuildCfbMocks(userId, slateNumber: slateNumber);
 
         cfbRepo.GetSpreadsForSlateAsync(1).Returns((IEnumerable<CfbSpreads>)[
-            new CfbSpreads { Id = 1, CfbSlateId = 1, EspnEventId = 100,
-                HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -10, AwayTeamSpread = 10, OverUnder = 50, IsLeagueEligible = true }
+            new CfbSpreads { Id = 1, CfbSlateId = 1, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -10, AwayTeamSpread = 10, OverUnder = 50, IsLeagueEligible = true }
         ]);
         cfbRepo.GetScoresForSlateAsync(1).Returns((IEnumerable<CfbScores>)[
-            new CfbScores { Id = 1, CfbSlateId = 1, EspnEventId = 100,
-                HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 20, GameStatus = "StatusFinal" }
+            new CfbScores { Id = 1, CfbSlateId = 1, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 20, GameStatus = "StatusFinal" }
         ]);
 
         var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo);

--- a/Server.UnitTests/LeagueControllerDtoTests.cs
+++ b/Server.UnitTests/LeagueControllerDtoTests.cs
@@ -33,7 +33,8 @@ public class LeagueControllerDtoTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            Substitute.For<IInvitationService>());
+            Substitute.For<IInvitationService>(),
+            Substitute.For<ILeagueInviteLinkService>());
 
         controller.ControllerContext = new ControllerContext
         {

--- a/Server.UnitTests/LeagueControllerDtoTests.cs
+++ b/Server.UnitTests/LeagueControllerDtoTests.cs
@@ -18,11 +18,13 @@ namespace FourPlayWebApp.Server.UnitTests;
 /// </summary>
 public class LeagueControllerDtoTests
 {
-    private static LeagueController BuildController(ILeagueRepository repo)
+    private static LeagueController BuildController(ILeagueRepository repo, UserManager<ApplicationUser>? userManager = null)
     {
-        var store = Substitute.For<IUserStore<ApplicationUser>>();
-        var userManager = Substitute.For<UserManager<ApplicationUser>>(
-            store, null, null, null, null, null, null, null, null);
+        if (userManager is null) {
+            var store = Substitute.For<IUserStore<ApplicationUser>>();
+            userManager = Substitute.For<UserManager<ApplicationUser>>(
+                store, null, null, null, null, null, null, null, null);
+        }
 
         var controller = new LeagueController(
             new MemoryCache(new MemoryCacheOptions()),
@@ -133,5 +135,36 @@ public class LeagueControllerDtoTests
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var dtos = Assert.IsType<List<NflSpreadDto>>(ok.Value);
         Assert.Empty(dtos);
+    }
+
+    // ── GetUsers ────────────────────────────────────────────────────────────
+
+    // frizat: GetUsers previously called userManager.GetRolesAsync(u) once per user
+    // (N+1) to compute IsAdmin — slow/timeout-prone as the user base grows, and a
+    // plausible reason the frontend's Add User/Create League/Assign Owner pickers went
+    // silently empty intermittently. This proves IsAdmin is still computed correctly via
+    // a single batched GetUsersInRoleAsync call instead.
+    [Fact]
+    public async Task GetUsers_ComputesIsAdmin_ViaSingleBatchedRoleLookup_NotPerUser()
+    {
+        var admin = new ApplicationUser { Id = "u1", UserName = "admin", Email = "admin@x.com", EmailConfirmed = true };
+        var regular = new ApplicationUser { Id = "u2", UserName = "bob", Email = "bob@x.com", EmailConfirmed = true };
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetUsersAsync().Returns([admin, regular]);
+
+        var store = Substitute.For<IUserStore<ApplicationUser>>();
+        var userManager = Substitute.For<UserManager<ApplicationUser>>(
+            store, null, null, null, null, null, null, null, null);
+        userManager.GetUsersInRoleAsync("Administrator").Returns([admin]);
+
+        var result = await BuildController(repo, userManager).GetUsers();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dtos = Assert.IsType<List<UserSummaryDto>>(ok.Value);
+        Assert.Equal(2, dtos.Count);
+        Assert.True(dtos.Single(d => d.Id == "u1").IsAdmin);
+        Assert.False(dtos.Single(d => d.Id == "u2").IsAdmin);
+        await userManager.Received(1).GetUsersInRoleAsync("Administrator");
+        await userManager.DidNotReceive().GetRolesAsync(Arg.Any<ApplicationUser>());
     }
 }

--- a/Server.UnitTests/LeagueInviteLinkTests.cs
+++ b/Server.UnitTests/LeagueInviteLinkTests.cs
@@ -1,0 +1,214 @@
+using FourPlayWebApp.Server.Controllers;
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Models.Identity;
+using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Server.Services.Repositories.Interfaces;
+using FourPlayWebApp.Shared.Models.Data.Dtos;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using System.Security.Claims;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+/// <summary>
+/// PR #223: Shareable league invite link — ownership guards, generate, validate, join.
+/// </summary>
+public class LeagueInviteLinkTests
+{
+    private const string OwnerId = "owner-001";
+    private const string MemberId = "member-002";
+    private const string StrangerId = "stranger-003";
+
+    private static LeagueController BuildController(
+        ClaimsPrincipal principal,
+        ILeagueRepository? repo = null,
+        ILeagueInviteLinkService? linkService = null)
+    {
+        var store = Substitute.For<IUserStore<ApplicationUser>>();
+        var userManager = Substitute.For<UserManager<ApplicationUser>>(
+            store, null, null, null, null, null, null, null, null);
+
+        var controller = new LeagueController(
+            new MemoryCache(new MemoryCacheOptions()),
+            repo ?? Substitute.For<ILeagueRepository>(),
+            NullLogger<LeagueController>.Instance,
+            userManager,
+            Substitute.For<ISpreadCalculatorBuilder>(),
+            Substitute.For<IEspnCacheService>(),
+            Substitute.For<IInvitationService>(),
+            linkService ?? Substitute.For<ILeagueInviteLinkService>());
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = principal }
+        };
+        return controller;
+    }
+
+    private static ClaimsPrincipal BuildPrincipal(string userId, bool isAdmin = false)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId),
+            new(ClaimTypes.Name, userId),
+        };
+        if (isAdmin)
+            claims.Add(new Claim(ClaimTypes.Role, "Administrator"));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+    }
+
+    // ── GenerateInviteLink ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GenerateInviteLink_ReturnsForbid_WhenCallerIsNotOwnerOrAdmin()
+    {
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "TestLeague" });
+
+        var controller = BuildController(BuildPrincipal(StrangerId), repo: repo);
+
+        var result = await controller.GenerateInviteLink(1);
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GenerateInviteLink_ReturnsOk_WhenCallerIsOwner()
+    {
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "TestLeague" });
+
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        linkService.GenerateAsync(1, OwnerId, Arg.Any<LeagueInfo>()).Returns(new LeagueInviteLink
+        {
+            Token = "abc123",
+            LeagueId = 1,
+            League = new LeagueInfo { Id = 1, LeagueName = "TestLeague" },
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(24),
+        });
+
+        var controller = BuildController(BuildPrincipal(OwnerId), repo: repo, linkService: linkService);
+
+        var result = await controller.GenerateInviteLink(1);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<LeagueInviteLinkDto>(ok.Value);
+        Assert.Equal("abc123", dto.Token);
+        Assert.Equal("TestLeague", dto.LeagueName);
+    }
+
+    [Fact]
+    public async Task GenerateInviteLink_ReturnsOk_WhenCallerIsAdmin()
+    {
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "TestLeague" });
+
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        linkService.GenerateAsync(1, Arg.Any<string>(), Arg.Any<LeagueInfo>()).Returns(new LeagueInviteLink
+        {
+            Token = "xyz789",
+            LeagueId = 1,
+            League = new LeagueInfo { Id = 1, LeagueName = "TestLeague" },
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(24),
+        });
+
+        var controller = BuildController(BuildPrincipal("admin-user", isAdmin: true), repo: repo, linkService: linkService);
+
+        var result = await controller.GenerateInviteLink(1);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    // ── ValidateInviteLink ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ValidateInviteLink_ReturnsNotFound_WhenTokenInvalid()
+    {
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        linkService.ValidateAsync("badtoken").Returns((LeagueInviteLink?)null);
+
+        var controller = BuildController(BuildPrincipal(OwnerId), linkService: linkService);
+
+        var result = await controller.ValidateInviteLink("badtoken");
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task ValidateInviteLink_ReturnsOk_WhenTokenValid()
+    {
+        var link = new LeagueInviteLink
+        {
+            Token = "valid123",
+            LeagueId = 5,
+            League = new LeagueInfo { Id = 5, LeagueName = "MyLeague" },
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(20),
+        };
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        linkService.ValidateAsync("valid123").Returns(link);
+
+        var controller = BuildController(BuildPrincipal(MemberId), linkService: linkService);
+
+        var result = await controller.ValidateInviteLink("valid123");
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<LeagueInviteLinkDto>(ok.Value);
+        Assert.Equal(5, dto.LeagueId);
+        Assert.Equal("MyLeague", dto.LeagueName);
+    }
+
+    // ── JoinViaLink ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task JoinViaLink_ReturnsNotFound_WhenTokenInvalid()
+    {
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        linkService.ValidateAsync("bad").Returns((LeagueInviteLink?)null);
+
+        var controller = BuildController(BuildPrincipal(MemberId), linkService: linkService);
+
+        var result = await controller.JoinViaLink("bad");
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task JoinViaLink_ReturnsConflict_WhenAlreadyMember()
+    {
+        var link = new LeagueInviteLink { Token = "tok", LeagueId = 1, League = new LeagueInfo { Id = 1, LeagueName = "L" }, ExpiresAt = DateTimeOffset.UtcNow.AddHours(1) };
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        linkService.ValidateAsync("tok").Returns(link);
+
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.UserExistsInLeagueAsync(MemberId, 1).Returns(true);
+
+        var controller = BuildController(BuildPrincipal(MemberId), repo: repo, linkService: linkService);
+
+        var result = await controller.JoinViaLink("tok");
+
+        Assert.IsType<ConflictObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task JoinViaLink_ReturnsNoContent_WhenSuccessful()
+    {
+        var link = new LeagueInviteLink { Token = "tok", LeagueId = 1, League = new LeagueInfo { Id = 1, LeagueName = "L" }, ExpiresAt = DateTimeOffset.UtcNow.AddHours(1) };
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        linkService.ValidateAsync("tok").Returns(link);
+
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.UserExistsInLeagueAsync(MemberId, 1).Returns(false);
+
+        var controller = BuildController(BuildPrincipal(MemberId), repo: repo, linkService: linkService);
+
+        var result = await controller.JoinViaLink("tok");
+
+        Assert.IsType<NoContentResult>(result);
+        await repo.Received(1).AddLeagueUserMappingAsync(Arg.Is<LeagueUserMapping>(m =>
+            m.LeagueId == 1 && m.UserId == MemberId));
+    }
+}

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -222,6 +222,60 @@ public class LeagueOwnershipTests
         await repo.Received(1).RemoveLeagueUserMappingAsync(1, "victim-003");
     }
 
+    // frizat: GetLeagueInfoAsync's real (non-mocked) implementation uses FirstAsync(), which
+    // throws InvalidOperationException rather than returning null for a missing league — a
+    // double-submitted delete (slow network, already-deleted league) would otherwise 500 instead
+    // of a clean 404. This is realistic specifically for a delete endpoint, unlike the read/update
+    // endpoints elsewhere in this controller that share the same GetLeagueInfoAsync-then-use
+    // pattern against a league the frontend already has loaded.
+    [Fact]
+    public async Task DeleteLeague_ReturnsNotFound_WhenLeagueDoesNotExist()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(999).Returns(Task.FromException<LeagueInfo>(new InvalidOperationException("Sequence contains no elements")));
+
+        var result = await ctrl.DeleteLeague(999);
+
+        Assert.IsType<NotFoundResult>(result);
+        await repo.DidNotReceive().DeleteLeagueAsync(Arg.Any<int>());
+    }
+
+    [Fact]
+    public async Task DeleteLeague_ReturnsForbid_WhenCallerIsNotOwnerOrAdmin()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
+
+        var result = await ctrl.DeleteLeague(1);
+
+        Assert.IsType<ForbidResult>(result);
+        await repo.DidNotReceive().DeleteLeagueAsync(Arg.Any<int>());
+    }
+
+    [Fact]
+    public async Task DeleteLeague_ReturnsNoContent_WhenCallerIsOwner()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
+
+        var result = await ctrl.DeleteLeague(1);
+
+        Assert.IsType<NoContentResult>(result);
+        await repo.Received(1).DeleteLeagueAsync(1);
+    }
+
+    [Fact]
+    public async Task DeleteLeague_ReturnsNoContent_WhenCallerIsAdmin()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId, isAdmin: true));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
+
+        var result = await ctrl.DeleteLeague(1);
+
+        Assert.IsType<NoContentResult>(result);
+        await repo.Received(1).DeleteLeagueAsync(1);
+    }
+
     [Fact]
     public async Task GetLeagueCost_ReturnsCorrectCostForBaseTier()
     {

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -328,6 +328,75 @@ public class LeagueOwnershipTests
         Assert.Null(roleAttr); // any authenticated user may call this now — class-level [Authorize] still applies
     }
 
+    // frizat: the frontend locks the Create League Sport field to the current subdomain, but a
+    // crafted/replayed request can still send a mismatched LeagueType directly — this is the
+    // server-side backstop, mirroring useSportContext's own cfb.-prefix host check.
+    //
+    // Origin is the PRIMARY signal, not Host: prod traffic goes through Vercel's /api/:path*
+    // rewrite to the Railway backend with no UseForwardedHeaders middleware, so Request.Host
+    // reflects Railway's own domain, not cfb.ivleague.xyz — using Host directly would silently
+    // resolve every request to Nfl. Origin survives the rewrite untouched (same mechanism the
+    // existing ALLOWED_ORIGINS/CORS check already relies on). Host is only a last-resort
+    // fallback for the no-Origin-no-Referer case (e.g. this test suite's plain DefaultHttpContext).
+    [Fact]
+    public async Task CreateLeague_ReturnsBadRequest_WhenLeagueTypeDoesNotMatchOrigin()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        ctrl.ControllerContext.HttpContext.Request.Headers.Origin = "https://cfb.ivleague.xyz";
+        repo.LeagueExistsAsync(Arg.Any<string>()).Returns(false);
+
+        var dto = new LeagueCreateDto("My League", LeagueType.Nfl, OwnerId, 2025, 0, 0, 0, 0);
+        var result = await ctrl.CreateLeague(dto);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        await repo.DidNotReceive().AddLeagueInfoAsync(Arg.Any<LeagueInfo>());
+    }
+
+    [Fact]
+    public async Task CreateLeague_Succeeds_WhenLeagueTypeMatchesCfbOrigin()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        ctrl.ControllerContext.HttpContext.Request.Headers.Origin = "https://cfb.ivleague.xyz";
+        repo.LeagueExistsAsync(Arg.Any<string>()).Returns(false);
+        var createdLeague = new LeagueInfo { Id = 42, LeagueName = "My League", OwnerUserId = OwnerId, LeagueType = LeagueType.Cfb };
+        repo.AddLeagueInfoAsync(Arg.Any<LeagueInfo>()).Returns(Task.FromResult(createdLeague));
+
+        var dto = new LeagueCreateDto("My League", LeagueType.Cfb, OwnerId, 2025, 0, 0, 0, 0);
+        var result = await ctrl.CreateLeague(dto);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    // Origin absent (e.g. some non-browser callers omit it) but Referer present — same host
+    // extraction, second-priority fallback.
+    [Fact]
+    public async Task CreateLeague_ResolvesSportFromReferer_WhenOriginIsAbsent()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        ctrl.ControllerContext.HttpContext.Request.Headers.Referer = "https://cfb.ivleague.xyz/league/manage";
+        repo.LeagueExistsAsync(Arg.Any<string>()).Returns(false);
+
+        var dto = new LeagueCreateDto("My League", LeagueType.Nfl, OwnerId, 2025, 0, 0, 0, 0);
+        var result = await ctrl.CreateLeague(dto);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    // Neither Origin nor Referer present — falls back to Host (matches this test suite's plain
+    // DefaultHttpContext, and is the pre-existing behavior for that edge case).
+    [Fact]
+    public async Task CreateLeague_FallsBackToHost_WhenOriginAndRefererAreBothAbsent()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        ctrl.ControllerContext.HttpContext.Request.Host = new HostString("cfb.ivleague.xyz");
+        repo.LeagueExistsAsync(Arg.Any<string>()).Returns(false);
+
+        var dto = new LeagueCreateDto("My League", LeagueType.Nfl, OwnerId, 2025, 0, 0, 0, 0);
+        var result = await ctrl.CreateLeague(dto);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
     // frizat-d6l live-testing follow-up: the CreateLeague_* tests above construct LeagueCreateDto
     // directly as a C# record, which never exercises JSON deserialization — so they all passed
     // while the real [FromBody] endpoint 400'd on every request. The frontend sends leagueType as

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -807,4 +807,50 @@ public class LeagueOwnershipTests
 
         Assert.IsType<OkObjectResult>(result.Result);
     }
+
+    // ─── frizat-dcz: IDOR on spread batch endpoints ──────────────────────────
+
+    [Fact]
+    public async Task GetSpreadBatch_ReturnsForbid_WhenUserNotInLeague()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId));
+        repo.UserExistsInLeagueAsync(AttackerId, 1).Returns(false);
+
+        var result = await ctrl.GetSpreadBatch(1, 2025, 1,
+            new FourPlayWebApp.Shared.Models.BatchSpreadRequest());
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetSpreadBatch_ReturnsOk_WhenAdminNotInLeague()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId, isAdmin: true));
+        repo.UserExistsInLeagueAsync(AttackerId, 1).Returns(false);
+        var calcBuilder = Substitute.For<ISpreadCalculatorBuilder>();
+        var calc = Substitute.For<FourPlayWebApp.Server.Services.Interfaces.ISpreadCalculator>();
+        calc.DoOddsExist().Returns(false);
+        calcBuilder.WithLeagueId(Arg.Any<int>()).Returns(calcBuilder);
+        calcBuilder.WithWeek(Arg.Any<int>()).Returns(calcBuilder);
+        calcBuilder.WithSeason(Arg.Any<int>()).Returns(calcBuilder);
+        calcBuilder.BuildAsync().Returns(calc);
+
+        // Admin bypass — result is NotFound (no odds), not Forbid
+        var result = await ctrl.GetSpreadBatch(1, 2025, 1,
+            new FourPlayWebApp.Shared.Models.BatchSpreadRequest());
+
+        Assert.IsNotType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task CalculateSpreadBatch_ReturnsForbid_WhenUserNotInLeague()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId));
+        repo.UserExistsInLeagueAsync(AttackerId, 1).Returns(false);
+
+        var result = await ctrl.CalculateSpreadBatch(1, 2025, 1,
+            new FourPlayWebApp.Shared.Models.BatchSpreadCalculationRequest());
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
 }

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -40,7 +40,8 @@ public class LeagueOwnershipTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            Substitute.For<IInvitationService>());
+            Substitute.For<IInvitationService>(),
+            Substitute.For<ILeagueInviteLinkService>());
 
         controller.ControllerContext = new ControllerContext
         {
@@ -96,7 +97,8 @@ public class LeagueOwnershipTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            Substitute.For<IInvitationService>());
+            Substitute.For<IInvitationService>(),
+            Substitute.For<ILeagueInviteLinkService>());
 
         controller.ControllerContext = new ControllerContext
         {
@@ -128,7 +130,8 @@ public class LeagueOwnershipTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            Substitute.For<IInvitationService>());
+            Substitute.For<IInvitationService>(),
+            Substitute.For<ILeagueInviteLinkService>());
 
         controller.ControllerContext = new ControllerContext
         {
@@ -155,7 +158,8 @@ public class LeagueOwnershipTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            Substitute.For<IInvitationService>());
+            Substitute.For<IInvitationService>(),
+            Substitute.For<ILeagueInviteLinkService>());
         ctrl.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext { User = principal }
@@ -592,7 +596,8 @@ public class LeagueOwnershipTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            invSvc);
+            invSvc,
+            Substitute.For<ILeagueInviteLinkService>());
         ctrl.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext { User = BuildPrincipal(OwnerId) }
@@ -623,7 +628,8 @@ public class LeagueOwnershipTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            invSvc);
+            invSvc,
+            Substitute.For<ILeagueInviteLinkService>());
         ctrl.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext { User = BuildPrincipal(OwnerId) }

--- a/Server.UnitTests/LeagueRepositoryTests.cs
+++ b/Server.UnitTests/LeagueRepositoryTests.cs
@@ -1,3 +1,6 @@
+using FourPlayWebApp.Server.Models;
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Repositories;
 using FourPlayWebApp.Shared.Models.Data;
 using Microsoft.EntityFrameworkCore;
@@ -39,5 +42,163 @@ public class LeagueRepositoryTests
 
         Assert.Contains((2026, 3), weeksWithData);
         Assert.DoesNotContain((2026, 4), weeksWithData);
+    }
+
+    // ── DeleteLeagueAsync ──────────────────────────────────────────────────────
+
+    // frizat: mirrors DemoDataSeeder.PurgeUnknownLeaguesAsync's explicit ordered RemoveRange —
+    // every FK off LeagueInfo is DB-level Cascade already, but deleting explicitly (not relying
+    // solely on cascade) keeps this correct against the in-memory provider too, which doesn't
+    // enforce relational FK cascade the way real Postgres does.
+    [Fact]
+    public async Task DeleteLeagueAsync_RemovesLeagueAndAllDependentRows()
+    {
+        var factory = new DbContextFactoryStub(nameof(DeleteLeagueAsync_RemovesLeagueAndAllDependentRows));
+        var seedDb = factory.CreateDbContext();
+
+        var league = new LeagueInfo { LeagueName = "Doomed League", OwnerUserId = "owner-1" };
+        var otherLeague = new LeagueInfo { LeagueName = "Untouched League", OwnerUserId = "owner-2" };
+        seedDb.LeagueInfo.AddRange(league, otherLeague);
+        await seedDb.SaveChangesAsync();
+
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = league.Id, UserId = "owner-1" });
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = otherLeague.Id, UserId = "owner-2" });
+        seedDb.LeagueJuiceMapping.Add(new LeagueJuiceMapping {
+            LeagueId = league.Id, Season = 2025, Juice = 13, JuiceDivisional = 10, JuiceConference = 6, WeeklyCost = 5,
+        });
+        seedDb.NflPicks.Add(new NflPicks { LeagueId = league.Id, UserId = "owner-1", Team = "BUF", NflWeek = 1, Season = 2025 });
+        seedDb.CfbPicks.Add(new CfbPicks { LeagueId = league.Id, UserId = "owner-1", Team = "MICH", CfbSlateId = 1, Season = 2025 });
+        seedDb.Invitations.Add(new Invitation { Email = "friend@example.com", LeagueId = league.Id, InvitedByUserId = "owner-1" });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        await repo.DeleteLeagueAsync(league.Id);
+
+        var db = factory.CreateDbContext();
+        Assert.False(await db.LeagueInfo.AnyAsync(l => l.Id == league.Id));
+        Assert.False(await db.LeagueUserMapping.AnyAsync(m => m.LeagueId == league.Id));
+        Assert.False(await db.LeagueJuiceMapping.AnyAsync(m => m.LeagueId == league.Id));
+        Assert.False(await db.NflPicks.AnyAsync(p => p.LeagueId == league.Id));
+        Assert.False(await db.CfbPicks.AnyAsync(p => p.LeagueId == league.Id));
+        Assert.False(await db.Invitations.AnyAsync(i => i.LeagueId == league.Id));
+
+        // Unrelated league and its own mapping survive untouched.
+        Assert.True(await db.LeagueInfo.AnyAsync(l => l.Id == otherLeague.Id));
+        Assert.True(await db.LeagueUserMapping.AnyAsync(m => m.LeagueId == otherLeague.Id));
+    }
+
+    // ── Soft-delete league membership ───────────────────────────────────────────
+    // frizat: removing a member must keep their pick history for audit purposes — flip IsActive
+    // instead of hard-deleting the LeagueUserMapping row.
+
+    [Fact]
+    public async Task RemoveLeagueUserMappingAsync_SetsInactive_DoesNotDeleteRow()
+    {
+        var factory = new DbContextFactoryStub(nameof(RemoveLeagueUserMappingAsync_SetsInactive_DoesNotDeleteRow));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = 1, UserId = "user-1" });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        await repo.RemoveLeagueUserMappingAsync(1, "user-1");
+
+        var db = factory.CreateDbContext();
+        var mapping = await db.LeagueUserMapping.SingleAsync(m => m.LeagueId == 1 && m.UserId == "user-1");
+        Assert.False(mapping.IsActive);
+        Assert.NotNull(mapping.RemovedAt);
+    }
+
+    // frizat: (LeagueId, UserId) is unique — a removed-then-re-added user must reactivate their
+    // existing row, not insert a second one (would violate the unique index against real Postgres).
+    [Fact]
+    public async Task AddLeagueUserMappingAsync_ReactivatesExistingInactiveRow_InsteadOfInserting()
+    {
+        var factory = new DbContextFactoryStub(nameof(AddLeagueUserMappingAsync_ReactivatesExistingInactiveRow_InsteadOfInserting));
+        var seedDb = factory.CreateDbContext();
+        var originalJoinDate = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping {
+            LeagueId = 1, UserId = "user-1", IsActive = false,
+            RemovedAt = DateTimeOffset.UtcNow, DateCreated = originalJoinDate,
+        });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        await repo.AddLeagueUserMappingAsync(new LeagueUserMapping { LeagueId = 1, UserId = "user-1" });
+
+        var db = factory.CreateDbContext();
+        var mappings = await db.LeagueUserMapping.Where(m => m.LeagueId == 1 && m.UserId == "user-1").ToListAsync();
+        Assert.Single(mappings);
+        Assert.True(mappings[0].IsActive);
+        Assert.Null(mappings[0].RemovedAt);
+        Assert.Equal(originalJoinDate, mappings[0].DateCreated); // original join date preserved, not clobbered
+    }
+
+    [Fact]
+    public async Task GetLeagueUserMappingsAsync_ByLeagueId_ExcludesInactiveMembers()
+    {
+        var factory = new DbContextFactoryStub(nameof(GetLeagueUserMappingsAsync_ByLeagueId_ExcludesInactiveMembers));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueInfo.Add(new LeagueInfo { Id = 1, LeagueName = "L", OwnerUserId = "active-user" });
+        seedDb.Users.AddRange(
+            new ApplicationUser { Id = "active-user", UserName = "active-user" },
+            new ApplicationUser { Id = "removed-user", UserName = "removed-user" });
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = 1, UserId = "active-user" });
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = 1, UserId = "removed-user", IsActive = false, RemovedAt = DateTimeOffset.UtcNow });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        var mappings = await repo.GetLeagueUserMappingsAsync(1);
+
+        Assert.Single(mappings);
+        Assert.Equal("active-user", mappings[0].UserId);
+    }
+
+    [Fact]
+    public async Task GetLeagueUserMappingsAsync_ByUser_ExcludesInactiveMemberships()
+    {
+        var factory = new DbContextFactoryStub(nameof(GetLeagueUserMappingsAsync_ByUser_ExcludesInactiveMemberships));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueInfo.AddRange(
+            new LeagueInfo { Id = 1, LeagueName = "L1", OwnerUserId = "user-1" },
+            new LeagueInfo { Id = 2, LeagueName = "L2", OwnerUserId = "user-1" });
+        seedDb.Users.Add(new ApplicationUser { Id = "user-1", UserName = "user-1" });
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = 1, UserId = "user-1" });
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = 2, UserId = "user-1", IsActive = false, RemovedAt = DateTimeOffset.UtcNow });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        var mappings = await repo.GetLeagueUserMappingsAsync(new ApplicationUser { Id = "user-1" });
+
+        Assert.Single(mappings);
+        Assert.Equal(1, mappings[0].LeagueId);
+    }
+
+    [Fact]
+    public async Task GetLeagueMemberCountAsync_ExcludesInactiveMembers()
+    {
+        var factory = new DbContextFactoryStub(nameof(GetLeagueMemberCountAsync_ExcludesInactiveMembers));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = 1, UserId = "active-user" });
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = 1, UserId = "removed-user", IsActive = false, RemovedAt = DateTimeOffset.UtcNow });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        var count = await repo.GetLeagueMemberCountAsync(1);
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task UserExistsInLeagueAsync_ReturnsFalse_ForInactiveMember()
+    {
+        var factory = new DbContextFactoryStub(nameof(UserExistsInLeagueAsync_ReturnsFalse_ForInactiveMember));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = 1, UserId = "removed-user", IsActive = false, RemovedAt = DateTimeOffset.UtcNow });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        var exists = await repo.UserExistsInLeagueAsync("removed-user", 1);
+
+        Assert.False(exists);
     }
 }

--- a/Server.UnitTests/NflCurrentWeekEndpointTests.cs
+++ b/Server.UnitTests/NflCurrentWeekEndpointTests.cs
@@ -34,7 +34,8 @@ public class NflCurrentWeekEndpointTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            Substitute.For<IInvitationService>());
+            Substitute.For<IInvitationService>(),
+            Substitute.For<ILeagueInviteLinkService>());
 
         controller.ControllerContext = new ControllerContext
         {

--- a/Server.UnitTests/PicksTests.cs
+++ b/Server.UnitTests/PicksTests.cs
@@ -53,7 +53,8 @@ public class PicksTests
             BuildUserManager(),
             Substitute.For<ISpreadCalculatorBuilder>(),
             espnCacheService,
-            Substitute.For<IInvitationService>());
+            Substitute.For<IInvitationService>(),
+            Substitute.For<ILeagueInviteLinkService>());
 
         var httpContext = new DefaultHttpContext();
         if (principal is not null)

--- a/Server.UnitTests/SpreadLockScheduleEndpointTests.cs
+++ b/Server.UnitTests/SpreadLockScheduleEndpointTests.cs
@@ -37,7 +37,8 @@ public class SpreadLockScheduleEndpointTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            Substitute.For<IInvitationService>());
+            Substitute.For<IInvitationService>(),
+            Substitute.For<ILeagueInviteLinkService>());
 
         controller.ControllerContext = new ControllerContext
         {

--- a/Server/Controllers/CfbPicksController.cs
+++ b/Server/Controllers/CfbPicksController.cs
@@ -62,12 +62,13 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
         // KNOW are ineligible (a matching CfbSpreads row exists and says so). A completed game
         // with no matching spread row at all (e.g. CfbSpreadJob's one-shot-per-week fetch missed
         // a late schedule change) still shows rather than silently vanishing from the scores page.
-        var ineligibleEventIds = spreadsTask.Result.WhereLeagueIneligible().Select(s => s.EspnEventId).ToHashSet();
-        var scores = scoresTask.Result.Where(s => !ineligibleEventIds.Contains(s.EspnEventId));
+        // Matched by HomeTeam (unique within a slate) rather than an ESPN id — CfbScores.HomeTeam
+        // and CfbSpreads.HomeTeam are populated from the same real-world game by design.
+        var ineligibleHomeTeams = spreadsTask.Result.WhereLeagueIneligible().Select(s => s.HomeTeam).ToHashSet();
+        var scores = scoresTask.Result.Where(s => !ineligibleHomeTeams.Contains(s.HomeTeam));
         var dtos = scores.Select(s => new CfbScoreDto {
             Id                  = s.Id,
             CfbSlateId          = s.CfbSlateId,
-            EspnEventId         = s.EspnEventId,
             HomeTeam            = s.HomeTeam,
             AwayTeam            = s.AwayTeam,
             HomeTeamScore       = s.HomeTeamScore,
@@ -85,8 +86,9 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
 
     // CFB has no live ESPN status feed the way NFL does (see cfbAdapter.ts) — CfbSpreads.GameTime
     // is the source of truth for kickoff time, same as the frontend's own gameIsLocked check.
-    private static HashSet<int> StartedEventIds(IEnumerable<CfbSpreads> spreads, DateTimeOffset now) =>
-        spreads.Where(s => s.GameTime <= now).Select(s => s.EspnEventId).ToHashSet();
+    // Returns both home and away team names for started games — a pick can be on either side.
+    private static HashSet<string> StartedTeams(IEnumerable<CfbSpreads> spreads, DateTimeOffset now) =>
+        spreads.Where(s => s.GameTime <= now).SelectMany(s => new[] { s.HomeTeam, s.AwayTeam }).ToHashSet();
 
     [HttpGet("picks/{leagueId}/{cfbSlateId}")]
     public async Task<IActionResult> GetAllPicks(int leagueId, int cfbSlateId) {
@@ -105,9 +107,9 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
         // Hide other users' picks for games that haven't kicked off yet — same rule as NFL's
         // GetLeaguePicks. Admins always see all picks, same as NFL.
         if (!isAdmin) {
-            var startedEventIds = StartedEventIds(spreadsTask.Result, DateTimeOffset.UtcNow);
+            var startedTeams = StartedTeams(spreadsTask.Result, DateTimeOffset.UtcNow);
             allPicks = allPicks
-                .Where(p => p.UserId == callerId || startedEventIds.Contains(p.EspnEventId))
+                .Where(p => p.UserId == callerId || startedTeams.Contains(p.Team))
                 .ToList();
         }
 
@@ -136,33 +138,35 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
         if (slate is null)
             return BadRequest("Cfb Slate Does Not Exist");
 
-        // Guard: reject picks for any game that has already kicked off.
-        var startedEventIds = StartedEventIds(spreadsTask.Result, DateTimeOffset.UtcNow);
+        // Guard: reject picks for any game that has already kicked off. Matched by team name
+        // (either side) rather than an ESPN id — a team plays at most one game per slate, so
+        // Team alone unambiguously identifies which CfbSpreads row a pick belongs to.
+        var startedTeams = StartedTeams(spreadsTask.Result, DateTimeOffset.UtcNow);
 
-        // Guard: reject picks for an event we KNOW is excluded from the league (MAC Tue/Wed,
+        // Guard: reject picks for a team we KNOW is excluded from the league (MAC Tue/Wed,
         // unranked, etc. — frizat-9m0). Distinct from "no matching spread at all", which stays
         // fail-open below (e.g. an ESPN cache gap) — this only rejects positive knowledge of
         // ineligibility, not absence of data.
-        var ineligibleEventIds = spreadsTask.Result.WhereLeagueIneligible().Select(s => s.EspnEventId).ToHashSet();
+        var ineligibleTeams = spreadsTask.Result.WhereLeagueIneligible()
+            .SelectMany(s => new[] { s.HomeTeam, s.AwayTeam }).ToHashSet();
 
         foreach (var pick in request.Picks) {
-            if (startedEventIds.Contains(pick.EspnEventId))
+            if (startedTeams.Contains(pick.Team))
                 return BadRequest($"Pick rejected: {pick.Team}'s game has already kicked off.");
-            if (ineligibleEventIds.Contains(pick.EspnEventId))
+            if (ineligibleTeams.Contains(pick.Team))
                 return BadRequest($"Pick rejected: {pick.Team}'s game is not part of this league's slate.");
         }
 
         var existingPicks = existingPicksTask.Result.ToList();
         var existingKeys = existingPicks
-            .Select(p => $"{p.EspnEventId}|{p.Team}|{p.PickType}")
+            .Select(p => $"{p.Team}|{p.PickType}")
             .ToHashSet();
         var newPicks = request.Picks
-            .Where(p => !existingKeys.Contains($"{p.EspnEventId}|{p.Team}|{p.PickType}"))
+            .Where(p => !existingKeys.Contains($"{p.Team}|{p.PickType}"))
             .Select(p => new CfbPicks {
                 UserId      = userId,
                 LeagueId    = request.LeagueId,
                 CfbSlateId  = request.CfbSlateId,
-                EspnEventId = p.EspnEventId,
                 Team        = p.Team,
                 PickType    = p.PickType,
                 Season      = request.Season,
@@ -203,7 +207,6 @@ public record AddCfbPicksRequest {
 }
 
 public record CfbPickItem {
-    public int    EspnEventId { get; init; }
     public string Team        { get; init; } = string.Empty;
     public string PickType    { get; init; } = "Spread";
 }

--- a/Server/Controllers/CfbPicksController.cs
+++ b/Server/Controllers/CfbPicksController.cs
@@ -185,8 +185,8 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
 
     [HttpDelete("picks/{leagueId}/{cfbSlateId}")]
     [Authorize(Roles = AppRoles.Administrator)]
-    public async Task<IActionResult> DeletePicks(int leagueId, int cfbSlateId) {
-        await repo.DeletePicksAsync(leagueId, cfbSlateId, CurrentUserId);
+    public async Task<IActionResult> DeletePicks(int leagueId, int cfbSlateId, [FromQuery] string userId) {
+        await repo.DeletePicksAsync(leagueId, cfbSlateId, userId);
         return Ok();
     }
 

--- a/Server/Controllers/LeaderboardController.cs
+++ b/Server/Controllers/LeaderboardController.cs
@@ -1,3 +1,4 @@
+using FourPlayWebApp.Server.Auth;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models.Data;
@@ -6,6 +7,7 @@ using FourPlayWebApp.Shared.Models.Enum;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
+using System.Security.Claims;
 
 namespace FourPlayWebApp.Server.Controllers;
 [Authorize]
@@ -19,6 +21,9 @@ public class LeaderboardController(
     : ControllerBase {
     [HttpGet("leaderboard/{seasonYear:long}")]
     public async Task<ActionResult<List<LeaderboardDto>>> GetLeaderboard(int leagueId, long seasonYear) {
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        if (!User.IsInRole(AppRoles.Administrator) && !await leagueRepository.UserExistsInLeagueAsync(callerId, leagueId))
+            return Forbid();
         var scoreboard = await memoryCache.GetOrCreateAsync($"{leagueId}-{seasonYear}", async entry => {
             entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(10);
             var leagueInfo = await leagueRepository.GetLeagueInfoAsync(leagueId);

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -502,6 +502,9 @@ public class LeagueController(
     public async Task<ActionResult<BatchSpreadResponse>> GetSpreadBatch(
         int leagueId, int season, int week,
         [FromBody] BatchSpreadRequest request) {
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        if (!User.IsInRole(AppRoles.Administrator) && !await repo.UserExistsInLeagueAsync(callerId, leagueId))
+            return Forbid();
         var calculator = await spreadCalculatorBuilder
             .WithLeagueId(leagueId)
             .WithWeek(week)
@@ -533,6 +536,9 @@ public class LeagueController(
     public async Task<ActionResult<BatchSpreadCalculationResponse>> CalculateSpreadBatch(
         int leagueId, int season, int week,
         [FromBody] BatchSpreadCalculationRequest request) {
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        if (!User.IsInRole(AppRoles.Administrator) && !await repo.UserExistsInLeagueAsync(callerId, leagueId))
+            return Forbid();
         var calculator = await spreadCalculatorBuilder
             .WithLeagueId(leagueId)
             .WithWeek(week)

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -197,17 +197,19 @@ public class LeagueController(
     [ProducesResponseType(typeof(List<UserSummaryDto>), StatusCodes.Status200OK)]
     public async Task<ActionResult<List<UserSummaryDto>>> GetUsers() {
 
-        var users = await repo.GetUsersAsync(); // returns List<IdentityUser>
-        var usersOutput = new List<UserSummaryDto>();
-        foreach (var u in users) {
-            // Check if the user is in the Administrator role
-            var roles = await userManager.GetRolesAsync(u);
-            var isAdmin = roles.Contains("Administrator");
-
-            usersOutput.Add(new UserSummaryDto(u.Id, u.UserName, u.Email, u.EmailConfirmed, isAdmin));
-
-            //Console.WriteLine($"User: {u.Id}, {u.UserName}, {u.Email}, IsAdmin: {isAdmin}");
-        }
+        // Single batched role lookup instead of one GetRolesAsync call per user (N+1) — was slow
+        // enough at real user-base sizes to plausibly time out, which combined with a missing
+        // frontend error handler left Add User/Create League/Assign Owner pickers silently empty.
+        // repo.GetUsersAsync() and userManager.GetUsersInRoleAsync() use separate DbContexts
+        // (IDbContextFactory-created vs. Identity's request-scoped one), so they're safe to run
+        // concurrently rather than as two sequential round trips.
+        var usersTask = repo.GetUsersAsync();
+        var adminsTask = userManager.GetUsersInRoleAsync(AppRoles.Administrator);
+        await Task.WhenAll(usersTask, adminsTask);
+        var adminIds = adminsTask.Result.Select(u => u.Id).ToHashSet();
+        var usersOutput = usersTask.Result
+            .Select(u => new UserSummaryDto(u.Id, u.UserName, u.Email, u.EmailConfirmed, adminIds.Contains(u.Id)))
+            .ToList();
 
         return Ok(usersOutput);
     }

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -639,6 +639,18 @@ public class LeagueController(
     [ProducesResponseType(typeof(LeagueInfoDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> CreateLeague([FromBody] LeagueCreateDto dto) {
+        // Mirrors useSportContext's own host-prefix check (Client.React/src/services/sport.tsx) —
+        // the frontend locks the Sport field to the current subdomain, but a crafted/replayed
+        // request could still send a mismatched LeagueType directly without this backstop.
+        // Request.Host can't be used here: prod traffic goes through Vercel's /api/:path*
+        // rewrite to the Railway backend (see CLAUDE.md's proxy note), and there's no
+        // UseForwardedHeaders middleware, so Host reflects Railway's own domain, not
+        // cfb.ivleague.xyz — it would resolve to Nfl for every request. Origin/Referer survive
+        // the rewrite untouched and are what the existing ALLOWED_ORIGINS/CORS check already
+        // relies on for this exact same-origin-per-sport distinction.
+        var requestSport = ResolveRequestSport(Request);
+        if (dto.LeagueType != requestSport)
+            return BadRequest($"League type '{dto.LeagueType}' does not match the current site.");
         if (await repo.LeagueExistsAsync(dto.LeagueName))
             return Conflict($"A league named '{dto.LeagueName}' already exists.");
         var ownerUserId = User.IsInRole(AppRoles.Administrator)
@@ -666,6 +678,23 @@ public class LeagueController(
         });
         return Ok(new LeagueInfoDto { Id = league.Id, LeagueName = league.LeagueName, LeagueType = league.LeagueType, OwnerUserId = league.OwnerUserId, DateCreated = league.DateCreated });
     }
+
+    // Prefers Origin (sent on every state-changing fetch, including same-origin ones — see
+    // CreateLeague's comment on why Host can't be used here), falls back to Referer, and if
+    // neither header is present at all falls back to Host rather than blind-guessing Nfl.
+    private static LeagueType ResolveRequestSport(HttpRequest request) {
+        var origin = request.Headers.Origin.FirstOrDefault();
+        if (origin is not null && Uri.TryCreate(origin, UriKind.Absolute, out var originUri))
+            return HostIsCfb(originUri.Host) ? LeagueType.Cfb : LeagueType.Nfl;
+
+        var referer = request.Headers.Referer.FirstOrDefault();
+        if (referer is not null && Uri.TryCreate(referer, UriKind.Absolute, out var refererUri))
+            return HostIsCfb(refererUri.Host) ? LeagueType.Cfb : LeagueType.Nfl;
+
+        return HostIsCfb(request.Host.Host) ? LeagueType.Cfb : LeagueType.Nfl;
+    }
+
+    private static bool HostIsCfb(string host) => host.StartsWith("cfb.", StringComparison.OrdinalIgnoreCase);
 
     [HttpPut("{leagueId:int}/owner/{newOwnerUserId}")]
     [Authorize(Roles = AppRoles.Administrator)]

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -798,6 +798,30 @@ public class LeagueController(
         return NoContent();
     }
 
+    // Every FK off LeagueInfo is DB-level Cascade (see LeagueRepository.DeleteLeagueAsync) — this
+    // permanently removes the league's members, juice settings, picks (NFL + CFB), and
+    // invitations along with it. The UI requires typing the league name to confirm.
+    [HttpDelete("{leagueId:int}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteLeague(int leagueId) {
+        LeagueInfo league;
+        try {
+            league = await repo.GetLeagueInfoAsync(leagueId);
+        } catch (InvalidOperationException) {
+            // GetLeagueInfoAsync's real implementation throws (FirstAsync) rather than returning
+            // null for a missing league — realistic here specifically: a double-submitted delete
+            // (slow network, already-deleted league) should 404, not 500.
+            return NotFound();
+        }
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
+            return Forbid();
+        await repo.DeleteLeagueAsync(leagueId);
+        return NoContent();
+    }
+
     [HttpPost("{leagueId:int}/invite")]
     [ProducesResponseType(typeof(InvitationDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -14,6 +14,7 @@ using FourPlayWebApp.Shared.Models.Enum;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using System.Net.Mime;
 using System.Security.Claims;
@@ -34,7 +35,8 @@ public class LeagueController(
     UserManager<ApplicationUser> userManager,
     ISpreadCalculatorBuilder spreadCalculatorBuilder,
     IEspnCacheService espnCacheService,
-    IInvitationService invitationService) : ControllerBase {
+    IInvitationService invitationService,
+    ILeagueInviteLinkService leagueInviteLinkService) : ControllerBase {
     // Mirrors CfbPicksController.GetCurrentSlate's role for CFB — exposes NflCurrentWeekService's
     // existing off-season/pre-season fallback (already used internally by NflSpreadJob and
     // EspnCacheService) to the frontend, so nflAdapter.ts no longer falls back to
@@ -816,15 +818,60 @@ public class LeagueController(
         try {
             league = await repo.GetLeagueInfoAsync(leagueId);
         } catch (InvalidOperationException) {
-            // GetLeagueInfoAsync's real implementation throws (FirstAsync) rather than returning
-            // null for a missing league — realistic here specifically: a double-submitted delete
-            // (slow network, already-deleted league) should 404, not 500.
             return NotFound();
         }
         var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
             return Forbid();
         await repo.DeleteLeagueAsync(leagueId);
+        return NoContent();
+    }
+
+    // ── Shareable invite link ─────────────────────────────────────────────────
+
+    [HttpPost("{leagueId:int}/invite-link")]
+    [ProducesResponseType(typeof(LeagueInviteLinkDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<LeagueInviteLinkDto>> GenerateInviteLink(int leagueId) {
+        LeagueInfo league;
+        try { league = await repo.GetLeagueInfoAsync(leagueId); }
+        catch (InvalidOperationException) { return NotFound(); }
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
+            return Forbid();
+        var link = await leagueInviteLinkService.GenerateAsync(leagueId, callerId, league);
+        return Ok(new LeagueInviteLinkDto(link.Token, link.LeagueId, link.League.LeagueName, link.ExpiresAt));
+    }
+
+    [HttpGet("join/{token}")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(LeagueInviteLinkDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<LeagueInviteLinkDto>> ValidateInviteLink(string token) {
+        var link = await leagueInviteLinkService.ValidateAsync(token);
+        if (link is null) return NotFound();
+        return Ok(new LeagueInviteLinkDto(link.Token, link.LeagueId, link.League.LeagueName, link.ExpiresAt));
+    }
+
+    [HttpPost("join/{token}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> JoinViaLink(string token) {
+        var link = await leagueInviteLinkService.ValidateAsync(token);
+        if (link is null) return NotFound();
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        if (await repo.UserExistsInLeagueAsync(userId, link.LeagueId))
+            return Conflict("You are already a member of this league.");
+        try {
+            await repo.AddLeagueUserMappingAsync(new LeagueUserMapping {
+                LeagueId = link.LeagueId,
+                UserId = userId,
+                DateCreated = DateTimeOffset.UtcNow,
+            });
+        } catch (DbUpdateException) {
+            return Conflict("You are already a member of this league.");
+        }
         return NoContent();
     }
 

--- a/Server/Data/ApplicationDbContext.cs
+++ b/Server/Data/ApplicationDbContext.cs
@@ -25,6 +25,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     public DbSet<CfbSeasonWeekConfig> CfbSeasonWeekConfigs { get; set; }
     public DbSet<NflSeasonWeekConfig> NflSeasonWeekConfigs { get; set; }
     public DbSet<CfbRanking> CfbRankings { get; set; }
+    public DbSet<LeagueInviteLink> LeagueInviteLinks { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder) {
         base.OnModelCreating(modelBuilder);

--- a/Server/Data/Configurations/CfbScoresConfiguration.cs
+++ b/Server/Data/Configurations/CfbScoresConfiguration.cs
@@ -14,10 +14,10 @@ public class CfbScoresConfiguration : IEntityTypeConfiguration<CfbScores>
             .HasColumnType("timestamptz")
             .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
-        // Mirrors NflScores' unique index — backstops UpsertCfbScoresAsync's app-level
-        // upsert-by-EspnEventId the same way CfbSpreads' index backstops its upsert.
-        entity.HasIndex(e => e.EspnEventId).IsUnique();
-        entity.HasIndex(e => e.CfbSlateId);
+        // Natural key mirroring NflScoresConfiguration's (Season, NflWeek, HomeTeam) — see
+        // CfbSpreadsConfiguration's comment for the full rationale. Backstops
+        // UpsertCfbScoresAsync's app-level upsert-by-(CfbSlateId, HomeTeam).
+        entity.HasIndex(e => new { e.CfbSlateId, e.HomeTeam }).IsUnique();
 
         // CfbSlateId was previously an unenforced "soft FK" — see CfbSpreadsConfiguration for the
         // full rationale (frizat-896 schema audit). Restrict protects real final-score history from

--- a/Server/Data/Configurations/CfbSpreadsConfiguration.cs
+++ b/Server/Data/Configurations/CfbSpreadsConfiguration.cs
@@ -14,8 +14,11 @@ public class CfbSpreadsConfiguration : IEntityTypeConfiguration<CfbSpreads>
             .HasColumnType("timestamptz")
             .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
-        entity.HasIndex(e => e.EspnEventId).IsUnique();
-        entity.HasIndex(e => e.CfbSlateId);
+        // Natural key mirroring NflSpreadsConfiguration's (Season, NflWeek, HomeTeam) — a team
+        // plays at most one game per slate, so (CfbSlateId, HomeTeam) uniquely identifies a game
+        // without depending on an ESPN-specific id. CfbSlateId already encodes season via
+        // CfbSlates.Season, so a separate Season column isn't needed in this index.
+        entity.HasIndex(e => new { e.CfbSlateId, e.HomeTeam }).IsUnique();
 
         // CfbSlateId was previously an unenforced "soft FK" (indexed, joined against in queries,
         // but no DB-level constraint) — frizat-896 schema audit. Restrict (not Cascade): CfbSlates

--- a/Server/Data/LeagueCascadeDelete.cs
+++ b/Server/Data/LeagueCascadeDelete.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace FourPlayWebApp.Server.Data;
+
+/// <summary>
+/// Shared by LeagueRepository.DeleteLeagueAsync (single league, owner/admin-initiated) and
+/// DemoDataSeeder.PurgeUnknownLeaguesAsync (bulk, startup hygiene) — one place for the ordered
+/// multi-table cascade so a future FK added off LeagueInfo only needs updating here, not in two
+/// independently-drifting copies. Explicit RemoveRange rather than relying solely on the DB's own
+/// Cascade FKs, so this stays correct against providers that don't enforce them (e.g. EF Core's
+/// UseInMemoryDatabase in tests).
+/// </summary>
+internal static class LeagueCascadeDelete {
+    public static void RemoveLeaguesAndDependents(ApplicationDbContext db, IReadOnlyCollection<int> leagueIds) {
+        if (leagueIds.Count == 0) return;
+        db.NflPicks.RemoveRange(db.NflPicks.Where(p => leagueIds.Contains(p.LeagueId)));
+        db.CfbPicks.RemoveRange(db.CfbPicks.Where(p => leagueIds.Contains(p.LeagueId)));
+        db.Invitations.RemoveRange(db.Invitations.Where(i => i.LeagueId != null && leagueIds.Contains(i.LeagueId.Value)));
+        db.LeagueJuiceMapping.RemoveRange(db.LeagueJuiceMapping.Where(m => leagueIds.Contains(m.LeagueId)));
+        db.LeagueUserMapping.RemoveRange(db.LeagueUserMapping.Where(m => leagueIds.Contains(m.LeagueId)));
+        db.LeagueInfo.RemoveRange(db.LeagueInfo.Where(l => leagueIds.Contains(l.Id)));
+    }
+}

--- a/Server/Jobs/CfbRankingCaptureJob.cs
+++ b/Server/Jobs/CfbRankingCaptureJob.cs
@@ -19,7 +19,7 @@ namespace FourPlayWebApp.Server.Jobs;
 // week is more complete history, not redundant noise.
 [DisallowConcurrentExecution]
 public class CfbRankingCaptureJob(ICfbLiveScoreFetcher fetcher, ICfbRepository repo, TimeProvider timeProvider) : IJob {
-    private const int Season = 2026;
+    private static int Season => DateTime.UtcNow.Month >= 8 ? DateTime.UtcNow.Year : DateTime.UtcNow.Year - 1;
 
     public async Task Execute(IJobExecutionContext context) {
         Log.Information("CfbRankingCaptureJob: capturing CFB rankings at {Time}", DateTime.UtcNow);

--- a/Server/Jobs/CfbScoresJob.cs
+++ b/Server/Jobs/CfbScoresJob.cs
@@ -53,7 +53,6 @@ public class CfbScoresJob(ICfbLiveScoreFetcher fetcher, ICfbRepository repo) : I
 
             scores.Add(new CfbScores {
                 CfbSlateId          = slate.Id,
-                EspnEventId         = int.Parse(evt.Id),
                 HomeTeam            = home.Team.Abbreviation,
                 AwayTeam            = away.Team.Abbreviation,
                 HomeTeamScore       = (int)home.Score,

--- a/Server/Jobs/CfbScoresJob.cs
+++ b/Server/Jobs/CfbScoresJob.cs
@@ -10,7 +10,8 @@ namespace FourPlayWebApp.Server.Jobs;
 
 [DisallowConcurrentExecution]
 public class CfbScoresJob(ICfbLiveScoreFetcher fetcher, ICfbRepository repo) : IJob {
-    private const int Season = 2026;
+    // CFB seasons run Aug–Jan; the season year is the calendar year the fall games start.
+    private static int Season => DateTime.UtcNow.Month >= 8 ? DateTime.UtcNow.Year : DateTime.UtcNow.Year - 1;
 
     public async Task Execute(IJobExecutionContext context) {
         Log.Information("CfbScoresJob: fetching CFB scores at {Time}", DateTime.UtcNow);

--- a/Server/Jobs/CfbSlateSeederJob.cs
+++ b/Server/Jobs/CfbSlateSeederJob.cs
@@ -10,7 +10,7 @@ namespace FourPlayWebApp.Server.Jobs;
 // cadence, not fused into this job).
 [DisallowConcurrentExecution]
 public class CfbSlateSeederJob(ICfbRepository repo) : IJob {
-    private const int Season = 2026;
+    private static int Season => DateTime.UtcNow.Month >= 8 ? DateTime.UtcNow.Year : DateTime.UtcNow.Year - 1;
 
     // IvLeagueWeekNumber is the canonical source for SlateType within FBS Playoff weeks
     // because both CFP First Round (IV=15) and Quarterfinals (IV=16) share ScoringFormat="NFLDivisional"

--- a/Server/Jobs/CfbSpreadJob.cs
+++ b/Server/Jobs/CfbSpreadJob.cs
@@ -95,7 +95,6 @@ public class CfbSpreadJob(
 
                 spreads.Add(new CfbSpreads {
                     CfbSlateId    = slate.Id,
-                    EspnEventId   = eventId,
                     HomeTeam      = home,
                     AwayTeam      = away,
                     HomeTeamSpread = parsedHome,

--- a/Server/Migrations/20260813205213_RemoveCfbEspnEventIdUseNaturalKey.Designer.cs
+++ b/Server/Migrations/20260813205213_RemoveCfbEspnEventIdUseNaturalKey.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260813205213_RemoveCfbEspnEventIdUseNaturalKey")]
+    partial class RemoveCfbEspnEventIdUseNaturalKey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/20260813205213_RemoveCfbEspnEventIdUseNaturalKey.cs
+++ b/Server/Migrations/20260813205213_RemoveCfbEspnEventIdUseNaturalKey.cs
@@ -1,0 +1,109 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveCfbEspnEventIdUseNaturalKey : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CfbSpreads_CfbSlateId",
+                table: "CfbSpreads");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CfbSpreads_EspnEventId",
+                table: "CfbSpreads");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CfbScores_CfbSlateId",
+                table: "CfbScores");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CfbScores_EspnEventId",
+                table: "CfbScores");
+
+            migrationBuilder.DropColumn(
+                name: "EspnEventId",
+                table: "CfbSpreads");
+
+            migrationBuilder.DropColumn(
+                name: "EspnEventId",
+                table: "CfbScores");
+
+            migrationBuilder.DropColumn(
+                name: "EspnEventId",
+                table: "CfbPicks");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CfbSpreads_CfbSlateId_HomeTeam",
+                table: "CfbSpreads",
+                columns: new[] { "CfbSlateId", "HomeTeam" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CfbScores_CfbSlateId_HomeTeam",
+                table: "CfbScores",
+                columns: new[] { "CfbSlateId", "HomeTeam" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CfbSpreads_CfbSlateId_HomeTeam",
+                table: "CfbSpreads");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CfbScores_CfbSlateId_HomeTeam",
+                table: "CfbScores");
+
+            migrationBuilder.AddColumn<int>(
+                name: "EspnEventId",
+                table: "CfbSpreads",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EspnEventId",
+                table: "CfbScores",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EspnEventId",
+                table: "CfbPicks",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CfbSpreads_CfbSlateId",
+                table: "CfbSpreads",
+                column: "CfbSlateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CfbSpreads_EspnEventId",
+                table: "CfbSpreads",
+                column: "EspnEventId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CfbScores_CfbSlateId",
+                table: "CfbScores",
+                column: "CfbSlateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CfbScores_EspnEventId",
+                table: "CfbScores",
+                column: "EspnEventId",
+                unique: true);
+        }
+    }
+}

--- a/Server/Migrations/20260815155826_AddIsActiveToLeagueUserMapping.Designer.cs
+++ b/Server/Migrations/20260815155826_AddIsActiveToLeagueUserMapping.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260815155826_AddIsActiveToLeagueUserMapping")]
+    partial class AddIsActiveToLeagueUserMapping
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/20260815155826_AddIsActiveToLeagueUserMapping.cs
+++ b/Server/Migrations/20260815155826_AddIsActiveToLeagueUserMapping.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsActiveToLeagueUserMapping : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // defaultValue: true (not EF's inferred `false` for bool) — every existing
+            // LeagueUserMapping row is a currently-active member; defaulting to false would
+            // silently soft-remove every real member in every league the moment this runs.
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                table: "LeagueUserMapping",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "RemovedAt",
+                table: "LeagueUserMapping",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                table: "LeagueUserMapping");
+
+            migrationBuilder.DropColumn(
+                name: "RemovedAt",
+                table: "LeagueUserMapping");
+        }
+    }
+}

--- a/Server/Migrations/20260816153828_AddLeagueInviteLinks.Designer.cs
+++ b/Server/Migrations/20260816153828_AddLeagueInviteLinks.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260816153828_AddLeagueInviteLinks")]
+    partial class AddLeagueInviteLinks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -21,40 +24,6 @@ namespace FourPlayWebApp.Server.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
-
-            modelBuilder.Entity("FourPlayWebApp.Server.Models.Data.CfbRanking", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<DateTime>("CapturedAtUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("CuratedRank")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("EspnEventId")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("EspnWeekNumber")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("Season")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("TeamAbbreviation")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("Season", "EspnWeekNumber", "EspnEventId", "TeamAbbreviation");
-
-                    b.ToTable("CfbRankings");
-                });
 
             modelBuilder.Entity("FourPlayWebApp.Server.Models.Data.CfbSeasonWeekConfig", b =>
                 {
@@ -83,9 +52,6 @@ namespace FourPlayWebApp.Server.Migrations
                     b.Property<int>("Season")
                         .HasColumnType("integer");
 
-                    b.Property<DateTime>("SpreadLockDatetime")
-                        .HasColumnType("timestamp with time zone");
-
                     b.Property<DateOnly>("WeekEndDate")
                         .HasColumnType("date");
 
@@ -101,10 +67,6 @@ namespace FourPlayWebApp.Server.Migrations
                     b.HasIndex("Season", "EspnWeekNumber")
                         .IsUnique();
 
-                    b.HasIndex("Season", "IvLeagueWeekNumber")
-                        .IsUnique()
-                        .HasFilter("\"IvLeagueWeekNumber\" <> 99");
-
                     b.ToTable("CfbSeasonWeekConfigs");
                 });
 
@@ -117,9 +79,7 @@ namespace FourPlayWebApp.Server.Migrations
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<DateTimeOffset>("DateCreated")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamptz")
-                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateOnly>("EndDate")
                         .HasColumnType("date");
@@ -151,9 +111,6 @@ namespace FourPlayWebApp.Server.Migrations
                         .HasColumnType("date");
 
                     b.HasKey("Id");
-
-                    b.HasIndex("Season", "SlateNumber")
-                        .IsUnique();
 
                     b.ToTable("CfbSlates");
                 });
@@ -294,14 +251,8 @@ namespace FourPlayWebApp.Server.Migrations
                         .HasColumnType("timestamptz")
                         .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
-                    b.Property<bool>("IsActive")
-                        .HasColumnType("boolean");
-
                     b.Property<int>("LeagueId")
                         .HasColumnType("integer");
-
-                    b.Property<DateTimeOffset?>("RemovedAt")
-                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("UserId")
                         .IsRequired()
@@ -315,6 +266,26 @@ namespace FourPlayWebApp.Server.Migrations
                         .IsUnique();
 
                     b.ToTable("LeagueUserMapping");
+                });
+
+            modelBuilder.Entity("FourPlayWebApp.Server.Models.Data.LeagueUsers", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("Email")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("Email")
+                        .IsUnique();
+
+                    b.ToTable("LeagueUsers");
                 });
 
             modelBuilder.Entity("FourPlayWebApp.Server.Models.Data.NflPicks", b =>
@@ -382,9 +353,6 @@ namespace FourPlayWebApp.Server.Migrations
 
                     b.Property<int>("Season")
                         .HasColumnType("integer");
-
-                    b.Property<DateTime>("SpreadLockDatetime")
-                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("WeekEndDatetime")
                         .HasColumnType("timestamp with time zone");
@@ -587,17 +555,13 @@ namespace FourPlayWebApp.Server.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("Email")
-                        .IsUnique()
-                        .HasFilter("\"LeagueId\" IS NULL");
+                        .IsUnique();
 
                     b.HasIndex("InvitedByUserId");
 
                     b.HasIndex("LeagueId");
 
                     b.HasIndex("RegisteredUserId");
-
-                    b.HasIndex("Email", "LeagueId")
-                        .IsUnique();
 
                     b.ToTable("Invitations");
                 });
@@ -614,9 +578,10 @@ namespace FourPlayWebApp.Server.Migrations
                         .HasColumnType("integer");
 
                     b.Property<DateTimeOffset>("DateCreated")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamptz")
-                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("EspnEventId")
+                        .HasColumnType("integer");
 
                     b.Property<int>("LeagueId")
                         .HasColumnType("integer");
@@ -637,13 +602,6 @@ namespace FourPlayWebApp.Server.Migrations
                         .HasColumnType("text");
 
                     b.HasKey("Id");
-
-                    b.HasIndex("CfbSlateId");
-
-                    b.HasIndex("LeagueId");
-
-                    b.HasIndex("UserId", "LeagueId", "CfbSlateId", "Season", "Team", "PickType")
-                        .IsUnique();
 
                     b.ToTable("CfbPicks");
                 });
@@ -667,9 +625,10 @@ namespace FourPlayWebApp.Server.Migrations
                         .HasColumnType("integer");
 
                     b.Property<DateTimeOffset>("DateCreated")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamptz")
-                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("EspnEventId")
+                        .HasColumnType("integer");
 
                     b.Property<string>("GameStatus")
                         .IsRequired()
@@ -696,9 +655,6 @@ namespace FourPlayWebApp.Server.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("CfbSlateId", "HomeTeam")
-                        .IsUnique();
-
                     b.ToTable("CfbScores");
                 });
 
@@ -721,9 +677,10 @@ namespace FourPlayWebApp.Server.Migrations
                         .HasColumnType("integer");
 
                     b.Property<DateTimeOffset>("DateCreated")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamptz")
-                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("EspnEventId")
+                        .HasColumnType("integer");
 
                     b.Property<DateTimeOffset>("GameTime")
                         .HasColumnType("timestamp with time zone");
@@ -735,16 +692,10 @@ namespace FourPlayWebApp.Server.Migrations
                     b.Property<double>("HomeTeamSpread")
                         .HasColumnType("double precision");
 
-                    b.Property<bool>("IsLeagueEligible")
-                        .HasColumnType("boolean");
-
                     b.Property<double>("OverUnder")
                         .HasColumnType("double precision");
 
                     b.HasKey("Id");
-
-                    b.HasIndex("CfbSlateId", "HomeTeam")
-                        .IsUnique();
 
                     b.ToTable("CfbSpreads");
                 });
@@ -1016,7 +967,7 @@ namespace FourPlayWebApp.Server.Migrations
             modelBuilder.Entity("FourPlayWebApp.Server.Models.Data.LeagueUserMapping", b =>
                 {
                     b.HasOne("FourPlayWebApp.Server.Models.Data.LeagueInfo", "League")
-                        .WithMany("LeagueUserMappings")
+                        .WithMany("LeagueUsers")
                         .HasForeignKey("LeagueId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
@@ -1074,63 +1025,21 @@ namespace FourPlayWebApp.Server.Migrations
                 {
                     b.HasOne("FourPlayWebApp.Server.Models.Identity.ApplicationUser", "InvitedByUser")
                         .WithMany()
-                        .HasForeignKey("InvitedByUserId")
-                        .OnDelete(DeleteBehavior.SetNull);
+                        .HasForeignKey("InvitedByUserId");
 
                     b.HasOne("FourPlayWebApp.Server.Models.Data.LeagueInfo", "League")
                         .WithMany()
-                        .HasForeignKey("LeagueId")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey("LeagueId");
 
                     b.HasOne("FourPlayWebApp.Server.Models.Identity.ApplicationUser", "RegisteredUser")
                         .WithMany()
-                        .HasForeignKey("RegisteredUserId")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey("RegisteredUserId");
 
                     b.Navigation("InvitedByUser");
 
                     b.Navigation("League");
 
                     b.Navigation("RegisteredUser");
-                });
-
-            modelBuilder.Entity("FourPlayWebApp.Shared.Models.Data.CfbPicks", b =>
-                {
-                    b.HasOne("FourPlayWebApp.Server.Models.Data.CfbSlates", null)
-                        .WithMany()
-                        .HasForeignKey("CfbSlateId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.HasOne("FourPlayWebApp.Server.Models.Data.LeagueInfo", null)
-                        .WithMany()
-                        .HasForeignKey("LeagueId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("FourPlayWebApp.Server.Models.Identity.ApplicationUser", null)
-                        .WithMany()
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-                });
-
-            modelBuilder.Entity("FourPlayWebApp.Shared.Models.Data.CfbScores", b =>
-                {
-                    b.HasOne("FourPlayWebApp.Server.Models.Data.CfbSlates", null)
-                        .WithMany()
-                        .HasForeignKey("CfbSlateId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-                });
-
-            modelBuilder.Entity("FourPlayWebApp.Shared.Models.Data.CfbSpreads", b =>
-                {
-                    b.HasOne("FourPlayWebApp.Server.Models.Data.CfbSlates", null)
-                        .WithMany()
-                        .HasForeignKey("CfbSlateId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
@@ -1188,7 +1097,7 @@ namespace FourPlayWebApp.Server.Migrations
                 {
                     b.Navigation("LeagueJuiceMappings");
 
-                    b.Navigation("LeagueUserMappings");
+                    b.Navigation("LeagueUsers");
 
                     b.Navigation("NflPicks");
                 });

--- a/Server/Migrations/20260816153828_AddLeagueInviteLinks.cs
+++ b/Server/Migrations/20260816153828_AddLeagueInviteLinks.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLeagueInviteLinks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LeagueInviteLinks",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Token = table.Column<string>(type: "text", nullable: false),
+                    LeagueId = table.Column<int>(type: "integer", nullable: false),
+                    CreatedByUserId = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ExpiresAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    IsRevoked = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LeagueInviteLinks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_LeagueInviteLinks_AspNetUsers_CreatedByUserId",
+                        column: x => x.CreatedByUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_LeagueInviteLinks_LeagueInfo_LeagueId",
+                        column: x => x.LeagueId,
+                        principalTable: "LeagueInfo",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeagueInviteLinks_CreatedByUserId",
+                table: "LeagueInviteLinks",
+                column: "CreatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeagueInviteLinks_LeagueId",
+                table: "LeagueInviteLinks",
+                column: "LeagueId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeagueInviteLinks_Token",
+                table: "LeagueInviteLinks",
+                column: "Token",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LeagueInviteLinks");
+        }
+    }
+}

--- a/Server/Models/Data/LeagueInviteLink.cs
+++ b/Server/Models/Data/LeagueInviteLink.cs
@@ -1,0 +1,39 @@
+using FourPlayWebApp.Server.Models.Identity;
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace FourPlayWebApp.Server.Models.Data;
+
+[Index(nameof(Token), IsUnique = true)]
+public class LeagueInviteLink
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    public string Token { get; set; } = Guid.NewGuid().ToString("N");
+
+    public int LeagueId { get; set; }
+
+    [ForeignKey("LeagueId")]
+    public LeagueInfo League { get; set; } = null!;
+
+    [Required]
+    public string CreatedByUserId { get; set; } = null!;
+
+    [ForeignKey("CreatedByUserId")]
+    public ApplicationUser CreatedByUser { get; set; } = null!;
+
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public DateTimeOffset ExpiresAt { get; set; } = DateTimeOffset.UtcNow.AddHours(24);
+
+    public bool IsRevoked { get; set; }
+
+    [NotMapped]
+    public bool IsExpired => ExpiresAt < DateTimeOffset.UtcNow;
+
+    [NotMapped]
+    public bool IsValid => !IsRevoked && !IsExpired;
+}

--- a/Server/Models/Data/LeagueUserMapping.cs
+++ b/Server/Models/Data/LeagueUserMapping.cs
@@ -9,4 +9,9 @@ public class LeagueUserMapping {
     public string UserId { get; set; }
     public ApplicationUser User { get; set; } // Navigation property
     public DateTimeOffset DateCreated { get; set; } = DateTimeOffset.UtcNow;
+    // Soft-delete: a removed member keeps their row (and their pick history stays intact for
+    // audit purposes) — they're just excluded from active-membership reads. See
+    // LeagueRepository.RemoveLeagueUserMappingAsync / AddLeagueUserMappingAsync.
+    public bool IsActive { get; set; } = true;
+    public DateTimeOffset? RemovedAt { get; set; }
 }

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -247,6 +247,7 @@ builder.Services.AddCors(options =>
 });
 // Add Invitation Service
 builder.Services.AddScoped<IInvitationService, InvitationService>();
+builder.Services.AddScoped<ILeagueInviteLinkService, LeagueInviteLinkService>();
 
 builder.Services.AddScoped<ISpreadCalculatorBuilder, SpreadCalculatorBuilder>();
 builder.Services.AddSingleton<ILeaderboardService, LeaderboardService>();

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -286,29 +286,11 @@ builder.Services.AddQuartz(q => {
         .StartAt(DateBuilder.FutureDate(userManagerDelay, IntervalUnit.Second))
     );
 
-    // NFL Spreads — frizat-pxy: NflSpreadJob has no fixed trigger of its own anymore.
-    // NflSpreadSchedulerJob reads NflSeasonWeekConfig.SpreadLockDatetime and registers a precise
-    // one-time trigger per upcoming week, replacing the old Thursday-2pm/Christmas-Eve crons
-    // (superseded docs/plans/SPREAD_GRAB_PLAN.md heuristic).
-    q.ScheduleJob<NflSpreadSchedulerJob>(trigger => trigger
-        .WithIdentity("NFL Spread Scheduler Startup")
-        .WithDescription("Registers per-week NFL spread-lock triggers from NflSeasonWeekConfig")
-        .StartAt(DateBuilder.FutureDate(60, IntervalUnit.Second))
-    );
-    q.ScheduleCstCronJob<NflSpreadSchedulerJob>("NFL Spread Scheduler Daily", "Daily catch-up pass for NFL spread-lock triggers", "0 0 6 * * ?");
-
-    // NFL Scores
-    q.ScheduleCstCronJob<NflScoresJob>("NFL Scores Thu 10am", "Fetches NFL scores Thursday morning at 10am CST", "0 0 10 ? * THU");
-    q.ScheduleCstCronJob<NflScoresJob>("NFL Scores Fri 1am", "Fetches NFL scores early Friday at 1am CST", "0 0 1 ? * FRI");
-    q.ScheduleCstCronJob<NflScoresJob>("NFL Scores Sun 12:30pm", "Fetches NFL scores just before Sunday early games at 12:30pm CST", "0 30 12 ? * SUN");
-    q.ScheduleCstCronJob<NflScoresJob>("NFL Scores Sun 4:30pm", "Fetches NFL scores during Sunday late games at 4:30pm CST", "0 30 16 ? * SUN");
-    q.ScheduleCstCronJob<NflScoresJob>("NFL Scores Sun 7:40pm", "Fetches NFL scores during Sunday evening games at 7:40pm CST", "0 40 19 ? * SUN");
-    q.ScheduleCstCronJob<NflScoresJob>("NFL Scores Mon 1am", "Fetches NFL scores early Monday after SNF at 1am CST", "0 0 1 ? * MON");
-    q.ScheduleCstCronJob<NflScoresJob>("NFL Scores Tue 1am", "Fetches NFL scores early Tuesday after MNF at 1am CST", "0 0 1 ? * TUE");
-
     // CFB Slate Seeder — idempotent, runs Monday 5am CST to catch new seasons. Slate-seeding only
     // — spread-lock trigger scheduling is CfbSpreadSchedulerJob below (frizat-pxy follow-on:
     // structurally identical to NflSpreadSchedulerJob, its own cadence, not fused into this job).
+    // Registered unconditionally (like UserManagerJob) — it only manages internal slate/date
+    // structure, never pulls live scores or spreads, so it's safe in demo mode.
     q.ScheduleJob<CfbSlateSeederJob>(trigger => trigger
         .WithIdentity("CFB Slate Seeder Startup")
         .WithDescription("Seeds CFB slate dates for the current season")
@@ -316,34 +298,67 @@ builder.Services.AddQuartz(q => {
     );
     q.ScheduleCstCronJob<CfbSlateSeederJob>("CFB Slate Seeder", "Seeds CFB slate dates for the current season", "0 0 5 ? * MON");
 
-    // CFB Rankings — CFB-only, no NFL equivalent (rank/eligibility is a CFB-specific concept).
-    // Same cadence as the slate seeder: capture rankings as soon as a week's schedule is known,
-    // not gated on that week's spread lock like CfbSpreadJob's own (later) ranking capture is.
-    q.ScheduleJob<CfbRankingCaptureJob>(trigger => trigger
-        .WithIdentity("CFB Ranking Capture Startup")
-        .WithDescription("Captures CFB AP rankings as soon as each week's schedule is known")
-        .StartAt(DateBuilder.FutureDate(60, IntervalUnit.Second))
-    );
-    q.ScheduleCstCronJob<CfbRankingCaptureJob>("CFB Ranking Capture", "Captures CFB AP rankings as soon as each week's schedule is known", "0 0 5 ? * MON");
+    // frizat: every job below this line pulls LIVE data from ESPN and writes it into the same
+    // tables DemoDataSeeder owns — NflScoresJob in particular loops currentYear-2..+1, which
+    // always includes whatever season the demo seeder fictionally populates. NflScores' unique
+    // index is (Season, NflWeek, HomeTeam), not a real per-game key, so a live upsert doesn't even
+    // reliably collide with the demo's row for the "same" game if the two sources disagree on
+    // which team was home — it just adds a second, conflicting row instead. Confirmed in practice:
+    // this is exactly what corrupted the local demo DB's NFL Week 18 data and leaderboard totals
+    // over the course of a multi-day session with these crons left unguarded. None of these jobs
+    // have any reason to run against a demo dataset that's supposed to be fully and only owned by
+    // the seeder — skip all of them (both sports, symmetrically) when seeding demo data.
+    if (!seedsDemoData)
+    {
+        // NFL Spreads — frizat-pxy: NflSpreadJob has no fixed trigger of its own anymore.
+        // NflSpreadSchedulerJob reads NflSeasonWeekConfig.SpreadLockDatetime and registers a precise
+        // one-time trigger per upcoming week, replacing the old Thursday-2pm/Christmas-Eve crons
+        // (superseded docs/plans/SPREAD_GRAB_PLAN.md heuristic).
+        q.ScheduleJob<NflSpreadSchedulerJob>(trigger => trigger
+            .WithIdentity("NFL Spread Scheduler Startup")
+            .WithDescription("Registers per-week NFL spread-lock triggers from NflSeasonWeekConfig")
+            .StartAt(DateBuilder.FutureDate(60, IntervalUnit.Second))
+        );
+        q.ScheduleCstCronJob<NflSpreadSchedulerJob>("NFL Spread Scheduler Daily", "Daily catch-up pass for NFL spread-lock triggers", "0 0 6 * * ?");
 
-    // CFB Spreads — mirrors NflSpreadSchedulerJob above exactly: CfbSpreadJob has no fixed trigger
-    // of its own; CfbSpreadSchedulerJob reads CfbSeasonWeekConfig.SpreadLockDatetime and registers
-    // a precise one-time trigger per upcoming week, with data-driven catch-up for past-due weeks.
-    // Same daily cadence as NFL — previously CFB's catch-up only ran weekly (piggybacked on the
-    // slate seeder), 7x less often than NFL for no sport-specific reason.
-    q.ScheduleJob<CfbSpreadSchedulerJob>(trigger => trigger
-        .WithIdentity("CFB Spread Scheduler Startup")
-        .WithDescription("Registers per-week CFB spread-lock triggers from CfbSeasonWeekConfig")
-        .StartAt(DateBuilder.FutureDate(60, IntervalUnit.Second))
-    );
-    q.ScheduleCstCronJob<CfbSpreadSchedulerJob>("CFB Spread Scheduler Daily", "Daily catch-up pass for CFB spread-lock triggers", "0 0 6 * * ?");
+        // NFL Scores
+        q.ScheduleCstCronJob<NflScoresJob>("NFL Scores Thu 10am", "Fetches NFL scores Thursday morning at 10am CST", "0 0 10 ? * THU");
+        q.ScheduleCstCronJob<NflScoresJob>("NFL Scores Fri 1am", "Fetches NFL scores early Friday at 1am CST", "0 0 1 ? * FRI");
+        q.ScheduleCstCronJob<NflScoresJob>("NFL Scores Sun 12:30pm", "Fetches NFL scores just before Sunday early games at 12:30pm CST", "0 30 12 ? * SUN");
+        q.ScheduleCstCronJob<NflScoresJob>("NFL Scores Sun 4:30pm", "Fetches NFL scores during Sunday late games at 4:30pm CST", "0 30 16 ? * SUN");
+        q.ScheduleCstCronJob<NflScoresJob>("NFL Scores Sun 7:40pm", "Fetches NFL scores during Sunday evening games at 7:40pm CST", "0 40 19 ? * SUN");
+        q.ScheduleCstCronJob<NflScoresJob>("NFL Scores Mon 1am", "Fetches NFL scores early Monday after SNF at 1am CST", "0 0 1 ? * MON");
+        q.ScheduleCstCronJob<NflScoresJob>("NFL Scores Tue 1am", "Fetches NFL scores early Tuesday after MNF at 1am CST", "0 0 1 ? * TUE");
 
-    // CFB Scores — Saturday noon, 4pm, 8pm, midnight CST + Sunday 6am CST (covers all kickoff windows)
-    q.ScheduleCstCronJob<CfbScoresJob>("CFB Scores Sat Noon", "Fetches CFB scores at Saturday noon kickoff window", "0 0 12 ? * SAT");
-    q.ScheduleCstCronJob<CfbScoresJob>("CFB Scores Sat 4pm", "Fetches CFB scores at Saturday afternoon kickoff window", "0 0 16 ? * SAT");
-    q.ScheduleCstCronJob<CfbScoresJob>("CFB Scores Sat 8pm", "Fetches CFB scores at Saturday evening kickoff window", "0 0 20 ? * SAT");
-    q.ScheduleCstCronJob<CfbScoresJob>("CFB Scores Sat Midnight", "Fetches CFB final scores late Saturday night", "0 0 0 ? * SUN");
-    q.ScheduleCstCronJob<CfbScoresJob>("CFB Scores Sun 6am", "Fetches CFB overnight final scores Sunday morning", "0 0 6 ? * SUN");
+        // CFB Rankings — CFB-only, no NFL equivalent (rank/eligibility is a CFB-specific concept).
+        // Same cadence as the slate seeder: capture rankings as soon as a week's schedule is known,
+        // not gated on that week's spread lock like CfbSpreadJob's own (later) ranking capture is.
+        q.ScheduleJob<CfbRankingCaptureJob>(trigger => trigger
+            .WithIdentity("CFB Ranking Capture Startup")
+            .WithDescription("Captures CFB AP rankings as soon as each week's schedule is known")
+            .StartAt(DateBuilder.FutureDate(60, IntervalUnit.Second))
+        );
+        q.ScheduleCstCronJob<CfbRankingCaptureJob>("CFB Ranking Capture", "Captures CFB AP rankings as soon as each week's schedule is known", "0 0 5 ? * MON");
+
+        // CFB Spreads — mirrors NflSpreadSchedulerJob above exactly: CfbSpreadJob has no fixed trigger
+        // of its own; CfbSpreadSchedulerJob reads CfbSeasonWeekConfig.SpreadLockDatetime and registers
+        // a precise one-time trigger per upcoming week, with data-driven catch-up for past-due weeks.
+        // Same daily cadence as NFL — previously CFB's catch-up only ran weekly (piggybacked on the
+        // slate seeder), 7x less often than NFL for no sport-specific reason.
+        q.ScheduleJob<CfbSpreadSchedulerJob>(trigger => trigger
+            .WithIdentity("CFB Spread Scheduler Startup")
+            .WithDescription("Registers per-week CFB spread-lock triggers from CfbSeasonWeekConfig")
+            .StartAt(DateBuilder.FutureDate(60, IntervalUnit.Second))
+        );
+        q.ScheduleCstCronJob<CfbSpreadSchedulerJob>("CFB Spread Scheduler Daily", "Daily catch-up pass for CFB spread-lock triggers", "0 0 6 * * ?");
+
+        // CFB Scores — Saturday noon, 4pm, 8pm, midnight CST + Sunday 6am CST (covers all kickoff windows)
+        q.ScheduleCstCronJob<CfbScoresJob>("CFB Scores Sat Noon", "Fetches CFB scores at Saturday noon kickoff window", "0 0 12 ? * SAT");
+        q.ScheduleCstCronJob<CfbScoresJob>("CFB Scores Sat 4pm", "Fetches CFB scores at Saturday afternoon kickoff window", "0 0 16 ? * SAT");
+        q.ScheduleCstCronJob<CfbScoresJob>("CFB Scores Sat 8pm", "Fetches CFB scores at Saturday evening kickoff window", "0 0 20 ? * SAT");
+        q.ScheduleCstCronJob<CfbScoresJob>("CFB Scores Sat Midnight", "Fetches CFB final scores late Saturday night", "0 0 0 ? * SUN");
+        q.ScheduleCstCronJob<CfbScoresJob>("CFB Scores Sun 6am", "Fetches CFB overnight final scores Sunday morning", "0 0 6 ? * SUN");
+    }
 });
 
 

--- a/Server/Services/CfbLeaderboardService.cs
+++ b/Server/Services/CfbLeaderboardService.cs
@@ -58,10 +58,11 @@ public class CfbLeaderboardService(
         return leaderboard;
     }
 
-    private static double JuiceForSlate(int slateNumber, LeagueJuiceMapping juice) => slateNumber switch {
+    // internal so CfbLeaderboardServiceTests can verify the per-slate tease amounts directly.
+    internal static double JuiceForSlate(int slateNumber, LeagueJuiceMapping juice) => slateNumber switch {
         <= 14 => juice.Juice,
-        <= 17 => juice.JuiceDivisional,
-        _ => juice.JuiceConference,  // slates 18 (Semifinals) and 19 (Championship)
+        <= 16 => juice.JuiceDivisional,  // quarterfinals (slates 15–16)
+        _ => juice.JuiceConference,       // slate 17 Semifinals + slate 18 Championship
     };
 
     private LeaderboardWeekResults EvaluateSlate(int slateNumber, List<CfbSpreads> spreads, List<CfbScores> scores,

--- a/Server/Services/DemoDataSeeder.cs
+++ b/Server/Services/DemoDataSeeder.cs
@@ -131,15 +131,30 @@ public class DemoDataSeeder(
 
         if (strayLeagueIds.Count == 0) return;
 
-        db.NflPicks.RemoveRange(db.NflPicks.Where(p => strayLeagueIds.Contains(p.LeagueId)));
-        db.CfbPicks.RemoveRange(db.CfbPicks.Where(p => strayLeagueIds.Contains(p.LeagueId)));
-        db.Invitations.RemoveRange(db.Invitations.Where(i => i.LeagueId != null && strayLeagueIds.Contains(i.LeagueId.Value)));
-        db.LeagueJuiceMapping.RemoveRange(db.LeagueJuiceMapping.Where(m => strayLeagueIds.Contains(m.LeagueId)));
-        db.LeagueUserMapping.RemoveRange(db.LeagueUserMapping.Where(m => strayLeagueIds.Contains(m.LeagueId)));
-        db.LeagueInfo.RemoveRange(db.LeagueInfo.Where(l => strayLeagueIds.Contains(l.Id)));
+        LeagueCascadeDelete.RemoveLeaguesAndDependents(db, strayLeagueIds);
         await db.SaveChangesAsync();
 
         Log.Information("DemoDataSeeder: purged {Count} stray league(s) not created by the seeder", strayLeagueIds.Count);
+    }
+
+    // frizat: this class's own doc comment promises "Idempotent — safe to call on every startup."
+    // Before soft-delete, a removed member's row was hard-deleted, so a bare AnyAsync-then-Add
+    // self-healed on reseed. Now the row persists with IsActive=false, so every "ensure this demo
+    // member exists" call site must reactivate an existing inactive row (not just skip-if-any-row)
+    // to keep that promise once someone exercises the Remove Member feature against the demo
+    // stack — mirrors LeagueRepository.AddLeagueUserMappingAsync's reactivate-not-duplicate logic.
+    public async Task EnsureActiveLeagueMemberAsync(int leagueId, string userId)
+    {
+        var existing = await db.LeagueUserMapping
+            .FirstOrDefaultAsync(m => m.LeagueId == leagueId && m.UserId == userId);
+        if (existing is null) {
+            db.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = leagueId, UserId = userId });
+            await db.SaveChangesAsync();
+        } else if (!existing.IsActive) {
+            existing.IsActive = true;
+            existing.RemovedAt = null;
+            await db.SaveChangesAsync();
+        }
     }
 
     private async Task SeedLeagueJuiceMappingAsync(LeagueInfo? league)
@@ -349,11 +364,7 @@ public class DemoDataSeeder(
         var adminUser = await userManager.FindByEmailAsync(adminEmail);
         if (adminUser == null) return;
 
-        if (await db.LeagueUserMapping.AnyAsync(m => m.LeagueId == league.Id && m.UserId == adminUser.Id))
-            return;
-
-        db.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = league.Id, UserId = adminUser.Id });
-        await db.SaveChangesAsync();
+        await EnsureActiveLeagueMemberAsync(league.Id, adminUser.Id);
         Log.Information("DemoDataSeeder: added admin to Demo League");
     }
 
@@ -425,11 +436,7 @@ public class DemoDataSeeder(
         }
 
         // Ensure league membership
-        if (!await db.LeagueUserMapping.AnyAsync(m => m.LeagueId == league.Id && m.UserId == user.Id))
-        {
-            db.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = league.Id, UserId = user.Id });
-            await db.SaveChangesAsync();
-        }
+        await EnsureActiveLeagueMemberAsync(league.Id, user.Id);
 
         return user;
     }
@@ -975,21 +982,14 @@ public class DemoDataSeeder(
 
         var adminEmail = configuration["ADMIN_EMAIL"] ?? throw new InvalidOperationException("ADMIN_EMAIL required");
         var adminUser = await userManager.FindByEmailAsync(adminEmail);
-        if (adminUser != null && !await db.LeagueUserMapping.AnyAsync(m => m.LeagueId == league.Id && m.UserId == adminUser.Id))
-        {
-            db.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = league.Id, UserId = adminUser.Id });
-            await db.SaveChangesAsync();
-        }
+        if (adminUser != null)
+            await EnsureActiveLeagueMemberAsync(league.Id, adminUser.Id);
 
         foreach (var (_, email) in DemoUsers)
         {
             var user = await userManager.FindByEmailAsync(email);
             if (user == null) continue;
-            if (!await db.LeagueUserMapping.AnyAsync(m => m.LeagueId == league.Id && m.UserId == user.Id))
-            {
-                db.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = league.Id, UserId = user.Id });
-                await db.SaveChangesAsync();
-            }
+            await EnsureActiveLeagueMemberAsync(league.Id, user.Id);
         }
         Log.Information("DemoDataSeeder: added all demo users to CFB Demo League");
     }

--- a/Server/Services/DemoDataSeeder.cs
+++ b/Server/Services/DemoDataSeeder.cs
@@ -295,7 +295,6 @@ public class DemoDataSeeder(
 
         db.CfbSpreads.Add(new CfbSpreads {
             CfbSlateId = slate.Id,
-            EspnEventId = 401772636,
             HomeTeam = "IND",
             AwayTeam = "ATL",
             HomeTeamSpread = -3.5,
@@ -1066,7 +1065,6 @@ public class DemoDataSeeder(
         var spreads = allGames.Select(g => new CfbSpreads
         {
             CfbSlateId     = slates.First(s => s.SlateNumber == g.SlateIdx).Id,
-            EspnEventId    = g.EventId,
             HomeTeam       = g.Home,
             AwayTeam       = g.Away,
             HomeTeamSpread = g.HomeSpread,
@@ -1105,7 +1103,6 @@ public class DemoDataSeeder(
         var scores = allGames.Select(g => new CfbScores
         {
             CfbSlateId    = slates.First(s => s.SlateNumber == g.SlateIdx).Id,
-            EspnEventId   = g.EventId,
             HomeTeam      = g.Home,
             AwayTeam      = g.Away,
             HomeTeamScore = g.HomeScore,
@@ -1237,8 +1234,8 @@ public class DemoDataSeeder(
 
         var picks = new List<CfbPicks>();
 
-        void AddPick(int leagueId, string userId, int slateId, int eventId, string team) =>
-            picks.Add(new CfbPicks { UserId = userId, LeagueId = leagueId, CfbSlateId = slateId, EspnEventId = eventId, Team = team, PickType = "Spread", Season = CfbDemoSeason });
+        void AddPick(int leagueId, string userId, int slateId, string team) =>
+            picks.Add(new CfbPicks { UserId = userId, LeagueId = leagueId, CfbSlateId = slateId, Team = team, PickType = "Spread", Season = CfbDemoSeason });
 
         // frizat: Over/Under is an alternate PICK TYPE for a game, not an additional pick beyond
         // the slate's required count — CfbPicksController's server-side validation enforces total
@@ -1248,16 +1245,16 @@ public class DemoDataSeeder(
         // requiredPicks+1 total picks, which no real submission could ever produce (confirmed via
         // direct DB query: Bob had 4 rows for a 3-required-pick week). Bob/Dana's O/U pick now
         // replaces their game-0 spread pick instead of adding to it.
-        void AddFirstPickOrOverUnder(string uName, string userId, int slateId, int eventId, string homeTeam, string pickedTeam) {
+        void AddFirstPickOrOverUnder(string uName, string userId, int slateId, string homeTeam, string pickedTeam) {
             if (uName == "Bob") {
-                picks.Add(new CfbPicks { UserId = userId, LeagueId = league.Id, CfbSlateId = slateId, EspnEventId = eventId, Team = homeTeam, PickType = "Over", Season = CfbDemoSeason });
+                picks.Add(new CfbPicks { UserId = userId, LeagueId = league.Id, CfbSlateId = slateId, Team = homeTeam, PickType = "Over", Season = CfbDemoSeason });
                 return;
             }
             if (uName == "Dana") {
-                picks.Add(new CfbPicks { UserId = userId, LeagueId = league.Id, CfbSlateId = slateId, EspnEventId = eventId, Team = homeTeam, PickType = "Under", Season = CfbDemoSeason });
+                picks.Add(new CfbPicks { UserId = userId, LeagueId = league.Id, CfbSlateId = slateId, Team = homeTeam, PickType = "Under", Season = CfbDemoSeason });
                 return;
             }
-            AddPick(league.Id, userId, slateId, eventId, pickedTeam);
+            AddPick(league.Id, userId, slateId, pickedTeam);
         }
 
         var seedUsernames = DemoUsers.Select(d => d.Username).Append("frizat");
@@ -1278,14 +1275,14 @@ public class DemoDataSeeder(
                 {
                     if (slates.FirstOrDefault(s => s.SlateNumber == slateNum) is not { } slate) continue;
                     for (int i = 0; i < Math.Min(rsPattern.Length, gamesArr.Length); i++)
-                        AddPick(league.Id, user.Id, slate.Id, gamesArr[i].EventId, rsPattern[i] ? gamesArr[i].Home : gamesArr[i].Away);
+                        AddPick(league.Id, user.Id, slate.Id, rsPattern[i] ? gamesArr[i].Home : gamesArr[i].Away);
                 }
             }
 
             // Week 8: 4 picks from 6 games
             if (CfbWeek8Picks.TryGetValue(username, out var w8) && slates.FirstOrDefault(s => s.SlateNumber == 8) is { } slate8)
                 for (int i = 0; i < Math.Min(w8.Length, Week8Games.Length); i++)
-                    AddPick(league.Id, user.Id, slate8.Id, Week8Games[i].EventId, w8[i] ? Week8Games[i].Home : Week8Games[i].Away);
+                    AddPick(league.Id, user.Id, slate8.Id, w8[i] ? Week8Games[i].Home : Week8Games[i].Away);
 
             // Regular season slates 9-13: 4 picks each
             if (CfbRegularSeasonPickPattern.TryGetValue(username, out var rsPattern2))
@@ -1299,7 +1296,7 @@ public class DemoDataSeeder(
                 {
                     if (slates.FirstOrDefault(s => s.SlateNumber == slateNum) is not { } slate) continue;
                     for (int i = 0; i < Math.Min(rsPattern2.Length, gamesArr.Length); i++)
-                        AddPick(league.Id, user.Id, slate.Id, gamesArr[i].EventId, rsPattern2[i] ? gamesArr[i].Home : gamesArr[i].Away);
+                        AddPick(league.Id, user.Id, slate.Id, rsPattern2[i] ? gamesArr[i].Home : gamesArr[i].Away);
                 }
             }
 
@@ -1308,8 +1305,8 @@ public class DemoDataSeeder(
             {
                 for (int i = 0; i < Math.Min(confPattern.Length, Slate15Games.Length); i++) {
                     var team = confPattern[i] ? Slate15Games[i].Home : Slate15Games[i].Away;
-                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slate14Champ.Id, Slate15Games[0].EventId, Slate15Games[0].Home, team);
-                    else AddPick(league.Id, user.Id, slate14Champ.Id, Slate15Games[i].EventId, team);
+                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slate14Champ.Id, Slate15Games[0].Home, team);
+                    else AddPick(league.Id, user.Id, slate14Champ.Id, team);
                 }
             }
 
@@ -1319,8 +1316,8 @@ public class DemoDataSeeder(
                 var fr15Games = CfpGames.Where(g => g.SlateIdx == 15).ToArray();
                 for (int i = 0; i < Math.Min(fr15Pattern.Length, fr15Games.Length); i++) {
                     var team = fr15Pattern[i] ? fr15Games[i].Home : fr15Games[i].Away;
-                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slate15.Id, fr15Games[0].EventId, fr15Games[0].Home, team);
-                    else AddPick(league.Id, user.Id, slate15.Id, fr15Games[i].EventId, team);
+                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slate15.Id, fr15Games[0].Home, team);
+                    else AddPick(league.Id, user.Id, slate15.Id, team);
                 }
             }
 
@@ -1330,8 +1327,8 @@ public class DemoDataSeeder(
                 var qfGames = CfpGames.Where(g => g.SlateIdx == 16).ToArray();
                 for (int i = 0; i < Math.Min(qf.Length, qfGames.Length); i++) {
                     var team = qf[i] ? qfGames[i].Home : qfGames[i].Away;
-                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slateQf.Id, qfGames[0].EventId, qfGames[0].Home, team);
-                    else AddPick(league.Id, user.Id, slateQf.Id, qfGames[i].EventId, team);
+                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slateQf.Id, qfGames[0].Home, team);
+                    else AddPick(league.Id, user.Id, slateQf.Id, team);
                 }
             }
 
@@ -1341,8 +1338,8 @@ public class DemoDataSeeder(
                 var sfGames = CfpGames.Where(g => g.SlateIdx == 17).ToArray();
                 for (int i = 0; i < Math.Min(sf.Length, sfGames.Length); i++) {
                     var team = sf[i] ? sfGames[i].Home : sfGames[i].Away;
-                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slateSf.Id, sfGames[0].EventId, sfGames[0].Home, team);
-                    else AddPick(league.Id, user.Id, slateSf.Id, sfGames[i].EventId, team);
+                    if (i == 0) AddFirstPickOrOverUnder(username, user.Id, slateSf.Id, sfGames[0].Home, team);
+                    else AddPick(league.Id, user.Id, slateSf.Id, team);
                 }
             }
 
@@ -1352,7 +1349,7 @@ public class DemoDataSeeder(
                 var finalGame = CfpGames.First(g => g.SlateIdx == 18);
                 if (CfbFinalPicks.TryGetValue(username, out var final)) {
                     var team = final ? finalGame.Home : finalGame.Away;
-                    AddFirstPickOrOverUnder(username, user.Id, slateFinal.Id, finalGame.EventId, finalGame.Home, team);
+                    AddFirstPickOrOverUnder(username, user.Id, slateFinal.Id, finalGame.Home, team);
                 }
             }
         }

--- a/Server/Services/GoogleEmailSender.cs
+++ b/Server/Services/GoogleEmailSender.cs
@@ -3,127 +3,136 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.Extensions.Logging;
 using System.Net;
-using System.Net.Mail;
+using System.Net.Http.Headers;
 using System.Text;
+using System.Text.Json;
 
 namespace FourPlayWebApp.Server.Services;
 
-public class GoogleEmailSender(ILogger<GoogleEmailSender> logger) : IEmailSender<ApplicationUser>, IEmailSender {
-    private const string _smtpHost = "smtp.gmail.com";
-    private const int _smtpPort = 587;
-    // Require environment variables with no hardcoded fallbacks
-    private readonly string? _userName = Environment.GetEnvironmentVariable("FOURPLAY_EMAIL_USER");
-    private readonly string? _password = Environment.GetEnvironmentVariable("FOURPLAY_EMAIL_PASS");
+public class GoogleEmailSender(ILogger<GoogleEmailSender> logger, IHttpClientFactory httpClientFactory)
+    : IEmailSender<ApplicationUser>, IEmailSender {
+
+    private readonly string? _fromEmail    = Environment.GetEnvironmentVariable("FOURPLAY_EMAIL_USER");
+    private readonly string? _clientId     = Environment.GetEnvironmentVariable("GOOGLE_CLIENT_ID");
+    private readonly string? _clientSecret = Environment.GetEnvironmentVariable("GOOGLE_CLIENT_SECRET");
+    private readonly string? _refreshToken = Environment.GetEnvironmentVariable("GOOGLE_REFRESH_TOKEN");
 
     #region Public Email Sender Methods
 
     public async Task SendEmailAsync(string toEmail, string subject, string htmlBody) {
-        // Guard: fail fast and log if credentials aren't configured
-        if (string.IsNullOrWhiteSpace(_userName) || string.IsNullOrWhiteSpace(_password)) {
-            logger.LogError("Email credentials are not configured. Please set FOURPLAY_EMAIL_USER and FOURPLAY_EMAIL_PASS environment variables.");
-            return; // don't throw here; startup validation will enforce presence earlier
+        if (string.IsNullOrWhiteSpace(_fromEmail) || string.IsNullOrWhiteSpace(_clientId)
+            || string.IsNullOrWhiteSpace(_clientSecret) || string.IsNullOrWhiteSpace(_refreshToken)) {
+            logger.LogError("Gmail API credentials not configured. Set FOURPLAY_EMAIL_USER, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REFRESH_TOKEN.");
+            return;
         }
 
         try {
-            using var message = new MailMessage {
-                From = new MailAddress(_userName, "IV League"),
-                Subject = subject,
-                Body = htmlBody,
-                IsBodyHtml = true
-            };
-
-            message.To.Add(toEmail);
-
-            using var smtpClient = new SmtpClient(_smtpHost, _smtpPort) {
-                Credentials = new NetworkCredential(_userName, _password),
-                EnableSsl = true
-            };
-
-            // Railway's HTTP proxy kills connections after ~2 min; cap SMTP at 15s so we return
-            // a proper error response instead of hanging until the proxy tears the connection.
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
-            await smtpClient.SendMailAsync(message, cts.Token);
-            logger.LogInformation("\u2705 Email sent to {Email} ({Subject})", toEmail, subject);
-        }
-        catch (Exception ex) {
-            logger.LogError(ex, "\u274c Failed to send email to {Email} ({Subject})", toEmail, subject);
+            var accessToken = await GetAccessTokenAsync();
+            await SendViaGmailApiAsync(toEmail, subject, htmlBody, accessToken);
+            logger.LogInformation("✅ Email sent to {Email} ({Subject})", toEmail, subject);
+        } catch (Exception ex) {
+            logger.LogError(ex, "❌ Failed to send email to {Email} ({Subject})", toEmail, subject);
         }
     }
 
-    public Task SendConfirmationLinkAsync(ApplicationUser user, string email, string confirmationLink) {
-        var body = BuildEmailTemplate(
-            title: "Confirm Your Email",
-            message: $"""
-                      <p>Hello <strong>{user.UserName}</strong>,</p>
-                      <p>Thanks for signing up! Please confirm your email address by clicking the button below.</p>
-                      <div style="text-align:center;margin:24px 0;">
-                        <a href="{confirmationLink}" style="display:inline-block;background-color:#4f46e5;color:#fff;text-decoration:none;padding:14px 30px;border-radius:6px;font-weight:bold;">
-                          Confirm Email
-                        </a>
-                      </div>
-                      <p>If you didn\u2019t create an account, you can safely ignore this message.</p>
-                      """);
+    public Task SendConfirmationLinkAsync(ApplicationUser user, string email, string confirmationLink) =>
+        SendEmailAsync(email, "Confirm your IV League email", BuildEmailTemplate(
+            "Confirm Your Email",
+            $"""
+             <p>Hello <strong>{user.UserName}</strong>,</p>
+             <p>Thanks for signing up! Please confirm your email address by clicking the button below.</p>
+             <div style="text-align:center;margin:24px 0;">
+               <a href="{confirmationLink}" style="display:inline-block;background-color:#4f46e5;color:#fff;text-decoration:none;padding:14px 30px;border-radius:6px;font-weight:bold;">
+                 Confirm Email
+               </a>
+             </div>
+             <p>If you didn't create an account, you can safely ignore this message.</p>
+             """));
 
-        return SendEmailAsync(email, "Confirm your IV League email", body);
-    }
+    public Task SendPasswordResetLinkAsync(ApplicationUser user, string email, string resetLink) =>
+        SendEmailAsync(email, "Reset your IV League password", BuildEmailTemplate(
+            "Reset Your Password",
+            $"""
+             <p>Hello <strong>{user.UserName}</strong>,</p>
+             <p>You recently requested to reset your password.</p>
+             <p>Click the button below to create a new password:</p>
+             <div style="text-align:center;margin:24px 0;">
+               <a href="{resetLink}" style="display:inline-block;background-color:#4f46e5;color:#ffffff;text-decoration:none;padding:14px 30px;border-radius:6px;font-weight:bold;">
+                 Reset Password
+               </a>
+             </div>
+             <p>If you didn't request this change, you can safely ignore this email.</p>
+             """));
 
-    public Task SendPasswordResetLinkAsync(ApplicationUser user, string email, string resetLink) {
-        var body = BuildEmailTemplate(
-            title: "Reset Your Password",
-            message: $"""
-                      <p>Hello <strong>{user.UserName}</strong>,</p>
-                      <p>You recently requested to reset your password.</p>
-                      <p>Click the button below to create a new password:</p>
-                      <div style="text-align:center;margin:24px 0;">
-                        <a href="{resetLink}" style="display:inline-block;background-color:#4f46e5;color:#ffffff;text-decoration:none;padding:14px 30px;border-radius:6px;font-weight:bold;">
-                          Reset Password
-                        </a>
-                      </div>
-                      <p>If you didn’t request this change, you can safely ignore this email.</p>
-                      """);
+    public async Task SendPasswordResetCodeAsync(ApplicationUser user, string email, string resetCode) =>
+        await SendEmailAsync(email, "Your IV League password reset code", BuildEmailTemplate(
+            "Your Password Reset Code",
+            $"""
+             <p>Hello <strong>{user.UserName}</strong>,</p>
+             <p>You recently requested to reset your password.</p>
+             <p>Use the following code to complete your password reset:</p>
+             <div style="text-align:center;margin:30px 0;">
+               <div style="display:inline-block;background-color:#4f46e5;color:#ffffff;font-size:24px;font-weight:bold;letter-spacing:3px;padding:14px 28px;border-radius:6px;">
+                 {WebUtility.HtmlEncode(resetCode)}
+               </div>
+             </div>
+             <p>If you didn't request this change, you can safely ignore this email.</p>
+             """));
 
-        return SendEmailAsync(email, "Reset your IV League password", body);
-    }
-
-    public async Task SendPasswordResetCodeAsync(ApplicationUser user, string email, string resetCode) {
-        var body = BuildEmailTemplate(
-            title: "Your Password Reset Code",
-            message: $"""
-                      <p>Hello <strong>{user.UserName}</strong>,</p>
-                      <p>You recently requested to reset your password.</p>
-                      <p>Use the following code to complete your password reset:</p>
-                      <div style="text-align:center;margin:30px 0;">
-                        <div style="display:inline-block;background-color:#4f46e5;color:#ffffff;font-size:24px;font-weight:bold;letter-spacing:3px;padding:14px 28px;border-radius:6px;">
-                          {WebUtility.HtmlEncode(resetCode)}
-                        </div>
-                      </div>
-                      <p>If you didn’t request this change, you can safely ignore this email.</p>
-                      """);
-
-        await SendEmailAsync(email, "Your IV League password reset code", body);
-    }
-
-    /// <summary>
-    /// Send a simple templated notification using the IV League template.
-    /// Accepts an optional ApplicationUser to personalize the message, but is not required.
-    /// </summary>
     public Task SendTemplatedMessageAsync(ApplicationUser? user, string email, string title, string message) {
-        // If we have a user, personalize the message with their username where applicable
-        var personalizedMessage = user is null ? message : $"<p>Hello <strong>{WebUtility.HtmlEncode(user.UserName)}</strong>,</p>\n" + message;
-        var body = BuildEmailTemplate(title: title, message: personalizedMessage);
-        return SendEmailAsync(email, title, body);
+        var personalizedMessage = user is null ? message
+            : $"<p>Hello <strong>{WebUtility.HtmlEncode(user.UserName)}</strong>,</p>\n" + message;
+        return SendEmailAsync(email, title, BuildEmailTemplate(title, personalizedMessage));
     }
 
     #endregion
 
-    #region Private Template Helpers
+    #region Gmail API
 
-    /// <summary>
-    /// Builds a unified IV League email layout with consistent design.
-    /// </summary>
-    private static string BuildEmailTemplate(string title, string message) {
-        var sb = new StringBuilder();
-        sb.Append($"""
+    private async Task<string> GetAccessTokenAsync() {
+        var http = httpClientFactory.CreateClient();
+        var resp = await http.PostAsync("https://oauth2.googleapis.com/token",
+            new FormUrlEncodedContent(new Dictionary<string, string> {
+                ["client_id"]     = _clientId!,
+                ["client_secret"] = _clientSecret!,
+                ["refresh_token"] = _refreshToken!,
+                ["grant_type"]    = "refresh_token",
+            }));
+        resp.EnsureSuccessStatusCode();
+        var json = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        return json.RootElement.GetProperty("access_token").GetString()
+            ?? throw new InvalidOperationException("No access_token in response");
+    }
+
+    private async Task SendViaGmailApiAsync(string toEmail, string subject, string htmlBody, string accessToken) {
+        // RFC 2822 MIME message — Gmail API requires base64url encoding of the raw message
+        var mime = new StringBuilder();
+        mime.AppendLine($"From: IV League <{_fromEmail}>");
+        mime.AppendLine($"To: {toEmail}");
+        mime.AppendLine($"Subject: {subject}");
+        mime.AppendLine("MIME-Version: 1.0");
+        mime.AppendLine("Content-Type: text/html; charset=utf-8");
+        mime.AppendLine();
+        mime.Append(htmlBody);
+
+        var raw = Convert.ToBase64String(Encoding.UTF8.GetBytes(mime.ToString()))
+            .Replace('+', '-').Replace('/', '_').TrimEnd('='); // base64url
+
+        var http = httpClientFactory.CreateClient();
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        var payload = JsonSerializer.Serialize(new { raw });
+        var resp = await http.PostAsync(
+            "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+        resp.EnsureSuccessStatusCode();
+    }
+
+    #endregion
+
+    #region Template
+
+    private static string BuildEmailTemplate(string title, string message) => $"""
         <!DOCTYPE html>
         <html>
         <head>
@@ -158,14 +167,8 @@ public class GoogleEmailSender(ILogger<GoogleEmailSender> logger) : IEmailSender
           </table>
         </body>
         </html>
-        """);
+        """;
 
-        return sb.ToString();
-    }
-
-    /// <summary>
-    /// Public wrapper for external callers that want the IV League HTML-wrapped body.
-    /// </summary>
     public static string CreateTemplatedBody(string title, string message) => BuildEmailTemplate(title, message);
 
     #endregion

--- a/Server/Services/GoogleEmailSender.cs
+++ b/Server/Services/GoogleEmailSender.cs
@@ -39,7 +39,10 @@ public class GoogleEmailSender(ILogger<GoogleEmailSender> logger) : IEmailSender
                 EnableSsl = true
             };
 
-            await smtpClient.SendMailAsync(message);
+            // Railway's HTTP proxy kills connections after ~2 min; cap SMTP at 15s so we return
+            // a proper error response instead of hanging until the proxy tears the connection.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            await smtpClient.SendMailAsync(message, cts.Token);
             logger.LogInformation("\u2705 Email sent to {Email} ({Subject})", toEmail, subject);
         }
         catch (Exception ex) {

--- a/Server/Services/Interfaces/ILeagueInviteLinkService.cs
+++ b/Server/Services/Interfaces/ILeagueInviteLinkService.cs
@@ -1,0 +1,9 @@
+using FourPlayWebApp.Server.Models.Data;
+
+namespace FourPlayWebApp.Server.Services.Interfaces;
+
+public interface ILeagueInviteLinkService
+{
+    Task<LeagueInviteLink> GenerateAsync(int leagueId, string createdByUserId, LeagueInfo league);
+    Task<LeagueInviteLink?> ValidateAsync(string token);
+}

--- a/Server/Services/LeagueInviteLinkService.cs
+++ b/Server/Services/LeagueInviteLinkService.cs
@@ -1,0 +1,40 @@
+using FourPlayWebApp.Server.Data;
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace FourPlayWebApp.Server.Services;
+
+public class LeagueInviteLinkService(IDbContextFactory<ApplicationDbContext> dbContextFactory)
+    : ILeagueInviteLinkService
+{
+    public async Task<LeagueInviteLink> GenerateAsync(int leagueId, string createdByUserId, LeagueInfo league)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+
+        await db.LeagueInviteLinks
+            .Where(l => l.LeagueId == leagueId && !l.IsRevoked)
+            .ExecuteUpdateAsync(s => s.SetProperty(l => l.IsRevoked, true));
+
+        var link = new LeagueInviteLink
+        {
+            LeagueId = leagueId,
+            CreatedByUserId = createdByUserId,
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(24),
+            League = league,
+        };
+        db.LeagueInviteLinks.Add(link);
+        await db.SaveChangesAsync();
+
+        return link;
+    }
+
+    public async Task<LeagueInviteLink?> ValidateAsync(string token)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+        return await db.LeagueInviteLinks
+            .Include(l => l.League)
+            .Where(l => !l.IsRevoked && l.ExpiresAt > DateTimeOffset.UtcNow)
+            .FirstOrDefaultAsync(l => l.Token == token);
+    }
+}

--- a/Server/Services/Repositories/CfbPicksRepository.cs
+++ b/Server/Services/Repositories/CfbPicksRepository.cs
@@ -24,7 +24,6 @@ public class CfbPicksRepository(IDbContextFactory<ApplicationDbContext> dbFactor
                 UserName   = u.UserName ?? string.Empty,
                 LeagueId   = p.LeagueId,
                 CfbSlateId = p.CfbSlateId,
-                EspnEventId = p.EspnEventId,
                 Team       = p.Team,
                 PickType   = p.PickType,
                 Season     = p.Season,

--- a/Server/Services/Repositories/CfbRepository.cs
+++ b/Server/Services/Repositories/CfbRepository.cs
@@ -54,17 +54,15 @@ public class CfbRepository(IDbContextFactory<ApplicationDbContext> dbFactory) : 
     public async Task UpsertAsync(IEnumerable<CfbSpreads> spreads) {
         await using var db = await dbFactory.CreateDbContextAsync();
         var spreadList = spreads.ToList();
-        var ids = spreadList.Select(s => s.EspnEventId).ToHashSet();
+        var slateIds = spreadList.Select(s => s.CfbSlateId).ToHashSet();
         var existingMap = await db.CfbSpreads
-            .Where(s => ids.Contains(s.EspnEventId))
-            .ToDictionaryAsync(s => s.EspnEventId);
+            .Where(s => slateIds.Contains(s.CfbSlateId))
+            .ToDictionaryAsync(s => (s.CfbSlateId, s.HomeTeam));
 
         foreach (var spread in spreadList) {
-            if (!existingMap.TryGetValue(spread.EspnEventId, out var existing))
+            if (!existingMap.TryGetValue((spread.CfbSlateId, spread.HomeTeam), out var existing))
                 db.CfbSpreads.Add(spread);
             else {
-                existing.CfbSlateId       = spread.CfbSlateId;
-                existing.HomeTeam         = spread.HomeTeam;
                 existing.AwayTeam         = spread.AwayTeam;
                 existing.HomeTeamSpread   = spread.HomeTeamSpread;
                 existing.AwayTeamSpread   = spread.AwayTeamSpread;
@@ -126,13 +124,13 @@ public class CfbRepository(IDbContextFactory<ApplicationDbContext> dbFactory) : 
     public async Task UpsertCfbScoresAsync(IEnumerable<CfbScores> scores) {
         await using var db = await dbFactory.CreateDbContextAsync();
         var scoreList = scores.ToList();
-        var ids = scoreList.Select(s => s.EspnEventId).ToHashSet();
+        var slateIds = scoreList.Select(s => s.CfbSlateId).ToHashSet();
         var existingMap = await db.CfbScores
-            .Where(s => ids.Contains(s.EspnEventId))
-            .ToDictionaryAsync(s => s.EspnEventId);
+            .Where(s => slateIds.Contains(s.CfbSlateId))
+            .ToDictionaryAsync(s => (s.CfbSlateId, s.HomeTeam));
 
         foreach (var score in scoreList) {
-            if (!existingMap.TryGetValue(score.EspnEventId, out var existing))
+            if (!existingMap.TryGetValue((score.CfbSlateId, score.HomeTeam), out var existing))
                 db.CfbScores.Add(score);
             else {
                 existing.HomeTeamScore       = score.HomeTeamScore;

--- a/Server/Services/Repositories/Interfaces/ILeagueRepository.cs
+++ b/Server/Services/Repositories/Interfaces/ILeagueRepository.cs
@@ -38,6 +38,7 @@ public interface ILeagueRepository : ISpreadRepository<NflSpreads> {
     Task UpdateLeagueJuiceMappingAsync(LeagueJuiceMapping mapping);
     Task RemoveLeagueUserMappingAsync(int leagueId, string userId);
     Task<int> GetLeagueMemberCountAsync(int leagueId);
+    Task DeleteLeagueAsync(int leagueId);
 
     // Add operations
     Task AddLeagueUserMappingAsync(LeagueUserMapping mapping);

--- a/Server/Services/Repositories/LeagueRepository.cs
+++ b/Server/Services/Repositories/LeagueRepository.cs
@@ -12,7 +12,7 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
     public async Task<List<LeagueUserMapping>> GetLeagueUserMappingsAsync(int leagueId) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
         return await db.LeagueUserMapping
-            .Where(lum => lum.LeagueId == leagueId)
+            .Where(lum => lum.LeagueId == leagueId && lum.IsActive)
             .Include(lum => lum.User)
             .Include(lum => lum.League)
             .ToListAsync();
@@ -21,7 +21,7 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
     public async Task<List<LeagueUserMapping>> GetLeagueUserMappingsAsync(ApplicationUser user) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
         return await db.LeagueUserMapping
-            .Where(lum => lum.UserId == user.Id)
+            .Where(lum => lum.UserId == user.Id && lum.IsActive)
             .Include(lum => lum.User)
             .Include(lum => lum.League)
             .ToListAsync();
@@ -260,25 +260,46 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
         await db.SaveChangesAsync();
     }
 
+    // Soft-delete — keeps the row (and the member's pick history) for audit purposes, just
+    // excluded from active-membership reads (see the IsActive filters throughout this class).
     public async Task RemoveLeagueUserMappingAsync(int leagueId, string userId) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
         var mapping = await db.LeagueUserMapping
             .FirstOrDefaultAsync(m => m.LeagueId == leagueId && m.UserId == userId);
         if (mapping is not null) {
-            db.LeagueUserMapping.Remove(mapping);
+            mapping.IsActive = false;
+            mapping.RemovedAt = DateTimeOffset.UtcNow;
             await db.SaveChangesAsync();
         }
     }
 
+    // Shared with DemoDataSeeder.PurgeUnknownLeaguesAsync via LeagueCascadeDelete — one place for
+    // the ordered multi-table cascade instead of two independently-drifting copies.
+    public async Task DeleteLeagueAsync(int leagueId) {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+        LeagueCascadeDelete.RemoveLeaguesAndDependents(db, [leagueId]);
+        await db.SaveChangesAsync();
+    }
+
     public async Task<int> GetLeagueMemberCountAsync(int leagueId) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
-        return await db.LeagueUserMapping.CountAsync(m => m.LeagueId == leagueId);
+        return await db.LeagueUserMapping.CountAsync(m => m.LeagueId == leagueId && m.IsActive);
     }
 
     // Add operations
+    // (LeagueId, UserId) is unique — a removed-then-re-added user must reactivate their existing
+    // (soft-deleted) row rather than insert a second one, or this throws a unique-index violation
+    // against real Postgres. Preserves the original DateCreated (join date), not a re-join date.
     public async Task AddLeagueUserMappingAsync(LeagueUserMapping mapping) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
-        await db.LeagueUserMapping.AddAsync(mapping);
+        var existing = await db.LeagueUserMapping
+            .FirstOrDefaultAsync(m => m.LeagueId == mapping.LeagueId && m.UserId == mapping.UserId);
+        if (existing is not null) {
+            existing.IsActive = true;
+            existing.RemovedAt = null;
+        } else {
+            await db.LeagueUserMapping.AddAsync(mapping);
+        }
         await db.SaveChangesAsync();
     }
 
@@ -349,6 +370,6 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
     public async Task<bool> UserExistsInLeagueAsync(string userId, int leagueId) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
         return await db.LeagueUserMapping
-            .AnyAsync(lum => lum.UserId == userId && lum.LeagueId == leagueId);
+            .AnyAsync(lum => lum.UserId == userId && lum.LeagueId == leagueId && lum.IsActive);
     }
 }

--- a/Shared/Models/Data/CfbPicks.cs
+++ b/Shared/Models/Data/CfbPicks.cs
@@ -10,7 +10,6 @@ public class CfbPicks {
     public string UserId { get; set; } = string.Empty;
     public int LeagueId { get; set; }
     public int CfbSlateId { get; set; }
-    public int EspnEventId { get; set; }
     public string Team { get; set; } = string.Empty;
     public string PickType { get; set; } = "Spread"; // "Spread" | "Over" | "Under"
     public int Season { get; set; }

--- a/Shared/Models/Data/CfbScores.cs
+++ b/Shared/Models/Data/CfbScores.cs
@@ -8,7 +8,6 @@ public class CfbScores {
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public int Id { get; set; }
     public int CfbSlateId { get; set; }
-    public int EspnEventId { get; set; }
     public string HomeTeam { get; set; } = string.Empty;
     public string AwayTeam { get; set; } = string.Empty;
     public int HomeTeamScore { get; set; }

--- a/Shared/Models/Data/CfbSpreads.cs
+++ b/Shared/Models/Data/CfbSpreads.cs
@@ -8,7 +8,6 @@ public class CfbSpreads {
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public int Id { get; set; }
     public int CfbSlateId { get; set; }
-    public int EspnEventId { get; set; }
     public string HomeTeam { get; set; } = string.Empty;
     public string AwayTeam { get; set; } = string.Empty;
     public double HomeTeamSpread { get; set; }

--- a/Shared/Models/Data/Dtos/CfbPickDto.cs
+++ b/Shared/Models/Data/Dtos/CfbPickDto.cs
@@ -6,7 +6,6 @@ public class CfbPickDto {
     public string UserName { get; set; } = string.Empty;
     public int LeagueId { get; set; }
     public int CfbSlateId { get; set; }
-    public int EspnEventId { get; set; }
     public string Team { get; set; } = string.Empty;
     public string PickType { get; set; } = "Spread";
     public int Season { get; set; }

--- a/Shared/Models/Data/Dtos/CfbScoreDto.cs
+++ b/Shared/Models/Data/Dtos/CfbScoreDto.cs
@@ -3,7 +3,6 @@ namespace FourPlayWebApp.Shared.Models.Data.Dtos;
 public class CfbScoreDto {
     public int    Id             { get; set; }
     public int    CfbSlateId     { get; set; }
-    public int    EspnEventId    { get; set; }
     public string HomeTeam       { get; set; } = string.Empty;
     public string AwayTeam       { get; set; } = string.Empty;
     public int    HomeTeamScore  { get; set; }

--- a/Shared/Models/Data/Dtos/LeagueInviteLinkDto.cs
+++ b/Shared/Models/Data/Dtos/LeagueInviteLinkDto.cs
@@ -1,0 +1,8 @@
+namespace FourPlayWebApp.Shared.Models.Data.Dtos;
+
+public record LeagueInviteLinkDto(
+    string Token,
+    int LeagueId,
+    string LeagueName,
+    DateTimeOffset ExpiresAt
+);


### PR DESCRIPTION
## Summary
- **Email fix**: switched from SMTP (blocked on Railway Hobby) to Gmail API over HTTPS — invite emails and all transactional emails now work reliably
- **Shareable invite link**: league owners can generate a 24h link and share via iOS/Android share sheet or copy — no email required for new members to join
- **Settings tab**: renamed "League Payouts" → "Settings" in League Portal for clarity

## What's in this release
- `GoogleEmailSender.cs` — Gmail API via `IHttpClientFactory`, OAuth2 refresh token flow; removes SmtpClient entirely
- `LeagueInviteLink` entity + EF migration + `LeagueInviteLinkService` + controller endpoints (`POST /api/league/{id}/invite-link`, `GET/POST /api/league/join/{token}`)
- `JoinLeaguePage.tsx` — public `/join/:token` route handles expired/valid/logged-in/logged-out states
- `LeaguePortalPage.tsx` — "Generate Invite Link" panel with Share/Copy buttons + Settings tab rename
- All tests updated (xUnit: `LeagueInviteLinkTests.cs`, Vitest: `JoinLeaguePage.test.tsx`, Playwright e2e: `leaguePortal.spec.ts`)

## Test plan
- [x] All CI checks passing on dev (backend, frontend, e2e, demo, replay)
- [x] Test email confirmed delivered via Gmail API
- [x] Invite link feature merged from PR #227 (all 553 backend + 313 frontend tests green)
- [ ] Manual: deploy to prod, generate invite link in a league, share with a new user in incognito, confirm auto-join after registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)