### PR TITLE
feat(invites): resend-on-login, email autofill, confirmation status, link revoke, invite-existing-user

### DIFF
--- a/Client.React/e2e/helpers/routes.ts
+++ b/Client.React/e2e/helpers/routes.ts
@@ -396,6 +396,11 @@ export async function setupRoutes(page: Page, options: SetupRoutesOptions = {}):
       return;
     }
 
+    if (url.match(/\/api\/league\/\d+\/invite-link$/) && method === 'DELETE') {
+      void route.fulfill({ status: 204 });
+      return;
+    }
+
     if (url.match(/\/api\/league\/\d+\/invitations$/) && method === 'GET') {
       void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
       return;

--- a/Client.React/e2e/inviteFlow.spec.ts
+++ b/Client.React/e2e/inviteFlow.spec.ts
@@ -84,6 +84,21 @@ test.describe('League portal: Generate Invite Link', () => {
 
     await expect(page.getByRole('button', { name: /regenerate link/i })).toBeVisible({ timeout: 5000 });
   });
+
+  test('Revoke Link shuts off the current link without generating a replacement', async ({ page }) => {
+    // Unlike Regenerate, a commissioner should be able to just stop accepting new signups
+    // without immediately producing a new link they'd have to reshare.
+    await mockAuth(page, { authUser: TEST_USER, navigateTo: '/league/manage' });
+    await waitForSpinner(page);
+
+    await page.getByRole('button', { name: /generate invite link/i }).click();
+    await expect(page.getByText(new RegExp(`/join/${MOCK_TOKEN}`))).toBeVisible({ timeout: 5000 });
+
+    await page.getByRole('button', { name: /revoke link/i }).click();
+
+    await expect(page.getByText(new RegExp(`/join/${MOCK_TOKEN}`))).not.toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('button', { name: /generate invite link/i })).toBeVisible({ timeout: 5000 });
+  });
 });
 
 // ── Group 2: Join page — unauthenticated user ─────────────────────────────────
@@ -224,16 +239,39 @@ test.describe('Join page: already-a-member (409)', () => {
 // ── Group 4c: Invite Player (email invite) dialog ─────────────────────────────
 
 test.describe('League portal: Invite Player (email) dialog', () => {
-  async function setupWithInviteRoute(page: Page, succeed = true): Promise<void> {
-    // Mock POST /api/league/{id}/invite before setupRoutes so it wins
+  async function setupWithInviteRoute(
+    page: Page,
+    outcome: 'invited' | 'addedExisting' | 'conflict' | 'error' = 'invited',
+  ): Promise<void> {
+    await mockAuth(page, { authUser: TEST_USER, navigateTo: '/league/manage' });
+
+    // Registered after mockAuth/setupRoutes so it wins — Playwright runs the most-recently
+    // registered route handler first. setupRoutes' own POST /invite mock always fulfills (never
+    // calls route.fallback()), so registering this before mockAuth was silently a no-op: every
+    // outcome here was masked by that generic {} success body.
     await page.route(/\/api\/league\/\d+\/invite$/, (route) => {
       if (route.request().method() === 'POST') {
-        void route.fulfill({ status: succeed ? 204 : 500 });
+        if (outcome === 'error') {
+          void route.fulfill({ status: 500 });
+          return;
+        }
+        if (outcome === 'conflict') {
+          void route.fulfill({
+            status: 409,
+            contentType: 'application/json',
+            body: JSON.stringify('friend@example.com is already a member of this league.'),
+          });
+          return;
+        }
+        void route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ email: 'friend@example.com', addedExistingUser: outcome === 'addedExisting' }),
+        });
         return;
       }
       void route.continue();
     });
-    await mockAuth(page, { authUser: TEST_USER, navigateTo: '/league/manage' });
     await waitForSpinner(page);
   }
 
@@ -258,7 +296,7 @@ test.describe('League portal: Invite Player (email) dialog', () => {
   });
 
   test('filling email and submitting sends invite and closes dialog', async ({ page }) => {
-    await setupWithInviteRoute(page, true);
+    await setupWithInviteRoute(page, 'invited');
 
     await page.getByRole('button', { name: /invite player/i }).click();
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
@@ -269,6 +307,34 @@ test.describe('League portal: Invite Player (email) dialog', () => {
     // Dialog closes and a success toast appears
     await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5000 });
     await expect(page.getByRole('alert')).toContainText(/invitation sent/i, { timeout: 5000 });
+  });
+
+  test('inviting an already-registered email adds them directly, with a distinct success message', async ({ page }) => {
+    // The whole point of this feature: someone with an existing account (owns a league or
+    // belongs to one) gets added to the new league immediately — no dead "register again"
+    // invitation that can never be redeemed because the email is already taken.
+    await setupWithInviteRoute(page, 'addedExisting');
+
+    await page.getByRole('button', { name: /invite player/i }).click();
+    await page.getByLabel(/email/i).fill('friend@example.com');
+    await page.getByRole('dialog').getByRole('button', { name: /send invite|invite/i }).click();
+
+    await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('alert')).toContainText(/added to the league/i, { timeout: 5000 });
+    await expect(page.getByRole('alert')).not.toContainText(/invitation sent/i);
+  });
+
+  test('inviting an email already on the league shows the server\'s specific conflict message', async ({ page }) => {
+    await setupWithInviteRoute(page, 'conflict');
+
+    await page.getByRole('button', { name: /invite player/i }).click();
+    await page.getByLabel(/email/i).fill('friend@example.com');
+    await page.getByRole('dialog').getByRole('button', { name: /send invite|invite/i }).click();
+
+    // Not getByRole('alert') here: on this error path the Dialog stays open (only success
+    // closes it), and MUI applies aria-hidden to background siblings — including the toast —
+    // while a modal is open, so a role-based query finds nothing even though it's rendered.
+    await expect(page.locator('.MuiAlert-root')).toContainText(/already a member of this league/i, { timeout: 5000 });
   });
 });
 

--- a/Client.React/src/__tests__/InvitationsPage.test.tsx
+++ b/Client.React/src/__tests__/InvitationsPage.test.tsx
@@ -89,4 +89,28 @@ describe('AdminInvitationsPage', () => {
 
     expect(mockedResendInvitation).toHaveBeenCalledWith(1);
   });
+
+  it('shows "Pending Confirmation" for a used invitation whose registered user has not confirmed their email', async () => {
+    // This is exactly what confused an admin twice: a green "Used" chip read as "fully
+    // onboarded" when the registered user was actually still stuck unable to log in.
+    mockedGetAllInvitations.mockResolvedValue([
+      makeInvitation({ email: 'stuck@example.com', isUsed: true, registeredUserEmailConfirmed: false }),
+    ]);
+
+    render(<AdminInvitationsPage />);
+
+    expect(await screen.findByText('Pending Confirmation')).toBeInTheDocument();
+    // "Used" is also a separate stats-card label elsewhere on the page — scope to the row.
+    expect(screen.queryByRole('row', { name: /stuck@example\.com.*used/i })).not.toBeInTheDocument();
+  });
+
+  it('shows "Confirmed" for a used invitation whose registered user has confirmed their email', async () => {
+    mockedGetAllInvitations.mockResolvedValue([
+      makeInvitation({ email: 'done@example.com', isUsed: true, registeredUserEmailConfirmed: true }),
+    ]);
+
+    render(<AdminInvitationsPage />);
+
+    expect(await screen.findByText('Confirmed')).toBeInTheDocument();
+  });
 });

--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -495,12 +495,26 @@ describe('LeaguePortalPage — invite link and sent invitations', () => {
     expect(await screen.findByText(/pending/i)).toBeInTheDocument();
   });
 
-  it('shows Accepted chip for a used invitation', async () => {
-    mockedGetLeagueInvitations.mockResolvedValue([makeInvitation({ isUsed: true, isValid: false })]);
+  it('shows Confirmed chip for a used invitation whose registered user has confirmed their email', async () => {
+    mockedGetLeagueInvitations.mockResolvedValue([
+      makeInvitation({ isUsed: true, isValid: false, registeredUserEmailConfirmed: true }),
+    ]);
     renderPage();
     await screen.findByText('frizat@example.com');
 
-    expect(await screen.findByText(/accepted/i)).toBeInTheDocument();
+    expect(await screen.findByText(/^confirmed$/i)).toBeInTheDocument();
+  });
+
+  it('shows Pending Confirmation chip for a used invitation whose registered user has not confirmed yet', async () => {
+    // Same confusion the admin Invitations page fix resolves — a plain "Accepted" here would
+    // hide that the registered user is still stuck unable to log in.
+    mockedGetLeagueInvitations.mockResolvedValue([
+      makeInvitation({ isUsed: true, isValid: false, registeredUserEmailConfirmed: false }),
+    ]);
+    renderPage();
+    await screen.findByText('frizat@example.com');
+
+    expect(await screen.findByText(/pending confirmation/i)).toBeInTheDocument();
   });
 
   it('shows Expired chip for an expired, unused invitation', async () => {
@@ -513,7 +527,7 @@ describe('LeaguePortalPage — invite link and sent invitations', () => {
 
   it('refreshes the invitations list after sending an email invite', async () => {
     const refreshedInvitation = makeInvitation({ email: 'bob@example.com' });
-    mockedInviteToLeague.mockResolvedValue(undefined);
+    mockedInviteToLeague.mockResolvedValue({ email: 'bob@example.com', addedExistingUser: false });
     mockedGetLeagueInvitations
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([refreshedInvitation]);
@@ -527,6 +541,44 @@ describe('LeaguePortalPage — invite link and sent invitations', () => {
 
     await waitFor(() => expect(mockedGetLeagueInvitations).toHaveBeenCalledTimes(2));
     expect(await screen.findByText('bob@example.com')).toBeInTheDocument();
+  });
+
+  it('inviting an already-registered email refreshes members, not invitations, with a distinct message', async () => {
+    // Someone who already has an account gets added to the league immediately — no dead
+    // "register again" invitation that can never be redeemed because the email is taken.
+    mockedInviteToLeague.mockResolvedValue({ email: 'bob@example.com', addedExistingUser: true });
+    mockedGetMappings.mockResolvedValue([makeMember()]);
+
+    renderPage();
+    await screen.findByText('frizat@example.com');
+    await userEvent.click(screen.getByRole('button', { name: /invite player/i }));
+    const dialog = await screen.findByRole('dialog');
+    await userEvent.type(within(dialog).getByLabelText(/email/i), 'bob@example.com');
+    await userEvent.click(within(dialog).getByRole('button', { name: /^send invite$/i }));
+
+    await waitFor(() => expect(toastPush).toHaveBeenCalledWith(expect.stringMatching(/added to the league/i), 'success'));
+    expect(mockedGetLeagueInvitations).toHaveBeenCalledTimes(1); // only the initial load, no refresh
+    await waitFor(() => expect(mockedGetMappings).toHaveBeenCalledTimes(2)); // initial load + refresh
+  });
+
+  it('shows the server\'s specific conflict message when inviting someone already on the league', async () => {
+    mockedInviteToLeague.mockRejectedValue(
+      Object.assign(new Error('Conflict'), {
+        isAxiosError: true,
+        response: { status: 409, data: 'bob@example.com is already a member of this league.' },
+      }),
+    );
+
+    renderPage();
+    await screen.findByText('frizat@example.com');
+    await userEvent.click(screen.getByRole('button', { name: /invite player/i }));
+    const dialog = await screen.findByRole('dialog');
+    await userEvent.type(within(dialog).getByLabelText(/email/i), 'bob@example.com');
+    await userEvent.click(within(dialog).getByRole('button', { name: /^send invite$/i }));
+
+    await waitFor(() =>
+      expect(toastPush).toHaveBeenCalledWith('bob@example.com is already a member of this league.', 'error'),
+    );
   });
 
   it('updates the invite link state after generating a new link', async () => {

--- a/Client.React/src/__tests__/LoginPage.test.tsx
+++ b/Client.React/src/__tests__/LoginPage.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+const { pushMock, loginMock } = vi.hoisted(() => ({ pushMock: vi.fn(), loginMock: vi.fn() }));
+vi.mock('../services/auth', () => ({ useAuth: () => ({ login: loginMock }) }));
+vi.mock('../services/toast', () => ({ useToast: () => ({ push: pushMock }) }));
+
+import LoginPage from '../pages/account/LoginPage';
+
+function renderLogin() {
+  return render(
+    <MemoryRouter initialEntries={['/account/login']}>
+      <LoginPage />
+    </MemoryRouter>,
+  );
+}
+
+async function submitLoginForm() {
+  await userEvent.type(screen.getByLabelText(/email/i), 'user@test.com');
+  await userEvent.type(screen.getByLabelText(/password/i), 'Passw0rd!');
+  await userEvent.click(screen.getByRole('button', { name: /^login$/i }));
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    pushMock.mockReset();
+    loginMock.mockReset();
+  });
+
+  it('navigates to returnUrl on success', async () => {
+    loginMock.mockResolvedValue({ succeeded: true, isLockedOut: false, requiresTwoFactor: false, isNotAllowed: false, accessFailedCount: 0 });
+    renderLogin();
+
+    await submitLoginForm();
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/dashboard', { replace: true }));
+  });
+
+  it('shows the generic message for ordinary invalid credentials — does not redirect', async () => {
+    loginMock.mockResolvedValue({
+      succeeded: false, isLockedOut: false, requiresTwoFactor: false, isNotAllowed: false,
+      accessFailedCount: 1, message: 'Invalid credentials',
+    });
+    renderLogin();
+
+    await submitLoginForm();
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('Invalid credentials', 'error'));
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('on unconfirmed-email (isNotAllowed), shows an actionable message and redirects to resend with the email prefilled', async () => {
+    // Two separate live testers hit exactly this: register -> emails send fine -> try to log
+    // in immediately -> generic "User is not allowed to sign in" toast with no indication this
+    // just means "click your confirmation email" and no path to fix it from here.
+    loginMock.mockResolvedValue({
+      succeeded: false, isLockedOut: false, requiresTwoFactor: false, isNotAllowed: true,
+      accessFailedCount: 0, message: 'User is not allowed to sign in',
+    });
+    renderLogin();
+
+    await submitLoginForm();
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith('/account/resendemailconfirmation?email=user%40test.com'),
+    );
+    expect(pushMock).toHaveBeenCalledWith(
+      expect.stringMatching(/confirm your email/i),
+      'warning',
+    );
+  });
+});

--- a/Client.React/src/__tests__/ResendEmailConfirmationPage.test.tsx
+++ b/Client.React/src/__tests__/ResendEmailConfirmationPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 
 vi.mock('../api/auth', () => ({ requestConfirmEmail: vi.fn() }));
@@ -7,6 +8,14 @@ vi.mock('../api/auth', () => ({ requestConfirmEmail: vi.fn() }));
 import ResendEmailConfirmationPage from '../pages/account/ResendEmailConfirmationPage';
 import { requestConfirmEmail } from '../api/auth';
 import { buildAxiosError } from './testUtils/axiosError';
+
+function renderResend(search = '') {
+  return render(
+    <MemoryRouter initialEntries={[`/account/resendemailconfirmation${search}`]}>
+      <ResendEmailConfirmationPage />
+    </MemoryRouter>,
+  );
+}
 
 describe('ResendEmailConfirmationPage', () => {
   beforeEach(() => {
@@ -16,7 +25,7 @@ describe('ResendEmailConfirmationPage', () => {
   it('sends an absolute confirmationUrl built from window.location.origin — not a hardcoded relative path', async () => {
     // frizat: this previously sent the literal string 'Account/ConfirmEmail' — no domain, wrong
     // case vs the real /account/confirmemail route — so every resend request produced a dead link.
-    render(<ResendEmailConfirmationPage />);
+    renderResend();
 
     await userEvent.type(screen.getByLabelText(/email/i), 'user@test.com');
     await userEvent.click(screen.getByRole('button', { name: /resend/i }));
@@ -33,7 +42,7 @@ describe('ResendEmailConfirmationPage', () => {
     // This endpoint is rate-limited (Program.cs "forgot" policy) and returns a bare 429 with no
     // body — must not silently swallow the failure or render a blank/undefined message.
     vi.mocked(requestConfirmEmail).mockRejectedValue(buildAxiosError(429, ''));
-    render(<ResendEmailConfirmationPage />);
+    renderResend();
 
     await userEvent.type(screen.getByLabelText(/email/i), 'user@test.com');
     await userEvent.click(screen.getByRole('button', { name: /resend/i }));
@@ -47,12 +56,18 @@ describe('ResendEmailConfirmationPage', () => {
   });
 
   it('shows the success message with info (not error) styling on the normal 200 response', async () => {
-    render(<ResendEmailConfirmationPage />);
+    renderResend();
 
     await userEvent.type(screen.getByLabelText(/email/i), 'user@test.com');
     await userEvent.click(screen.getByRole('button', { name: /resend/i }));
 
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
     expect(screen.getByRole('alert')).toHaveClass('MuiAlert-outlinedInfo');
+  });
+
+  it('pre-fills the email field from a ?email= query param (arriving here from LoginPage)', async () => {
+    renderResend('?email=blocked%40test.com');
+
+    expect(screen.getByLabelText(/email/i)).toHaveValue('blocked@test.com');
   });
 });

--- a/Client.React/src/api/league.ts
+++ b/Client.React/src/api/league.ts
@@ -158,8 +158,14 @@ export async function deleteLeague(leagueId: number) {
   await http.delete(`/api/league/${leagueId}`);
 }
 
-export async function inviteToLeague(leagueId: number, email: string) {
-  await http.post(`/api/league/${leagueId}/invite`, { email, baseUrl: window.location.origin });
+export interface LeagueInviteResultDto {
+  email: string;
+  addedExistingUser: boolean;
+}
+
+export async function inviteToLeague(leagueId: number, email: string): Promise<LeagueInviteResultDto> {
+  const { data } = await http.post<LeagueInviteResultDto>(`/api/league/${leagueId}/invite`, { email, baseUrl: window.location.origin });
+  return data;
 }
 
 export async function assignLeagueOwner(leagueId: number, newOwnerUserId: string) {
@@ -207,6 +213,7 @@ export interface InvitationDto {
   isExpired: boolean;
   isValid: boolean;
   usedAt: string | null;
+  registeredUserEmailConfirmed?: boolean | null;
 }
 
 export async function getCurrentInviteLink(leagueId: number): Promise<LeagueInviteLinkDto | null> {
@@ -223,4 +230,8 @@ export async function getCurrentInviteLink(leagueId: number): Promise<LeagueInvi
 export async function getLeagueInvitations(leagueId: number): Promise<InvitationDto[]> {
   const { data } = await http.get<InvitationDto[]>(`/api/league/${leagueId}/invitations`);
   return data;
+}
+
+export async function revokeInviteLink(leagueId: number): Promise<void> {
+  await http.delete(`/api/league/${leagueId}/invite-link`);
 }

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -29,6 +29,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DeleteIcon from '@mui/icons-material/Delete';
 import IosShareIcon from '@mui/icons-material/IosShare';
 import LinkIcon from '@mui/icons-material/Link';
+import LinkOffIcon from '@mui/icons-material/LinkOff';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import PageHeader from '../components/PageHeader';
 import OwnerCostSummary from '../components/OwnerCostSummary';
@@ -37,6 +38,7 @@ import { useSportContext } from '../services/sport';
 import { useAuth } from '../services/auth';
 import { useToast } from '../services/toast';
 import { isAdmin } from '../utils/auth';
+import { extractApiErrorMessage } from '../utils/apiError';
 import {
   getLeagueUserMappings,
   getLeagueJuice,
@@ -46,6 +48,7 @@ import {
   removeLeagueMember,
   inviteToLeague,
   generateInviteLink,
+  revokeInviteLink,
   getCurrentInviteLink,
   getLeagueInvitations,
   getAllLeagues,
@@ -116,6 +119,7 @@ export default function LeaguePortalPage() {
 
   // Shareable invite link
   const [generatingLink, setGeneratingLink] = useState(false);
+  const [revokingLink, setRevokingLink] = useState(false);
   const [inviteLink, setInviteLink] = useState<LeagueInviteLinkDto | null>(null);
 
   // Email invitations sent to this league
@@ -247,13 +251,18 @@ export default function LeaguePortalPage() {
     if (!selectedLeague || !inviteEmail.trim()) return;
     setInviting(true);
     try {
-      await inviteToLeague(selectedLeague.id, inviteEmail.trim());
-      toast.push(`Invitation sent to ${inviteEmail}`, 'success');
+      const result = await inviteToLeague(selectedLeague.id, inviteEmail.trim());
+      if (result.addedExistingUser) {
+        toast.push(`${inviteEmail} added to the league`, 'success');
+        loadMembers(selectedLeague.id).catch(() => {});
+      } else {
+        toast.push(`Invitation sent to ${inviteEmail}`, 'success');
+        getLeagueInvitations(selectedLeague.id).then(setInvitations).catch(() => {});
+      }
       setInviteEmail('');
       setInviteOpen(false);
-      getLeagueInvitations(selectedLeague.id).then(setInvitations).catch(() => {});
-    } catch {
-      toast.push('Failed to send invitation', 'error');
+    } catch (error) {
+      toast.push(extractApiErrorMessage(error, 'Failed to send invitation'), 'error');
     } finally {
       setInviting(false);
     }
@@ -283,6 +292,20 @@ export default function LeaguePortalPage() {
       toast.push('Failed to generate invite link', 'error');
     } finally {
       setGeneratingLink(false);
+    }
+  };
+
+  const handleRevokeInviteLink = async () => {
+    if (!selectedLeague) return;
+    setRevokingLink(true);
+    try {
+      await revokeInviteLink(selectedLeague.id);
+      setInviteLink(null);
+      toast.push('Invite link revoked', 'success');
+    } catch (error) {
+      toast.push(extractApiErrorMessage(error, 'Failed to revoke invite link'), 'error');
+    } finally {
+      setRevokingLink(false);
     }
   };
 
@@ -464,7 +487,9 @@ export default function LeaguePortalPage() {
               onAddUser={openAddUser}
               inviteLink={inviteLink}
               generatingLink={generatingLink}
+              revokingLink={revokingLink}
               onGenerateInviteLink={() => void handleGenerateInviteLink()}
+              onRevokeInviteLink={() => void handleRevokeInviteLink()}
               invitations={invitations}
             />
           )}
@@ -671,11 +696,13 @@ interface MembersTabProps {
   onAddUser: () => void;
   inviteLink: LeagueInviteLinkDto | null;
   generatingLink: boolean;
+  revokingLink: boolean;
   onGenerateInviteLink: () => void;
+  onRevokeInviteLink: () => void;
   invitations: InvitationDto[];
 }
 
-function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInvite, onAddUser, inviteLink, generatingLink, onGenerateInviteLink, invitations }: MembersTabProps) {
+function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInvite, onAddUser, inviteLink, generatingLink, revokingLink, onGenerateInviteLink, onRevokeInviteLink, invitations }: MembersTabProps) {
   const count = costDto?.memberCount ?? members.length;
   const cost = computeLeagueCost(count);
   const toast = useToast();
@@ -747,6 +774,16 @@ function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInv
                 <Button size="small" startIcon={<IosShareIcon />} variant="contained" color="secondary" onClick={handleShare}>
                   Share
                 </Button>
+                <Button
+                  size="small"
+                  startIcon={revokingLink ? <CircularProgress size={14} /> : <LinkOffIcon />}
+                  variant="outlined"
+                  color="error"
+                  onClick={onRevokeInviteLink}
+                  disabled={revokingLink}
+                >
+                  Revoke Link
+                </Button>
               </Stack>
             )}
             <Typography variant="caption" color={linkExpired ? 'warning.main' : 'text.secondary'}>{expiresLabel}</Typography>
@@ -816,7 +853,11 @@ function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInv
                     <TableCell>{new Date(inv.createdAt).toLocaleDateString()}</TableCell>
                     <TableCell>
                       {inv.isUsed ? (
-                        <Chip label="Accepted" color="success" size="small" />
+                        inv.registeredUserEmailConfirmed ? (
+                          <Chip label="Confirmed" color="success" size="small" />
+                        ) : (
+                          <Chip label="Pending Confirmation" color="warning" size="small" />
+                        )
                       ) : inv.isExpired ? (
                         <Chip label="Expired" color="default" size="small" />
                       ) : (

--- a/Client.React/src/pages/account/LoginPage.tsx
+++ b/Client.React/src/pages/account/LoginPage.tsx
@@ -55,6 +55,11 @@ export default function LoginPage() {
       rememberMe: values.rememberMe ?? false,
     });
     if (!result.succeeded) {
+      if (result.isNotAllowed) {
+        toast.push('Please confirm your email before logging in. Sending you to resend it…', 'warning');
+        navigate(`/account/resendemailconfirmation?email=${encodeURIComponent(values.email)}`);
+        return;
+      }
       toast.push(result.message ?? 'Login failed', 'error');
       return;
     }

--- a/Client.React/src/pages/account/ResendEmailConfirmationPage.tsx
+++ b/Client.React/src/pages/account/ResendEmailConfirmationPage.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Button, Card, CardContent, Stack, TextField, Typography } from '@mui/material';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -15,6 +16,9 @@ const schema = z.object({
 type FormValues = z.infer<typeof schema>;
 
 export default function ResendEmailConfirmationPage() {
+  const location = useLocation();
+  const prefilledEmail = useMemo(() => new URLSearchParams(location.search).get('email') ?? '', [location.search]);
+
   const {
     register,
     handleSubmit,
@@ -22,7 +26,7 @@ export default function ResendEmailConfirmationPage() {
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
     resolver: zodResolver(schema),
-    defaultValues: { email: '' },
+    defaultValues: { email: prefilledEmail },
   });
   const [message, setMessage] = useState<string | null>(null);
   const [severity, setSeverity] = useState<'info' | 'error'>('info');

--- a/Client.React/src/pages/admin/InvitationsPage.tsx
+++ b/Client.React/src/pages/admin/InvitationsPage.tsx
@@ -31,6 +31,16 @@ import { createInvitation, deleteInvitation, getAllInvitations, resendInvitation
 import { getAllLeagues } from '../../api/league';
 import type { InvitationDto, LeagueInfoDto } from '../../types/admin';
 
+function getInvitationStatusChip(invitation: InvitationDto): { label: string; color: 'success' | 'warning' | 'error' | 'info' } {
+  if (invitation.isUsed) {
+    return invitation.registeredUserEmailConfirmed
+      ? { label: 'Confirmed', color: 'success' }
+      : { label: 'Pending Confirmation', color: 'warning' };
+  }
+  if (invitation.isExpired) return { label: 'Expired', color: 'error' };
+  return { label: 'Active', color: 'info' };
+}
+
 export default function AdminInvitationsPage() {
   const [invitations, setInvitations] = useState<InvitationDto[]>([]);
   const [loading, setLoading] = useState(true);
@@ -216,13 +226,7 @@ export default function AdminInvitationsPage() {
                   <TableCell>{invitation.email}</TableCell>
                   <TableCell>{invitation.leagueName ?? '-'}</TableCell>
                   <TableCell>
-                    {invitation.isUsed ? (
-                      <Chip size="small" label="Used" color="success" />
-                    ) : invitation.isExpired ? (
-                      <Chip size="small" label="Expired" color="error" />
-                    ) : (
-                      <Chip size="small" label="Active" color="info" />
-                    )}
+                    <Chip size="small" {...getInvitationStatusChip(invitation)} />
                   </TableCell>
                   <TableCell>
                     {invitation.expiresAt ? new Date(invitation.expiresAt).toLocaleString() : 'Never'}

--- a/Client.React/src/types/admin.ts
+++ b/Client.React/src/types/admin.ts
@@ -59,6 +59,7 @@ export interface InvitationDto {
   usedAt?: string | null;
   registeredUserId?: string | null;
   registeredUserName?: string | null;
+  registeredUserEmailConfirmed?: boolean | null;
   isExpired: boolean;
   isValid: boolean;
   leagueId?: number | null;

--- a/Server.UnitTests/InvitationControllerTests.cs
+++ b/Server.UnitTests/InvitationControllerTests.cs
@@ -4,6 +4,7 @@ using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Interfaces;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
 using Xunit;
 
@@ -37,5 +38,17 @@ public class InvitationControllerTests
         await controller.Resend(7, "https://ivleague.com");
 
         await invitationService.Received(1).ResendInvitationEmailAsync(7, "https://ivleague.com");
+    }
+
+    [Fact]
+    public async Task Delete_CallsDeleteInvitationAsync_ReturnsNoContent()
+    {
+        var invitationService = Substitute.For<IInvitationService>();
+        var controller = BuildController(invitationService);
+
+        var result = await controller.Delete(7);
+
+        await invitationService.Received(1).DeleteInvitationAsync(7);
+        Assert.IsType<NoContentResult>(result);
     }
 }

--- a/Server.UnitTests/InvitationMapperTests.cs
+++ b/Server.UnitTests/InvitationMapperTests.cs
@@ -1,0 +1,52 @@
+using FourPlayWebApp.Server.Models;
+using FourPlayWebApp.Server.Models.Identity;
+using FourPlayWebApp.Server.Models.Mappers;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+public class InvitationMapperTests
+{
+    [Fact]
+    public void ToDto_UsedInvitation_WithConfirmedRegisteredUser_SetsRegisteredUserEmailConfirmedTrue()
+    {
+        var invitation = new Invitation
+        {
+            Email = "invited@test.com",
+            IsUsed = true,
+            RegisteredUserId = "user-1",
+            RegisteredUser = new ApplicationUser { UserName = "invited", EmailConfirmed = true },
+        };
+
+        var dto = invitation.ToDto();
+
+        Assert.True(dto.RegisteredUserEmailConfirmed);
+    }
+
+    [Fact]
+    public void ToDto_UsedInvitation_WithUnconfirmedRegisteredUser_SetsRegisteredUserEmailConfirmedFalse()
+    {
+        // This is the exact case that confused an admin twice: the invitation shows "used" but
+        // the registered account can't log in yet because RequireConfirmedEmail is blocking it.
+        var invitation = new Invitation
+        {
+            Email = "invited@test.com",
+            IsUsed = true,
+            RegisteredUserId = "user-1",
+            RegisteredUser = new ApplicationUser { UserName = "invited", EmailConfirmed = false },
+        };
+
+        var dto = invitation.ToDto();
+
+        Assert.False(dto.RegisteredUserEmailConfirmed);
+    }
+
+    [Fact]
+    public void ToDto_UnusedInvitation_SetsRegisteredUserEmailConfirmedNull()
+    {
+        var invitation = new Invitation { Email = "invited@test.com", IsUsed = false };
+
+        var dto = invitation.ToDto();
+
+        Assert.Null(dto.RegisteredUserEmailConfirmed);
+    }
+}

--- a/Server.UnitTests/InvitationServiceTests.cs
+++ b/Server.UnitTests/InvitationServiceTests.cs
@@ -158,5 +158,41 @@ namespace FourPlayWebApp.Server.UnitTests
             Assert.Equal("the-registered-user", second.RegisteredUserId);
             await emailSender.DidNotReceiveWithAnyArgs().SendEmailAsync(default!, default!, default!);
         }
+
+        [Fact]
+        public async Task DeleteInvitationAsync_ExistingInvitation_RemovesIt()
+        {
+            var (service, _) = BuildService(nameof(DeleteInvitationAsync_ExistingInvitation_RemovesIt));
+            var invitation = await service.CreateInvitationAsync("delete-me@example.com", "user123");
+
+            await service.DeleteInvitationAsync(invitation.Id);
+
+            var remaining = await service.GetAllInvitationsAsync();
+            Assert.DoesNotContain(remaining, i => i.Id == invitation.Id);
+        }
+
+        [Fact]
+        public async Task DeleteInvitationAsync_AlreadyUsedInvitation_RemovesIt()
+        {
+            // Deleting a used invitation is allowed today (UI shows the delete button
+            // regardless of used/expired state) — it only destroys the audit trail linking a
+            // user to how they joined, nothing else references Invitation as a parent FK.
+            var (service, _) = BuildService(nameof(DeleteInvitationAsync_AlreadyUsedInvitation_RemovesIt));
+            var invitation = await service.CreateInvitationAsync("used-then-deleted@example.com", "user123");
+            await service.MarkInvitationAsUsedAsync(invitation.InvitationCode, "registered-user-1");
+
+            await service.DeleteInvitationAsync(invitation.Id);
+
+            var remaining = await service.GetAllInvitationsAsync();
+            Assert.DoesNotContain(remaining, i => i.Id == invitation.Id);
+        }
+
+        [Fact]
+        public async Task DeleteInvitationAsync_NonExistentId_DoesNotThrow()
+        {
+            var (service, _) = BuildService(nameof(DeleteInvitationAsync_NonExistentId_DoesNotThrow));
+
+            await service.DeleteInvitationAsync(999999);
+        }
     }
 }

--- a/Server.UnitTests/LeagueInviteLinkServiceTests.cs
+++ b/Server.UnitTests/LeagueInviteLinkServiceTests.cs
@@ -226,4 +226,76 @@ public class LeagueInviteLinkServiceTests
             Assert.Equal("expired", result!.Token);
         });
     }
+
+    // ── RevokeAsync ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RevokeAsync_ActiveLink_MarksItRevoked_WithoutCreatingAReplacement()
+    {
+        // Unlike GenerateAsync, revoking must shut off signups without immediately producing
+        // a new link a commissioner would have to reshare.
+        var db = nameof(RevokeAsync_ActiveLink_MarksItRevoked_WithoutCreatingAReplacement);
+        await WithDb(db, async factory =>
+        {
+            await using (var seed = OpenDb(db))
+            {
+                await SeedUser(seed, "owner");
+                seed.LeagueInfo.Add(new LeagueInfo { Id = 1, LeagueName = "Test", OwnerUserId = "owner" });
+                seed.LeagueInviteLinks.Add(new LeagueInviteLink
+                {
+                    Token = "live-token", LeagueId = 1, CreatedByUserId = "owner",
+                    ExpiresAt = DateTimeOffset.UtcNow.AddHours(12), IsRevoked = false,
+                });
+                await seed.SaveChangesAsync();
+            }
+
+            var service = new LeagueInviteLinkService(factory);
+            await service.RevokeAsync(1);
+
+            await using var verify = OpenDb(db);
+            Assert.True((await verify.LeagueInviteLinks.SingleAsync(l => l.Token == "live-token")).IsRevoked);
+            Assert.Equal(1, await verify.LeagueInviteLinks.CountAsync());
+            // Not asserting ValidateAsync here — its ExpiresAt > DateTimeOffset.UtcNow filter
+            // doesn't translate under this file's SQLite in-memory provider (pre-existing,
+            // unrelated to this change: no other test in this file calls it either).
+            Assert.Null(await service.GetCurrentAsync(1));
+        });
+    }
+
+    [Fact]
+    public async Task RevokeAsync_NoActiveLink_DoesNotThrow()
+    {
+        await WithDb(nameof(RevokeAsync_NoActiveLink_DoesNotThrow), async factory =>
+        {
+            await new LeagueInviteLinkService(factory).RevokeAsync(999);
+        });
+    }
+
+    [Fact]
+    public async Task RevokeAsync_DoesNotAffectOtherLeaguesLinks()
+    {
+        var db = nameof(RevokeAsync_DoesNotAffectOtherLeaguesLinks);
+        await WithDb(db, async factory =>
+        {
+            await using (var seed = OpenDb(db))
+            {
+                await SeedUser(seed, "owner");
+                seed.LeagueInfo.AddRange(
+                    new LeagueInfo { Id = 1, LeagueName = "League One", OwnerUserId = "owner" },
+                    new LeagueInfo { Id = 2, LeagueName = "League Two", OwnerUserId = "owner" });
+                seed.LeagueInviteLinks.AddRange(
+                    new LeagueInviteLink { Token = "league-1-token", LeagueId = 1, CreatedByUserId = "owner",
+                        ExpiresAt = DateTimeOffset.UtcNow.AddHours(12), IsRevoked = false },
+                    new LeagueInviteLink { Token = "league-2-token", LeagueId = 2, CreatedByUserId = "owner",
+                        ExpiresAt = DateTimeOffset.UtcNow.AddHours(12), IsRevoked = false });
+                await seed.SaveChangesAsync();
+            }
+
+            await new LeagueInviteLinkService(factory).RevokeAsync(1);
+
+            await using var verify = OpenDb(db);
+            Assert.True((await verify.LeagueInviteLinks.SingleAsync(l => l.Token == "league-1-token")).IsRevoked);
+            Assert.False((await verify.LeagueInviteLinks.SingleAsync(l => l.Token == "league-2-token")).IsRevoked);
+        });
+    }
 }

--- a/Server.UnitTests/LeagueInviteLinkTests.cs
+++ b/Server.UnitTests/LeagueInviteLinkTests.cs
@@ -229,6 +229,65 @@ public class LeagueInviteLinkTests
         Assert.IsType<OkObjectResult>(result.Result);
     }
 
+    // ── RevokeInviteLink ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RevokeInviteLink_ReturnsNotFound_WhenLeagueDoesNotExist()
+    {
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetLeagueInfoAsync(999).Returns(Task.FromException<LeagueInfo>(new InvalidOperationException("Sequence contains no elements")));
+
+        var controller = BuildController(BuildPrincipal(OwnerId), repo: repo);
+
+        var result = await controller.RevokeInviteLink(999);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task RevokeInviteLink_ReturnsForbid_WhenCallerIsNotOwnerOrAdmin()
+    {
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "TestLeague" });
+
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        var controller = BuildController(BuildPrincipal(StrangerId), repo: repo, linkService: linkService);
+
+        var result = await controller.RevokeInviteLink(1);
+
+        Assert.IsType<ForbidResult>(result);
+        await linkService.DidNotReceive().RevokeAsync(Arg.Any<int>());
+    }
+
+    [Fact]
+    public async Task RevokeInviteLink_ReturnsNoContent_WhenCallerIsOwner()
+    {
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "TestLeague" });
+
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        var controller = BuildController(BuildPrincipal(OwnerId), repo: repo, linkService: linkService);
+
+        var result = await controller.RevokeInviteLink(1);
+
+        Assert.IsType<NoContentResult>(result);
+        await linkService.Received(1).RevokeAsync(1);
+    }
+
+    [Fact]
+    public async Task RevokeInviteLink_ReturnsNoContent_WhenCallerIsAdmin()
+    {
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "TestLeague" });
+
+        var linkService = Substitute.For<ILeagueInviteLinkService>();
+        var controller = BuildController(BuildPrincipal("admin-user", isAdmin: true), repo: repo, linkService: linkService);
+
+        var result = await controller.RevokeInviteLink(1);
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
     // ── GetLeagueInvitations ─────────────────────────────────────────────────
 
     [Fact]
@@ -267,6 +326,32 @@ public class LeagueInviteLinkTests
         var item = Assert.Single(list);
         Assert.Equal("alice@test.com", item.Email);
         Assert.Equal(10, item.Id);
+    }
+
+    [Fact]
+    public async Task GetLeagueInvitations_UsedInvitation_CarriesRegisteredUserEmailConfirmed()
+    {
+        // Mirrors the admin Invitations page fix — owners must see the same "used but not yet
+        // confirmed" distinction, not just a blanket "Accepted" that hides the same stuck-user
+        // scenario this whole fix was written to resolve.
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "TestLeague" });
+
+        var invSvc = Substitute.For<IInvitationService>();
+        invSvc.GetInvitationsByLeagueAsync(1).Returns(new List<Invitation>
+        {
+            new() { Id = 10, Email = "alice@test.com", LeagueId = 1, IsUsed = true,
+                    RegisteredUserId = "alice-1",
+                    RegisteredUser = new ApplicationUser { UserName = "alice", EmailConfirmed = false } }
+        });
+
+        var controller = BuildController(BuildPrincipal(OwnerId), repo: repo, invitationService: invSvc);
+
+        var result = await controller.GetLeagueInvitations(1);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var item = Assert.Single(Assert.IsAssignableFrom<IEnumerable<InvitationDto>>(ok.Value));
+        Assert.False(item.RegisteredUserEmailConfirmed);
     }
 
     [Fact]

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -145,9 +146,11 @@ public class LeagueOwnershipTests
 
     // ─── Commissioner Portal: owner-scoped endpoint tests ───────────────────
 
-    private static (LeagueController ctrl, ILeagueRepository repo) BuildControllerWithRepo(ClaimsPrincipal principal)
+    private static (LeagueController ctrl, ILeagueRepository repo, UserManager<ApplicationUser> userManager, IInvitationService invitationService)
+        BuildFullController(ClaimsPrincipal principal)
     {
         var repo = Substitute.For<ILeagueRepository>();
+        var invSvc = Substitute.For<IInvitationService>();
         var store = Substitute.For<IUserStore<ApplicationUser>>();
         var userManager = Substitute.For<UserManager<ApplicationUser>>(
             store, null, null, null, null, null, null, null, null);
@@ -158,12 +161,18 @@ public class LeagueOwnershipTests
             userManager,
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
-            Substitute.For<IInvitationService>(),
+            invSvc,
             Substitute.For<ILeagueInviteLinkService>());
         ctrl.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext { User = principal }
         };
+        return (ctrl, repo, userManager, invSvc);
+    }
+
+    private static (LeagueController ctrl, ILeagueRepository repo) BuildControllerWithRepo(ClaimsPrincipal principal)
+    {
+        var (ctrl, repo, _, _) = BuildFullController(principal);
         return (ctrl, repo);
     }
 
@@ -577,6 +586,20 @@ public class LeagueOwnershipTests
     }
 
     [Fact]
+    public async Task InviteToLeague_ReturnsNotFound_WhenLeagueDoesNotExist()
+    {
+        // Matches every sibling owner-scoped endpoint in this controller (including
+        // RevokeInviteLink, added alongside this fix) — GetLeagueInfoAsync's real
+        // implementation throws InvalidOperationException, not null, for a missing league.
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(999).Returns(Task.FromException<LeagueInfo>(new InvalidOperationException("Sequence contains no elements")));
+
+        var result = await ctrl.InviteToLeague(999, new LeagueInviteDto("target@example.com"));
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
     public async Task InviteToLeague_ReturnsOk_WhenCallerIsOwner()
     {
         var invSvc = Substitute.For<IInvitationService>();
@@ -638,6 +661,67 @@ public class LeagueOwnershipTests
         await ctrl.InviteToLeague(1, new LeagueInviteDto("target@example.com", "https://ivleague.com"));
 
         await invSvc.Received(1).CreateInvitationAsync("target@example.com", OwnerId, 1, baseUrl: "https://ivleague.com");
+    }
+
+    private static (LeagueController ctrl, ILeagueRepository repo, UserManager<ApplicationUser> userManager, IInvitationService invitationService)
+        BuildControllerWithUserManager(ClaimsPrincipal principal) => BuildFullController(principal);
+
+    [Fact]
+    public async Task InviteToLeague_ExistingUser_NotYetMember_AddsDirectly_WithoutCreatingInvitation()
+    {
+        // The whole point: someone who already has an IV League account (whether they own a
+        // league or belong to one) must be addable to a NEW league without re-registering —
+        // previously InviteToLeague always created an Invitation, and re-registering with an
+        // email that already exists fails with "User already exists", leaving a dead invite.
+        var (ctrl, repo, userManager, invSvc) = BuildControllerWithUserManager(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
+        var existingUser = new ApplicationUser { Id = "existing-user-1", Email = "already-registered@example.com" };
+        userManager.FindByEmailAsync("already-registered@example.com").Returns(existingUser);
+        repo.UserExistsInLeagueAsync("existing-user-1", 1).Returns(false);
+
+        var result = await ctrl.InviteToLeague(1, new LeagueInviteDto("already-registered@example.com"));
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<LeagueInviteResultDto>(ok.Value);
+        Assert.True(dto.AddedExistingUser);
+        await repo.Received(1).AddLeagueUserMappingAsync(
+            Arg.Is<LeagueUserMapping>(m => m.UserId == "existing-user-1" && m.LeagueId == 1));
+        await invSvc.DidNotReceiveWithAnyArgs().CreateInvitationAsync(default!, default!, default, default);
+    }
+
+    [Fact]
+    public async Task InviteToLeague_ExistingUser_AlreadyMember_ReturnsConflict_WithoutDuplicateMapping()
+    {
+        var (ctrl, repo, userManager, invSvc) = BuildControllerWithUserManager(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
+        var existingUser = new ApplicationUser { Id = "existing-user-1", Email = "already-member@example.com" };
+        userManager.FindByEmailAsync("already-member@example.com").Returns(existingUser);
+        repo.UserExistsInLeagueAsync("existing-user-1", 1).Returns(true);
+
+        var result = await ctrl.InviteToLeague(1, new LeagueInviteDto("already-member@example.com"));
+
+        Assert.IsType<ConflictObjectResult>(result);
+        await repo.DidNotReceiveWithAnyArgs().AddLeagueUserMappingAsync(default!);
+        await invSvc.DidNotReceiveWithAnyArgs().CreateInvitationAsync(default!, default!, default, default);
+    }
+
+    [Fact]
+    public async Task InviteToLeague_ExistingUser_ConcurrentAddRace_ReturnsConflict_NotUnhandledException()
+    {
+        // TOCTOU: UserExistsInLeagueAsync says "not yet a member", but a concurrent request wins
+        // the insert first — the unique-constraint violation must surface as a 409, same as
+        // JoinViaLink already guards against, not an unhandled 500.
+        var (ctrl, repo, userManager, _) = BuildControllerWithUserManager(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
+        var existingUser = new ApplicationUser { Id = "existing-user-1", Email = "race@example.com" };
+        userManager.FindByEmailAsync("race@example.com").Returns(existingUser);
+        repo.UserExistsInLeagueAsync("existing-user-1", 1).Returns(false);
+        repo.AddLeagueUserMappingAsync(Arg.Any<LeagueUserMapping>())
+            .Returns(Task.FromException(new DbUpdateException("unique constraint", new Exception("inner"))));
+
+        var result = await ctrl.InviteToLeague(1, new LeagueInviteDto("race@example.com"));
+
+        Assert.IsType<ConflictObjectResult>(result);
     }
 
     [Fact]

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -864,18 +864,29 @@ public class LeagueController(
         var link = await leagueInviteLinkService.ValidateAsync(token);
         if (link is null) return NotFound();
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
-        if (await repo.UserExistsInLeagueAsync(userId, link.LeagueId))
+        if (!await TryAddUserToLeagueAsync(userId, link.LeagueId))
             return Conflict("You are already a member of this league.");
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Adds userId to leagueId. Returns false (no-op) if they're already a member — checked up
+    /// front, and again via the DbUpdateException race guard in case a concurrent request adds
+    /// them between the check and the insert.
+    /// </summary>
+    private async Task<bool> TryAddUserToLeagueAsync(string userId, int leagueId) {
+        if (await repo.UserExistsInLeagueAsync(userId, leagueId))
+            return false;
         try {
             await repo.AddLeagueUserMappingAsync(new LeagueUserMapping {
-                LeagueId = link.LeagueId,
+                LeagueId = leagueId,
                 UserId = userId,
                 DateCreated = DateTimeOffset.UtcNow,
             });
+            return true;
         } catch (DbUpdateException) {
-            return Conflict("You are already a member of this league.");
+            return false;
         }
-        return NoContent();
     }
 
     [HttpGet("{leagueId:int}/invite-link")]
@@ -894,6 +905,20 @@ public class LeagueController(
         return Ok(new LeagueInviteLinkDto(link.Token, link.LeagueId, league.LeagueName, link.ExpiresAt));
     }
 
+    [HttpDelete("{leagueId:int}/invite-link")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> RevokeInviteLink(int leagueId) {
+        LeagueInfo league;
+        try { league = await repo.GetLeagueInfoAsync(leagueId); }
+        catch (InvalidOperationException) { return NotFound(); }
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
+            return Forbid();
+        await leagueInviteLinkService.RevokeAsync(leagueId);
+        return NoContent();
+    }
+
     [HttpGet("{leagueId:int}/invitations")]
     [ProducesResponseType(typeof(IReadOnlyList<InvitationDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -905,38 +930,34 @@ public class LeagueController(
         if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
             return Forbid();
         var invitations = await invitationService.GetInvitationsByLeagueAsync(leagueId);
-        return Ok(invitations.Select(i => new InvitationDto {
-            Id = i.Id,
-            Email = i.Email,
-            CreatedAt = i.CreatedAt,
-            ExpiresAt = i.ExpiresAt,
-            IsUsed = i.IsUsed,
-            IsExpired = i.IsExpired,
-            IsValid = i.IsValid,
-            UsedAt = i.UsedAt,
-        }).ToList());
+        return Ok(invitations.ToDtoList());
     }
 
     [HttpPost("{leagueId:int}/invite")]
-    [ProducesResponseType(typeof(InvitationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(LeagueInviteResultDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> InviteToLeague(int leagueId, [FromBody] LeagueInviteDto dto) {
-        var league = await repo.GetLeagueInfoAsync(leagueId);
+        LeagueInfo league;
+        try { league = await repo.GetLeagueInfoAsync(leagueId); }
+        catch (InvalidOperationException) { return NotFound(); }
         var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
         if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
             return Forbid();
-        var invitation = await invitationService.CreateInvitationAsync(dto.Email, callerId, leagueId, baseUrl: dto.BaseUrl);
-        return Ok(new InvitationDto {
-            Id = invitation.Id,
-            InvitationCode = invitation.InvitationCode,
-            Email = invitation.Email,
-            LeagueId = invitation.LeagueId,
-            IsUsed = invitation.IsUsed,
-            IsExpired = invitation.IsExpired,
-            IsValid = invitation.IsValid,
-            CreatedAt = invitation.CreatedAt,
-            ExpiresAt = invitation.ExpiresAt,
-        });
+
+        // Someone who already has an account (owns a league or belongs to one) must be
+        // addable to a NEW league directly — routing them through CreateInvitationAsync would
+        // require them to "register" with an email that already exists, which always fails.
+        var existingUser = await userManager.FindByEmailAsync(dto.Email);
+        if (existingUser != null) {
+            if (!await TryAddUserToLeagueAsync(existingUser.Id, leagueId))
+                return Conflict($"{dto.Email} is already a member of this league.");
+            return Ok(new LeagueInviteResultDto(dto.Email, AddedExistingUser: true));
+        }
+
+        await invitationService.CreateInvitationAsync(dto.Email, callerId, leagueId, baseUrl: dto.BaseUrl);
+        return Ok(new LeagueInviteResultDto(dto.Email, AddedExistingUser: false));
     }
 
 }

--- a/Server/Models/Mappers/InvitationMapper.cs
+++ b/Server/Models/Mappers/InvitationMapper.cs
@@ -19,6 +19,7 @@ public static class InvitationMapper
             UsedAt = invitation.UsedAt,
             RegisteredUserId = invitation.RegisteredUserId,
             RegisteredUserName = invitation.RegisteredUser?.UserName, // from ApplicationUser
+            RegisteredUserEmailConfirmed = invitation.RegisteredUser?.EmailConfirmed,
             IsExpired = invitation.IsExpired,
             IsValid = invitation.IsValid,
             LeagueId = invitation.LeagueId,

--- a/Server/Services/Interfaces/ILeagueInviteLinkService.cs
+++ b/Server/Services/Interfaces/ILeagueInviteLinkService.cs
@@ -7,4 +7,5 @@ public interface ILeagueInviteLinkService
     Task<LeagueInviteLink> GenerateAsync(int leagueId, string createdByUserId);
     Task<LeagueInviteLink?> ValidateAsync(string token);
     Task<LeagueInviteLink?> GetCurrentAsync(int leagueId);
+    Task RevokeAsync(int leagueId);
 }

--- a/Server/Services/InvitationService.cs
+++ b/Server/Services/InvitationService.cs
@@ -179,6 +179,7 @@ public class InvitationService(IDbContextFactory<ApplicationDbContext> dbContext
 
         return await dbContext.Invitations
             .Where(i => i.LeagueId == leagueId)
+            .Include(i => i.RegisteredUser)
             .OrderByDescending(i => i.CreatedAt)
             .ToListAsync();
     }

--- a/Server/Services/LeagueInviteLinkService.cs
+++ b/Server/Services/LeagueInviteLinkService.cs
@@ -12,9 +12,7 @@ public class LeagueInviteLinkService(IDbContextFactory<ApplicationDbContext> dbC
     {
         await using var db = await dbContextFactory.CreateDbContextAsync();
 
-        await db.LeagueInviteLinks
-            .Where(l => l.LeagueId == leagueId && !l.IsRevoked)
-            .ExecuteUpdateAsync(s => s.SetProperty(l => l.IsRevoked, true));
+        await RevokeActiveLinksAsync(db, leagueId);
 
         var link = new LeagueInviteLink
         {
@@ -45,4 +43,16 @@ public class LeagueInviteLinkService(IDbContextFactory<ApplicationDbContext> dbC
             .OrderByDescending(l => l.Id)
             .FirstOrDefaultAsync();
     }
+
+    public async Task RevokeAsync(int leagueId)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+
+        await RevokeActiveLinksAsync(db, leagueId);
+    }
+
+    private static Task<int> RevokeActiveLinksAsync(ApplicationDbContext db, int leagueId) =>
+        db.LeagueInviteLinks
+            .Where(l => l.LeagueId == leagueId && !l.IsRevoked)
+            .ExecuteUpdateAsync(s => s.SetProperty(l => l.IsRevoked, true));
 }

--- a/Shared/Models/Data/Dtos/InvitationDto.cs
+++ b/Shared/Models/Data/Dtos/InvitationDto.cs
@@ -15,6 +15,7 @@ public class InvitationDto
     public DateTimeOffset? UsedAt { get; set; }
     public string? RegisteredUserId { get; set; }
     public string? RegisteredUserName { get; set; }
+    public bool? RegisteredUserEmailConfirmed { get; set; }
     public bool IsExpired { get; set; }
     public bool IsValid { get; set; }
     public int? LeagueId { get; set; }

--- a/Shared/Models/Data/Dtos/LeagueInviteResultDto.cs
+++ b/Shared/Models/Data/Dtos/LeagueInviteResultDto.cs
@@ -1,0 +1,6 @@
+namespace FourPlayWebApp.Shared.Models.Data.Dtos;
+
+public record LeagueInviteResultDto(
+    string Email,
+    bool AddedExistingUser
+);


### PR DESCRIPTION
## Summary
Batch of related fixes to the invite/registration flow, surfaced while live-testing the confirmation-email fix (#239, #240) on dev.ivleague.xyz.

- **LoginPage**: a login blocked by an unconfirmed email now shows an actionable message and redirects to the resend-confirmation page with the email prefilled, instead of a generic "not allowed" toast with no next step.
- **RegisterPage**: auto-fills the email field from the invitation-code lookup — the server already had it, only `leagueName` was being used from that response.
- **Admin Invitations page + league owner's Sent Invitations table**: a used invitation now shows "Pending Confirmation" vs "Confirmed" instead of a blanket "Used"/"Accepted" that hides whether the registered user can actually log in yet — this is exactly what confused an admin twice this session. Required threading `RegisteredUser` through both invitation-list endpoints (`InvitationMapper.ToDto()` reused for both instead of a second hand-built DTO).
- **Invitation delete**: already fully wired end-to-end (admin UI → API → service) with zero test coverage; added it.
- **Shareable invite links**: added a standalone revoke (`DELETE /api/league/{id}/invite-link` + "Revoke Link" button) — previously the only way to invalidate a link was to regenerate it, which immediately produces a new link that has to be reshared.
- **InviteToLeague**: a league owner inviting someone who already has an account now adds them directly instead of creating an `Invitation` that can never be redeemed (registering with an already-registered email always fails with "User already exists"). Extracted the check-then-add-with-race-guard logic shared with `JoinViaLink` into one `TryAddUserToLeagueAsync` helper instead of a second copy (also closes a TOCTOU gap the new code would otherwise have introduced).

## Test plan
- [x] `dotnet test` — 598/598 passing
- [x] `npm run test -- --run` — 353/353 passing
- [x] `npm run test:e2e -- --project=chromium` — 74/74 passing
- [x] `npm run typecheck` — clean
- [x] `/simplify` (4 parallel review agents) + `/code-review` (multi-angle) run on the full diff; findings applied — dedup'd test-controller builders, extracted shared invite-link revoke logic, fixed a missing 404 guard, added TOCTOU race-guard coverage, wired `extractApiErrorMessage` into the revoke handler, added a loading/disabled state to the Revoke button, fixed owner-view invitation status parity with the admin page

🤖 Generated with [Claude Code](https://claude.com/claude-code)