### PR TITLE
fix(seeder): raw SQL wipe for historical weeks — bypass EF Core cascade-FK confusion

### DIFF
--- a/Server/Services/DemoDataSeeder.cs
+++ b/Server/Services/DemoDataSeeder.cs
@@ -600,16 +600,15 @@ public class DemoDataSeeder(
         if (adminUser == null) return;
 
         // Wipe all historical weeks so every deploy starts from a clean slate.
-        // Delete in FK order: picks → scores → spreads → weeks.
-        // Use ToList+RemoveRange instead of ExecuteDeleteAsync — int[] Contains translates
-        // correctly in SELECT but not reliably in bulk-delete on Npgsql, causing silent no-ops
-        // that leave rows behind and crash unconditional re-inserts with PK violations.
-        int[] historicalWeekNums = [.. Enumerable.Range(1, 17), .. Enumerable.Range(19, 4)];
-        db.NflPicks.RemoveRange(await db.NflPicks.Where(p => p.Season == DemoSeason && historicalWeekNums.Contains(p.NflWeek)).ToListAsync());
-        db.NflScores.RemoveRange(await db.NflScores.Where(s => s.Season == DemoSeason && historicalWeekNums.Contains(s.NflWeek)).ToListAsync());
-        db.NflSpreads.RemoveRange(await db.NflSpreads.Where(s => s.Season == DemoSeason && historicalWeekNums.Contains(s.NflWeek)).ToListAsync());
-        db.NflWeeks.RemoveRange(await db.NflWeeks.Where(w => w.Season == DemoSeason && historicalWeekNums.Contains(w.NflWeek)).ToListAsync());
-        await db.SaveChangesAsync();
+        // Raw SQL bypasses EF Core ORM entirely — neither ExecuteDeleteAsync (silent no-op with
+        // int[] Contains on Npgsql) nor RemoveRange+SaveChangesAsync (cascade-FK confusion causes
+        // EF Core to skip the DELETE entirely) produce reliable results on the Neon dev PostgreSQL.
+        // DemoSeason is a compile-time constant; weekIn is a literal — no injection risk.
+        const string weekIn = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22";
+        await db.Database.ExecuteSqlRawAsync($"DELETE FROM \"NflPicks\" WHERE \"Season\" = {DemoSeason} AND \"NflWeek\" IN ({weekIn})");
+        await db.Database.ExecuteSqlRawAsync($"DELETE FROM \"NflScores\" WHERE \"Season\" = {DemoSeason} AND \"NflWeek\" IN ({weekIn})");
+        await db.Database.ExecuteSqlRawAsync($"DELETE FROM \"NflSpreads\" WHERE \"Season\" = {DemoSeason} AND \"NflWeek\" IN ({weekIn})");
+        await db.Database.ExecuteSqlRawAsync($"DELETE FROM \"NflWeeks\" WHERE \"Season\" = {DemoSeason} AND \"NflWeek\" IN ({weekIn})");
 
         // Admin (frizat) win pattern for weeks 1-17: W W L W W W W W W L W W W W W W W
         bool[] adminWins = [true, true, false, true, true, true, true, true, true, false, true, true, true, true, true, true, true];


### PR DESCRIPTION
## Summary
- Fixes Railway dev crash: `PK_NflWeeks` duplicate key on every redeploy
- Three ORM approaches all failed silently on Neon dev PostgreSQL; raw SQL is the only reliable path
- Adds Testcontainers PostgreSQL integration tests to catch this class of bug before merge

## Root cause
`NflPicks.NflWeekId → NflWeeks.Id` FK has `ON DELETE CASCADE`. When EF Core sees this during `SaveChangesAsync`, its cascade optimization skips generating the explicit `DELETE FROM NflWeeks` — leaving all rows intact. The subsequent unconditional `NflWeeks` inserts then crash with `PK_NflWeeks`.

Previous attempts:
1. `ExecuteDeleteAsync` with `int[] Contains` — silently no-ops on Npgsql (works on SQLite → false green in tests)
2. `ToListAsync + RemoveRange + SaveChangesAsync` — EF Core cascade optimization skips the DELETE

## Fix
Raw `ExecuteSqlRawAsync` sends unambiguous `DELETE` statements directly to PostgreSQL, bypassing all ORM translation. `DemoSeason` and `weekIn` are compile-time constants — no injection risk.

## Tests
Replaced SQLite-based `DemoDataSeederIdempotencyTests` with Testcontainers PostgreSQL tests:
1. Does not crash when all historical data already exists (simulates second deploy)
2. Wipes and reseeds on repeated calls — row count stays at 21, not 42
3. Does not delete week 18 or CFB data

574/574 pass.

## Test plan
- [ ] CI green (all 6 jobs)
- [ ] Railway dev redeploys successfully
- [ ] Dev site loads and seeder runs without PK crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)