### PR TITLE
fix(seeder): reset NflWeeks_Id_seq after historical wipe to prevent PK collision

### DIFF
--- a/Server/Services/DemoDataSeeder.cs
+++ b/Server/Services/DemoDataSeeder.cs
@@ -610,6 +610,20 @@ public class DemoDataSeeder(
         await db.Database.ExecuteSqlRawAsync($"DELETE FROM \"NflSpreads\" WHERE \"Season\" = {DemoSeason} AND \"NflWeek\" IN ({weekIn})");
         await db.Database.ExecuteSqlRawAsync($"DELETE FROM \"NflWeeks\" WHERE \"Season\" = {DemoSeason} AND \"NflWeek\" IN ({weekIn})");
 
+        // After deleting, reset the NflWeeks sequence so the next auto-generated Id
+        // is above the current max Id in the table. Without this, crash-loop cycles
+        // that insert-then-wipe rows exhaust sequence values into the range already
+        // held by rows from other seasons (e.g. Season 2026 rows with Ids 126-150
+        // inserted by NflScoresJob before DEMO_MODE was enabled), causing PK_NflWeeks
+        // violations on the very next insert.
+        await db.Database.ExecuteSqlRawAsync(
+            "SELECT setval('\"NflWeeks_Id_seq\"', GREATEST((SELECT MAX(\"Id\") FROM \"NflWeeks\"), 1))");
+
+        // Clear the change tracker so stale tracked entities from earlier in SeedAsync
+        // (e.g. the NflWeeks week-18 entity loaded in SeedDemoUsersAsync) don't
+        // interfere with the raw-SQL-deleted state.
+        db.ChangeTracker.Clear();
+
         // Admin (frizat) win pattern for weeks 1-17: W W L W W W W W W L W W W W W W W
         bool[] adminWins = [true, true, false, true, true, true, true, true, true, false, true, true, true, true, true, true, true];
 


### PR DESCRIPTION
## Summary

- After the raw-SQL wipe of Season=2025 NflWeeks rows, call `setval('NflWeeks_Id_seq', GREATEST(MAX(Id), 1))` to reset the PostgreSQL sequence above the current max Id in the table
- Also call `db.ChangeTracker.Clear()` to detach stale tracked entities so they don't interfere with the raw-SQL-deleted state

## Root cause

Railway dev was crash-looping on `PK_NflWeeks` (duplicate key on `Id`). Timeline:

1. Before `DEMO_MODE` was enabled, `NflScoresJob` inserted real Season 2026 weeks → Ids 126–150
2. Each crash-loop cycle inserted 2025 historical rows (consuming sequence values) then wiped them (but the `NflWeeks_Id_seq` sequence kept advancing)
3. Eventually the sequence reached 126, so the next INSERT assigned Id=126 — already held by the Season 2026 row → `PK_NflWeeks` duplicate key violation
4. The wipe only deletes `Season=2025` rows; the 2026 rows are left intact, so there was no way to recover without resetting the sequence

## Test plan

- [x] Existing 8 Testcontainers PostgreSQL tests pass (`dotnet test --filter "DemoDataSeeder"`)
- [ ] CI: Backend build & test + Demo backend e2e all green
- [ ] Railway dev redeploy succeeds (seeder runs without PK crash)
- [ ] Dev site loads after redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)