### PR TITLE
fix(auth): confirmation-email link was dead — App:BaseUrl was never set on Railway

### DIFF
--- a/Client.React/e2e/registration.spec.ts
+++ b/Client.React/e2e/registration.spec.ts
@@ -62,6 +62,33 @@ test.describe('Registration flow', () => {
     await expect(page.getByText('newuser@example.com')).toBeVisible({ timeout: 5000 });
   });
 
+  test('sends an absolute confirmationUrl built from the page origin', async ({ page }) => {
+    // Regression guard: AuthController.CreateUser used to build the confirmation-email link
+    // from a server config value (App:BaseUrl) that was never set on Railway, so every
+    // confirmation link was a dead relative path. The link is now built entirely from this
+    // client-supplied absolute URL — if this drifts back to a relative path, new users will
+    // be unable to confirm their email and will be locked out with "not allowed to sign in".
+    let capturedBody: Record<string, unknown> | undefined;
+    await page.route('**/api/auth/create-user', (route) => {
+      capturedBody = route.request().postDataJSON();
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ isSuccess: true, errors: [] }),
+      });
+    });
+    await page.goto(`/account/register?inviteCode=${INVITE_CODE}`);
+
+    await page.getByLabel(/username/i).fill('newuser');
+    await page.getByLabel(/^email/i).fill('newuser@example.com');
+    await page.getByLabel(/^password$/i).fill('Test@1234');
+    await page.getByLabel(/confirm password/i).fill('Test@1234');
+    await page.getByRole('button', { name: /^register$/i }).click();
+
+    await page.waitForURL('**/account/registerconfirmation**', { timeout: 10000 });
+    expect(capturedBody?.confirmationUrl).toBe(`${new URL(page.url()).origin}/account/confirmemail`);
+  });
+
   test('error path: invalid invite code shows error toast', async ({ page }) => {
     await setupRegistrationRoutes(page, false);
     await page.goto('/account/register?inviteCode=bad-code');

--- a/Client.React/src/__tests__/RegisterPage.test.tsx
+++ b/Client.React/src/__tests__/RegisterPage.test.tsx
@@ -72,4 +72,24 @@ describe('RegisterPage — invite link flow', () => {
     const callArg = vi.mocked(createUser).mock.calls[0][0];
     expect(callArg.inviteLinkToken).toBeUndefined();
   });
+
+  it('sends an absolute confirmationUrl built from window.location.origin — not a bare relative path', async () => {
+    // frizat: the server no longer has a working App:BaseUrl config; the confirmation-email
+    // link is now built entirely from this client-supplied absolute URL. A relative path here
+    // silently breaks every new user's ability to confirm their email and log in.
+    renderWithSearch('?inviteCode=MYCODE');
+
+    await userEvent.type(screen.getByLabelText(/invitation code/i), 'MYCODE');
+    await userEvent.type(screen.getByLabelText(/username/i), 'newuser');
+    await userEvent.type(screen.getByLabelText(/^email$/i), 'new@test.com');
+    await userEvent.type(screen.getByLabelText(/^password$/i), VALID_PASSWORD);
+    await userEvent.type(screen.getByLabelText(/confirm password/i), VALID_PASSWORD);
+    await userEvent.click(screen.getByRole('button', { name: /register/i }));
+
+    await waitFor(() =>
+      expect(createUser).toHaveBeenCalledWith(
+        expect.objectContaining({ confirmationUrl: `${window.location.origin}/account/confirmemail` }),
+      ),
+    );
+  });
 });

--- a/Client.React/src/__tests__/ResendEmailConfirmationPage.test.tsx
+++ b/Client.React/src/__tests__/ResendEmailConfirmationPage.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+vi.mock('../api/auth', () => ({ requestConfirmEmail: vi.fn() }));
+
+import ResendEmailConfirmationPage from '../pages/account/ResendEmailConfirmationPage';
+import { requestConfirmEmail } from '../api/auth';
+
+describe('ResendEmailConfirmationPage', () => {
+  beforeEach(() => {
+    vi.mocked(requestConfirmEmail).mockResolvedValue('If your email is registered, you will receive a confirmation link.');
+  });
+
+  it('sends an absolute confirmationUrl built from window.location.origin — not a hardcoded relative path', async () => {
+    // frizat: this previously sent the literal string 'Account/ConfirmEmail' — no domain, wrong
+    // case vs the real /account/confirmemail route — so every resend request produced a dead link.
+    render(<ResendEmailConfirmationPage />);
+
+    await userEvent.type(screen.getByLabelText(/email/i), 'user@test.com');
+    await userEvent.click(screen.getByRole('button', { name: /resend/i }));
+
+    await waitFor(() =>
+      expect(requestConfirmEmail).toHaveBeenCalledWith({
+        email: 'user@test.com',
+        confirmationUrl: `${window.location.origin}/account/confirmemail`,
+      }),
+    );
+  });
+});

--- a/Client.React/src/__tests__/url.test.ts
+++ b/Client.React/src/__tests__/url.test.ts
@@ -1,0 +1,15 @@
+import { buildAbsoluteUrl } from '../utils/url';
+
+describe('buildAbsoluteUrl', () => {
+  it('joins a leading-slash path onto window.location.origin', () => {
+    expect(buildAbsoluteUrl('/account/confirmemail')).toBe(`${window.location.origin}/account/confirmemail`);
+  });
+
+  it('joins a path without a leading slash the same way', () => {
+    expect(buildAbsoluteUrl('account/confirmemail')).toBe(`${window.location.origin}/account/confirmemail`);
+  });
+
+  it('returns the origin with a trailing slash for an empty path', () => {
+    expect(buildAbsoluteUrl('')).toBe(`${window.location.origin}/`);
+  });
+});

--- a/Client.React/src/pages/account/ForgotPasswordPage.tsx
+++ b/Client.React/src/pages/account/ForgotPasswordPage.tsx
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { forgotPassword } from '../../api/auth';
 import { useToast } from '../../services/toast';
+import { buildAbsoluteUrl } from '../../utils/url';
 
 const schema = z.object({
   email: z.string().email('Invalid email'),
@@ -27,7 +28,7 @@ export default function ForgotPasswordPage() {
     try {
       await forgotPassword({
         email: values.email,
-        resetUrl: new URL('/account/resetpassword', window.location.origin).toString(),
+        resetUrl: buildAbsoluteUrl('/account/resetpassword'),
       });
       navigate('/account/forgotpasswordconfirmation', { replace: true });
     } catch {

--- a/Client.React/src/pages/account/RegisterPage.tsx
+++ b/Client.React/src/pages/account/RegisterPage.tsx
@@ -7,6 +7,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { createUser } from '../../api/auth';
 import { validateInvitation } from '../../api/invitations';
 import { useToast } from '../../services/toast';
+import { buildAbsoluteUrl } from '../../utils/url';
 
 const baseSchema = z.object({
   invitationCode: z.string(),
@@ -79,6 +80,7 @@ export default function RegisterPage() {
       code: values.invitationCode,
       password: values.password,
       username: values.userName,
+      confirmationUrl: buildAbsoluteUrl('/account/confirmemail'),
       ...(inviteLinkToken ? { inviteLinkToken } : {}),
     });
 

--- a/Client.React/src/pages/account/ResendEmailConfirmationPage.tsx
+++ b/Client.React/src/pages/account/ResendEmailConfirmationPage.tsx
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { requestConfirmEmail } from '../../api/auth';
 import StatusMessage from '../../components/StatusMessage';
+import { buildAbsoluteUrl } from '../../utils/url';
 
 const schema = z.object({
   email: z.string().email('Invalid email'),
@@ -26,7 +27,7 @@ export default function ResendEmailConfirmationPage() {
 
   const onSubmit = async (values: FormValues) => {
     const result = await requestConfirmEmail({
-      confirmationUrl: 'Account/ConfirmEmail',
+      confirmationUrl: buildAbsoluteUrl('/account/confirmemail'),
       email: values.email,
     });
     setMessage(result);

--- a/Client.React/src/types/auth.ts
+++ b/Client.React/src/types/auth.ts
@@ -31,6 +31,7 @@ export interface CreateUserRequest {
   password: string;
   code: string;
   inviteLinkToken?: string;
+  confirmationUrl: string;
 }
 
 export interface CreateUserResponse {

--- a/Client.React/src/utils/url.ts
+++ b/Client.React/src/utils/url.ts
@@ -1,0 +1,3 @@
+export function buildAbsoluteUrl(path: string): string {
+  return new URL(path, window.location.origin).toString();
+}

--- a/Server.UnitTests/AuthControllerTests.cs
+++ b/Server.UnitTests/AuthControllerTests.cs
@@ -69,7 +69,9 @@ public class AuthControllerTests
         IWebHostEnvironment? environment                = null,
         IInvitationService? invitationService           = null,
         ILeagueInviteLinkService? leagueInviteLinkService = null,
-        ApplicationDbContext? db                        = null)
+        ApplicationDbContext? db                        = null,
+        IEmailSender<ApplicationUser>? emailSenderApplication = null,
+        IConfiguration? config                          = null)
     {
         userManager     ??= BuildUserManager();
         signInManager   ??= BuildSignInManager(userManager);
@@ -78,6 +80,8 @@ public class AuthControllerTests
         environment     ??= BuildDevEnvironment();
         invitationService ??= Substitute.For<IInvitationService>();
         leagueInviteLinkService ??= Substitute.For<ILeagueInviteLinkService>();
+        emailSenderApplication ??= Substitute.For<IEmailSender<ApplicationUser>>();
+        config          ??= Substitute.For<IConfiguration>();
 
         db ??= new ApplicationDbContext(
             new DbContextOptionsBuilder<ApplicationDbContext>()
@@ -88,10 +92,10 @@ public class AuthControllerTests
             userManager,
             signInManager,
             Substitute.For<IEmailSender>(),
-            Substitute.For<IEmailSender<ApplicationUser>>(),
+            emailSenderApplication,
             invitationService,
             NullLogger<AuthController>.Instance,
-            Substitute.For<IConfiguration>(),
+            config,
             refreshTokenService,
             jwtTokenService,
             environment,
@@ -744,6 +748,36 @@ public class AuthControllerTests
     }
 
     [Fact]
+    public async Task CreateUser_WithInviteLinkToken_SendsConfirmationEmail_UsingClientSuppliedUrl()
+    {
+        // frizat: confirmation link must be built from the client-supplied ConfirmationUrl
+        // (same pattern as ForgotPassword/RequestEmailConfirmation), not server IConfiguration
+        // — App:BaseUrl is never configured on Railway, so that link was always broken.
+        var userManager = BuildUserManager();
+        userManager.FindByEmailAsync("brand-new@test.com").Returns((ApplicationUser?)null);
+        userManager.CreateAsync(Arg.Any<ApplicationUser>(), Arg.Any<string>())
+            .Returns(IdentityResult.Success);
+        userManager.GenerateEmailConfirmationTokenAsync(Arg.Any<ApplicationUser>())
+            .Returns("confirm-token");
+
+        var link = new LeagueInviteLink { Token = "valid-token", LeagueId = 7, ExpiresAt = DateTimeOffset.UtcNow.AddHours(1) };
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        linkService.ValidateAsync("valid-token").Returns(link);
+
+        var emailSender = Substitute.For<IEmailSender<ApplicationUser>>();
+        var controller = BuildController(
+            userManager: userManager, leagueInviteLinkService: linkService,
+            db: BuildDb("CreateUser_LinkFlow_ConfirmUrl"), emailSenderApplication: emailSender);
+
+        await AssertConfirmationEmailSentAsync(controller, emailSender, "brand-new@test.com", new CreateUserRequest
+        {
+            Username = "brandnew", Email = "brand-new@test.com", Password = "Pass1!", Code = "",
+            InviteLinkToken = "valid-token",
+            ConfirmationUrl = "https://dev.ivleague.xyz/account/confirmemail",
+        });
+    }
+
+    [Fact]
     public async Task CreateUser_WithCode_NoInviteLinkToken_UsesExistingCodePath()
     {
         // Regression: the original invitation-code path must still work after adding the link path
@@ -763,5 +797,149 @@ public class AuthControllerTests
         Assert.False(dto.IsSuccess);
         // Link service was never touched
         await linkService.DidNotReceive().ValidateAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task CreateUser_WithCode_ValidInvitation_SendsConfirmationEmail_UsingClientSuppliedUrl()
+    {
+        var userManager = BuildUserManager();
+        userManager.FindByEmailAsync("invited@test.com").Returns((ApplicationUser?)null);
+        userManager.CreateAsync(Arg.Any<ApplicationUser>(), Arg.Any<string>())
+            .Returns(IdentityResult.Success);
+        userManager.GenerateEmailConfirmationTokenAsync(Arg.Any<ApplicationUser>())
+            .Returns("confirm-token");
+
+        var invitation = new Invitation { InvitationCode = "good-code", Email = "invited@test.com", LeagueId = 8 };
+        var invSvc = Substitute.For<IInvitationService>();
+        invSvc.ValidateInvitationAsync("good-code").Returns(invitation);
+        invSvc.MarkInvitationAsUsedAsync("good-code", Arg.Any<string>()).Returns(true);
+
+        var emailSender = Substitute.For<IEmailSender<ApplicationUser>>();
+        var controller = BuildController(
+            userManager: userManager, invitationService: invSvc,
+            db: BuildDb("CreateUser_CodeFlow_ConfirmUrl"), emailSenderApplication: emailSender);
+
+        await AssertConfirmationEmailSentAsync(controller, emailSender, "invited@test.com", new CreateUserRequest
+        {
+            Username = "invited", Email = "invited@test.com", Password = "Pass1!", Code = "good-code",
+            ConfirmationUrl = "https://dev.ivleague.xyz/account/confirmemail",
+        });
+    }
+
+    [Fact]
+    public async Task CreateUser_WithMissingConfirmationUrl_DoesNotSendConfirmationEmail_ButStillCreatesAccount()
+    {
+        // Guard against a caller that omits ConfirmationUrl (stale client, direct API call):
+        // must not silently build a dead relative link (the exact bug this PR fixes) — skip
+        // the send and log, but the account itself must still be created successfully.
+        var userManager = BuildUserManager();
+        userManager.FindByEmailAsync("invited@test.com").Returns((ApplicationUser?)null);
+        userManager.CreateAsync(Arg.Any<ApplicationUser>(), Arg.Any<string>())
+            .Returns(IdentityResult.Success);
+
+        var invitation = new Invitation { InvitationCode = "good-code", Email = "invited@test.com" };
+        var invSvc = Substitute.For<IInvitationService>();
+        invSvc.ValidateInvitationAsync("good-code").Returns(invitation);
+        invSvc.MarkInvitationAsUsedAsync("good-code", Arg.Any<string>()).Returns(true);
+
+        var emailSender = Substitute.For<IEmailSender<ApplicationUser>>();
+        var controller = BuildController(
+            userManager: userManager, invitationService: invSvc,
+            db: BuildDb("CreateUser_MissingConfirmUrl"), emailSenderApplication: emailSender);
+
+        var result = await controller.CreateUser(new CreateUserRequest
+        {
+            Username = "invited", Email = "invited@test.com", Password = "Pass1!", Code = "good-code",
+            ConfirmationUrl = "",
+        });
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.True(Assert.IsType<CreateUserResponse>(ok.Value).IsSuccess);
+        await emailSender.DidNotReceive().SendConfirmationLinkAsync(
+            Arg.Any<ApplicationUser>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task CreateUser_WhenAllowedOriginsConfigured_RejectsConfirmationUrlOnUntrustedDomain()
+    {
+        // Security: without this check, an anonymous caller can register an account for
+        // ANY email address with an attacker-controlled ConfirmationUrl, and our server will
+        // send a real, branded "confirm your email" message pointing at a phishing domain.
+        var config = Substitute.For<IConfiguration>();
+        config["ALLOWED_ORIGINS"].Returns("https://dev.ivleague.xyz,https://ivleague.com");
+
+        var invitation = new Invitation { InvitationCode = "good-code", Email = "victim@test.com" };
+        var invSvc = Substitute.For<IInvitationService>();
+        invSvc.ValidateInvitationAsync("good-code").Returns(invitation);
+
+        var emailSender = Substitute.For<IEmailSender<ApplicationUser>>();
+        var userManager = BuildUserManager();
+        var controller = BuildController(
+            userManager: userManager, invitationService: invSvc, config: config,
+            db: BuildDb("CreateUser_UntrustedOrigin"), emailSenderApplication: emailSender);
+
+        var result = await controller.CreateUser(new CreateUserRequest
+        {
+            Username = "attacker", Email = "victim@test.com", Password = "Pass1!", Code = "good-code",
+            ConfirmationUrl = "https://evil.example/steal?userId=",
+        });
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.False(Assert.IsType<CreateUserResponse>(bad.Value).IsSuccess);
+        await userManager.DidNotReceive().CreateAsync(Arg.Any<ApplicationUser>(), Arg.Any<string>());
+        await emailSender.DidNotReceive().SendConfirmationLinkAsync(
+            Arg.Any<ApplicationUser>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task CreateUser_WhenAllowedOriginsConfigured_AcceptsConfirmationUrlOnTrustedDomain()
+    {
+        var config = Substitute.For<IConfiguration>();
+        config["ALLOWED_ORIGINS"].Returns("https://dev.ivleague.xyz,https://ivleague.com");
+
+        var userManager = BuildUserManager();
+        userManager.FindByEmailAsync("invited@test.com").Returns((ApplicationUser?)null);
+        userManager.CreateAsync(Arg.Any<ApplicationUser>(), Arg.Any<string>())
+            .Returns(IdentityResult.Success);
+
+        var invitation = new Invitation { InvitationCode = "good-code", Email = "invited@test.com" };
+        var invSvc = Substitute.For<IInvitationService>();
+        invSvc.ValidateInvitationAsync("good-code").Returns(invitation);
+        invSvc.MarkInvitationAsUsedAsync("good-code", Arg.Any<string>()).Returns(true);
+
+        var emailSender = Substitute.For<IEmailSender<ApplicationUser>>();
+        var controller = BuildController(
+            userManager: userManager, invitationService: invSvc, config: config,
+            db: BuildDb("CreateUser_TrustedOrigin"), emailSenderApplication: emailSender);
+
+        var result = await controller.CreateUser(new CreateUserRequest
+        {
+            Username = "invited", Email = "invited@test.com", Password = "Pass1!", Code = "good-code",
+            ConfirmationUrl = "https://dev.ivleague.xyz/account/confirmemail",
+        });
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.True(Assert.IsType<CreateUserResponse>(ok.Value).IsSuccess);
+    }
+
+    // ── Shared helpers for the confirmation-email tests above ──────────────────
+
+    private static ApplicationDbContext BuildDb(string namePrefix) =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(namePrefix + "_" + Guid.NewGuid())
+            .Options);
+
+    private static async Task AssertConfirmationEmailSentAsync(
+        AuthController controller,
+        IEmailSender<ApplicationUser> emailSender,
+        string expectedEmail,
+        CreateUserRequest request)
+    {
+        await controller.CreateUser(request);
+
+        await emailSender.Received(1).SendConfirmationLinkAsync(
+            Arg.Any<ApplicationUser>(),
+            expectedEmail,
+            Arg.Is<string>(link => link.StartsWith($"{request.ConfirmationUrl}?")));
     }
 }

--- a/Server.UnitTests/AuthControllerTests.cs
+++ b/Server.UnitTests/AuthControllerTests.cs
@@ -827,11 +827,15 @@ public class AuthControllerTests
     }
 
     [Fact]
-    public async Task CreateUser_WithMissingConfirmationUrl_DoesNotSendConfirmationEmail_ButStillCreatesAccount()
+    public async Task CreateUser_WhenAllowedOriginsUnconfigured_MissingConfirmationUrl_DoesNotSendConfirmationEmail_ButStillCreatesAccount()
     {
-        // Guard against a caller that omits ConfirmationUrl (stale client, direct API call):
-        // must not silently build a dead relative link (the exact bug this PR fixes) — skip
-        // the send and log, but the account itself must still be created successfully.
+        // This exercises the ALLOWED_ORIGINS-unset case only (Development/local — Program.cs
+        // fails startup otherwise), where IsAllowedConfirmationOrigin lets everything through
+        // and SendEmailConfirmationLinkAsync's own guard is what catches the empty URL: skip
+        // the send and log, but the account itself must still be created successfully. In any
+        // environment where ALLOWED_ORIGINS *is* configured (i.e. every real deploy), an empty
+        // ConfirmationUrl is instead rejected earlier with BadRequest — see
+        // CreateUser_WhenAllowedOriginsConfigured_RejectsConfirmationUrlOnUntrustedDomain.
         var userManager = BuildUserManager();
         userManager.FindByEmailAsync("invited@test.com").Returns((ApplicationUser?)null);
         userManager.CreateAsync(Arg.Any<ApplicationUser>(), Arg.Any<string>())

--- a/Server.UnitTests/EmailProcessTests.cs
+++ b/Server.UnitTests/EmailProcessTests.cs
@@ -205,7 +205,8 @@ public class EmailProcessTests
             Email = email,
             Username = username,
             Password = "Test@12345",
-            Code = inviteCode
+            Code = inviteCode,
+            ConfirmationUrl = "https://example.com/account/confirmemail",
         };
 
         // Act
@@ -267,7 +268,8 @@ public class EmailProcessTests
             Email = email,
             Username = "newuser2",
             Password = "Test@12345",
-            Code = inviteCode
+            Code = inviteCode,
+            ConfirmationUrl = "https://example.com/account/confirmemail",
         };
 
         // Act

--- a/Server.UnitTests/InvitationLeagueTests.cs
+++ b/Server.UnitTests/InvitationLeagueTests.cs
@@ -128,8 +128,6 @@ public class InvitationLeagueTests
         userManager.GenerateEmailConfirmationTokenAsync(Arg.Any<ApplicationUser>())
             .Returns("token");
 
-        config["App:BaseUrl"].Returns("http://localhost");
-
         var controller = BuildAuthController(userManager, invitationService, config, db);
 
         // Act
@@ -139,6 +137,7 @@ public class InvitationLeagueTests
             Email = "newuser@example.com",
             Password = "Pass@123",
             Code = "code-abc",
+            ConfirmationUrl = "http://localhost/account/confirmemail",
         });
 
         // Assert — LeagueUserMapping must exist for the new user in league 5
@@ -173,8 +172,6 @@ public class InvitationLeagueTests
         userManager.GenerateEmailConfirmationTokenAsync(Arg.Any<ApplicationUser>())
             .Returns("token");
 
-        config["App:BaseUrl"].Returns("http://localhost");
-
         var controller = BuildAuthController(userManager, invitationService, config, db);
 
         // Act
@@ -184,6 +181,7 @@ public class InvitationLeagueTests
             Email = "user2@example.com",
             Password = "Pass@123",
             Code = "code-xyz",
+            ConfirmationUrl = "http://localhost/account/confirmemail",
         });
 
         // Assert — no LeagueUserMapping should be created

--- a/Server/Controllers/AuthController.cs
+++ b/Server/Controllers/AuthController.cs
@@ -261,6 +261,15 @@ public class AuthController(
     public async Task<ActionResult<string>> CreateUser([FromBody] CreateUserRequest user) {
         var response = new CreateUserResponse();
 
+        // Reject a ConfirmationUrl on a domain we don't control — otherwise an anonymous caller
+        // could register an account for any email with a phishing domain as ConfirmationUrl,
+        // and our server would send a real, branded "confirm your email" message pointing there.
+        if (!IsAllowedConfirmationOrigin(user.ConfirmationUrl)) {
+            response.IsSuccess = false;
+            response.Errors = new List<string> { "Invalid confirmation URL." };
+            return BadRequest(response);
+        }
+
         // Invite-link registration path (shareable link, no per-email code required)
         if (!string.IsNullOrWhiteSpace(user.InviteLinkToken)) {
             var link = await leagueInviteLinkService.ValidateAsync(user.InviteLinkToken);
@@ -286,16 +295,7 @@ public class AuthController(
             response.UserId = linkUser.Id;
             db.LeagueUserMapping.Add(new LeagueUserMapping { LeagueId = link.LeagueId, UserId = linkUser.Id });
             await db.SaveChangesAsync();
-            try {
-                var token = await userManager.GenerateEmailConfirmationTokenAsync(linkUser);
-                var code = System.Text.Encoding.UTF8.GetBytes(token);
-                var encodedCode = WebEncoders.Base64UrlEncode(code);
-                var confirmationUrl = $"{config["App:BaseUrl"]?.TrimEnd('/') ?? string.Empty}/account/confirmemail";
-                var callbackUrl = $"{confirmationUrl}?userId={linkUser.Id}&code={encodedCode}";
-                await emailSenderApplication.SendConfirmationLinkAsync(linkUser, linkUser.Email!, HtmlEncoder.Default.Encode(callbackUrl));
-            } catch (Exception ex) {
-                logger.LogError(ex, "Failed to send confirmation email to {Email} after invite-link registration", linkUser.Email);
-            }
+            await SendEmailConfirmationLinkAsync(linkUser, user.ConfirmationUrl, "invite-link registration");
             return Ok(response);
         }
 
@@ -348,19 +348,50 @@ public class AuthController(
 
         // Send confirmation email server-side — do not rely on client making a second call.
         // Failure is logged but must not prevent the user account from being returned as created.
-        try {
-            var token = await userManager.GenerateEmailConfirmationTokenAsync(newUser);
-            var code = System.Text.Encoding.UTF8.GetBytes(token);
-            var encodedCode = Microsoft.AspNetCore.WebUtilities.WebEncoders.Base64UrlEncode(code);
-            var confirmationUrl = $"{config["App:BaseUrl"]?.TrimEnd('/') ?? string.Empty}/account/confirmemail";
-            var callbackUrl = $"{confirmationUrl}?userId={newUser.Id}&code={encodedCode}";
-            await emailSenderApplication.SendConfirmationLinkAsync(newUser, newUser.Email!, System.Text.Encodings.Web.HtmlEncoder.Default.Encode(callbackUrl));
-        }
-        catch (Exception ex) {
-            logger.LogError(ex, "Failed to send confirmation email to {Email} after registration; user was still created", newUser.Email);
-        }
+        await SendEmailConfirmationLinkAsync(newUser, user.ConfirmationUrl, "registration");
 
         return Ok(response);
+    }
+
+    /// <summary>
+    /// Generates an email-confirmation token and sends the confirmation link, using the
+    /// client-supplied absolute confirmationUrl (see CreateUserRequest.ConfirmationUrl — the
+    /// server has no App:BaseUrl config of its own; without a client-supplied URL this would
+    /// silently mail a dead relative link). Failure is logged but must not prevent the caller
+    /// from treating account creation as successful.
+    /// </summary>
+    private async Task SendEmailConfirmationLinkAsync(ApplicationUser newlyCreatedUser, string confirmationUrl, string context) {
+        if (string.IsNullOrWhiteSpace(confirmationUrl)) {
+            logger.LogError("Cannot send confirmation email to {Email} after {Context}: no ConfirmationUrl was supplied", newlyCreatedUser.Email, context);
+            return;
+        }
+        try {
+            var token = await userManager.GenerateEmailConfirmationTokenAsync(newlyCreatedUser);
+            var code = WebEncoders.Base64UrlEncode(System.Text.Encoding.UTF8.GetBytes(token));
+            var callbackUrl = $"{confirmationUrl}?userId={newlyCreatedUser.Id}&code={code}";
+            await emailSenderApplication.SendConfirmationLinkAsync(newlyCreatedUser, newlyCreatedUser.Email!, HtmlEncoder.Default.Encode(callbackUrl));
+        } catch (Exception ex) {
+            logger.LogError(ex, "Failed to send confirmation email to {Email} after {Context}", newlyCreatedUser.Email, context);
+        }
+    }
+
+    /// <summary>
+    /// True if confirmationUrl is an absolute URL whose origin is in ALLOWED_ORIGINS (the same
+    /// comma-separated allow-list used for CORS). ALLOWED_ORIGINS is only ever empty in
+    /// Development — Program.cs fails startup otherwise — so an empty list allows any origin,
+    /// mirroring the AllowAnyOrigin() CORS fallback for that same case.
+    /// </summary>
+    private bool IsAllowedConfirmationOrigin(string? confirmationUrl) {
+        var allowedOrigins = (config["ALLOWED_ORIGINS"] ?? string.Empty)
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (allowedOrigins.Length == 0)
+            return true;
+
+        if (!Uri.TryCreate(confirmationUrl, UriKind.Absolute, out var uri))
+            return false;
+
+        var origin = $"{uri.Scheme}://{uri.Authority}";
+        return allowedOrigins.Contains(origin, StringComparer.OrdinalIgnoreCase);
     }
     [HttpPost("forgot-password")]
     [AllowAnonymous] // User is not logged in

--- a/Server/Properties/launchSettings.json
+++ b/Server/Properties/launchSettings.json
@@ -26,8 +26,7 @@
           "Jwt__Audience": "FourPlayWebAppClient",
           "Jwt__ExpiresMinutes": "1000",
           "Jwt__Issuer": "FourPlayWebApp",
-          "Jwt__Key": "",
-          "APP_URL": ""
+          "Jwt__Key": ""
         }
       },
       "IIS Express": {

--- a/Shared/Models/Account/CreateUserRequest.cs
+++ b/Shared/Models/Account/CreateUserRequest.cs
@@ -6,4 +6,5 @@ public class CreateUserRequest {
     public string Email { get; set; }
     public string Code { get; set; }
     public string? InviteLinkToken { get; set; }
+    public string ConfirmationUrl { get; set; }
 }


### PR DESCRIPTION
## Summary
- `CreateUser` built the email-confirmation link from `config["App:BaseUrl"]`, which has no matching env var on Railway in either `development` or `production`. Every confirmation link since the initial release was a bare relative path (`/account/confirmemail?...`) with no domain — `RequireConfirmedEmail=true` then silently locks the new user out with "User is not allowed to sign in" and no self-serve fix. This is what blocked today's live tester on dev.ivleague.xyz.
- The link is now built from a client-supplied absolute `ConfirmationUrl` (`window.location.origin`), matching the existing pattern for `ForgotPassword`/`RequestEmailConfirmation`/`InviteToLeague`. Extracted a shared `buildAbsoluteUrl()` frontend helper and a shared `SendEmailConfirmationLinkAsync` backend helper to remove the duplication this introduced.
- Fixed a second, independent instance of the same bug class in `ResendEmailConfirmationPage`, which hardcoded a broken relative string (`'Account/ConfirmEmail'`).
- Since `CreateUser` now trusts a client-supplied URL, added an origin check against `ALLOWED_ORIGINS` (the same allow-list CORS already uses) — otherwise an anonymous caller could register an account for any email with an attacker-controlled `ConfirmationUrl` and have the server mail a real, branded confirmation link pointing at a phishing domain.

## Test plan
- [x] `dotnet test` — 579/579 passing (new tests cover: client-URL used instead of server config, missing-URL guard, untrusted-origin rejection, trusted-origin acceptance)
- [x] `npm run test -- --run` — 328/328 passing
- [x] `npm run test:e2e -- --project=chromium` — 71/71 passing (new regression test asserts the registration request body carries an absolute `confirmationUrl`)
- [x] `npm run typecheck` — clean
- [ ] Live verification on dev.ivleague.xyz after deploy: register a throwaway account, confirm the email link lands on the real site and flips `EmailConfirmed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)