### PR TITLE
fix: logout race, clearer confirmation copy, real accept/decline flow for existing-user league invites

### DIFF
--- a/Client.React/e2e/helpers/routes.ts
+++ b/Client.React/e2e/helpers/routes.ts
@@ -406,6 +406,26 @@ export async function setupRoutes(page: Page, options: SetupRoutesOptions = {}):
       return;
     }
 
+    if (url.match(/\/api\/league\/\d+\/membership-invites$/) && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+      return;
+    }
+
+    if (url.match(/\/api\/league\/membership-invites\/mine$/) && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+      return;
+    }
+
+    if (url.match(/\/api\/league\/membership-invites\/\d+\/(accept|decline)$/) && method === 'POST') {
+      void route.fulfill({ status: 204 });
+      return;
+    }
+
+    if (url.match(/\/api\/league\/membership-invites\/\d+$/) && method === 'DELETE') {
+      void route.fulfill({ status: 204 });
+      return;
+    }
+
     if (url.match(/\/api\/league\/join\/[^/]+$/) && method === 'GET') {
       void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockInviteLink()) });
       return;

--- a/Client.React/e2e/inviteFlow.spec.ts
+++ b/Client.React/e2e/inviteFlow.spec.ts
@@ -241,7 +241,7 @@ test.describe('Join page: already-a-member (409)', () => {
 test.describe('League portal: Invite Player (email) dialog', () => {
   async function setupWithInviteRoute(
     page: Page,
-    outcome: 'invited' | 'addedExisting' | 'conflict' | 'error' = 'invited',
+    outcome: 'invited' | 'existingUserPending' | 'conflict' | 'error' = 'invited',
   ): Promise<void> {
     await mockAuth(page, { authUser: TEST_USER, navigateTo: '/league/manage' });
 
@@ -266,7 +266,10 @@ test.describe('League portal: Invite Player (email) dialog', () => {
         void route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ email: 'friend@example.com', addedExistingUser: outcome === 'addedExisting' }),
+          body: JSON.stringify({
+            email: 'friend@example.com',
+            outcome: outcome === 'existingUserPending' ? 'ExistingUserInvitePending' : 'NewUserInvitationSent',
+          }),
         });
         return;
       }
@@ -309,19 +312,19 @@ test.describe('League portal: Invite Player (email) dialog', () => {
     await expect(page.getByRole('alert')).toContainText(/invitation sent/i, { timeout: 5000 });
   });
 
-  test('inviting an already-registered email adds them directly, with a distinct success message', async ({ page }) => {
+  test('inviting an already-registered email creates a pending invite, with a distinct message', async ({ page }) => {
     // The whole point of this feature: someone with an existing account (owns a league or
-    // belongs to one) gets added to the new league immediately — no dead "register again"
-    // invitation that can never be redeemed because the email is already taken.
-    await setupWithInviteRoute(page, 'addedExisting');
+    // belongs to one) doesn't need to re-register — but unlike a brand-new user, they get a
+    // pending invite they must explicitly accept, not instant membership with no consent.
+    await setupWithInviteRoute(page, 'existingUserPending');
 
     await page.getByRole('button', { name: /invite player/i }).click();
     await page.getByLabel(/email/i).fill('friend@example.com');
     await page.getByRole('dialog').getByRole('button', { name: /send invite|invite/i }).click();
 
     await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5000 });
-    await expect(page.getByRole('alert')).toContainText(/added to the league/i, { timeout: 5000 });
-    await expect(page.getByRole('alert')).not.toContainText(/invitation sent/i);
+    await expect(page.getByRole('alert')).toContainText(/pending their acceptance/i, { timeout: 5000 });
+    await expect(page.getByRole('alert')).not.toContainText(/^invitation sent/i);
   });
 
   test('inviting an email already on the league shows the server\'s specific conflict message', async ({ page }) => {
@@ -338,7 +341,80 @@ test.describe('League portal: Invite Player (email) dialog', () => {
   });
 });
 
-// ── Group 4d: Registration confirmation — always shows Go to login ────────────
+// ── Group 4d: Pending membership invite banner (invitee-facing) ───────────────
+
+test.describe('Pending membership invite banner', () => {
+  test('shows on any authenticated page; Accept clears it', async ({ page }) => {
+    await mockAuth(page, { authUser: TEST_USER, navigateTo: '/picks' });
+
+    let resolved = false;
+    // Registered after mockAuth so it wins over setupRoutes' default empty-array response.
+    await page.route(/\/api\/league\/membership-invites\/mine$/, (route) => {
+      if (route.request().method() !== 'GET') return void route.continue();
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(resolved ? [] : [{
+          id: 9, leagueId: 1, leagueName: 'Rival League', invitedByUserName: 'commish',
+          createdAt: new Date().toISOString(),
+        }]),
+      });
+    });
+    await page.route(/\/api\/league\/membership-invites\/\d+\/accept$/, (route) => {
+      if (route.request().method() !== 'POST') return void route.continue();
+      resolved = true;
+      void route.fulfill({ status: 204 });
+    });
+
+    await page.reload();
+    await waitForSpinner(page);
+
+    const banner = page.getByRole('alert').filter({ hasText: /rival league/i });
+    await expect(banner).toBeVisible({ timeout: 5000 });
+    await expect(banner).toContainText(/you're being asked to join/i);
+
+    await page.getByRole('button', { name: /^accept$/i }).click();
+
+    await expect(banner).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('Decline clears the banner without adding the league', async ({ page }) => {
+    await mockAuth(page, { authUser: TEST_USER, navigateTo: '/picks' });
+
+    let resolved = false;
+    let declineCalled = false;
+    await page.route(/\/api\/league\/membership-invites\/mine$/, (route) => {
+      if (route.request().method() !== 'GET') return void route.continue();
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(resolved ? [] : [{
+          id: 9, leagueId: 1, leagueName: 'Rival League', invitedByUserName: 'commish',
+          createdAt: new Date().toISOString(),
+        }]),
+      });
+    });
+    await page.route(/\/api\/league\/membership-invites\/\d+\/decline$/, (route) => {
+      if (route.request().method() !== 'POST') return void route.continue();
+      resolved = true;
+      declineCalled = true;
+      void route.fulfill({ status: 204 });
+    });
+
+    await page.reload();
+    await waitForSpinner(page);
+
+    const banner = page.getByRole('alert').filter({ hasText: /rival league/i });
+    await expect(banner).toBeVisible({ timeout: 5000 });
+
+    await page.getByRole('button', { name: /^decline$/i }).click();
+
+    await expect(banner).not.toBeVisible({ timeout: 5000 });
+    expect(declineCalled).toBe(true);
+  });
+});
+
+// ── Group 4e: Registration confirmation — always shows Go to login ────────────
 
 test.describe('Registration confirmation page', () => {
   test('shows Go to login button (not returnUrl redirect) — email confirmation step is required first', async ({ page }) => {

--- a/Client.React/e2e/leaguePortal.spec.ts
+++ b/Client.React/e2e/leaguePortal.spec.ts
@@ -87,4 +87,36 @@ test.describe('Commissioner portal (/league/manage)', () => {
     await page.getByRole('dialog').getByRole('textbox').fill('newplayer@test.com');
     await expect(page.getByRole('dialog').getByRole('textbox')).toHaveValue('newplayer@test.com');
   });
+
+  test('shows a pending membership invite with a Cancel button, and canceling removes it', async ({ page }) => {
+    await ownerAuth(page);
+    await waitForSpinner(page);
+
+    // Registered after mockAuth so it wins over setupRoutes' default empty-array response.
+    let cancelCalled = false;
+    await page.route(/\/api\/league\/\d+\/membership-invites$/, (route) => {
+      if (route.request().method() !== 'GET') return void route.continue();
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(cancelCalled ? [] : [{
+          id: 1, leagueId: 1, invitedUserEmail: 'bob@example.com', invitedUserName: 'bob',
+          status: 'Pending', createdAt: new Date().toISOString(), respondedAt: null,
+        }]),
+      });
+    });
+    await page.route(/\/api\/league\/membership-invites\/\d+$/, (route) => {
+      if (route.request().method() !== 'DELETE') return void route.continue();
+      cancelCalled = true;
+      void route.fulfill({ status: 204 });
+    });
+
+    await page.reload();
+    await waitForSpinner(page);
+
+    await expect(page.getByText('bob@example.com')).toBeVisible({ timeout: 5000 });
+    await page.getByRole('button', { name: /^cancel$/i }).click();
+
+    await expect(page.getByText('bob@example.com')).not.toBeVisible({ timeout: 5000 });
+  });
 });

--- a/Client.React/src/App.tsx
+++ b/Client.React/src/App.tsx
@@ -83,6 +83,10 @@ export default function App() {
       <Route path="/account/resendemailconfirmation" caseSensitive={false} element={<ResendEmailConfirmationPage />} />
       <Route path="/account/invaliduser" caseSensitive={false} element={<InvalidUserPage />} />
       <Route path="/account/lockout" caseSensitive={false} element={<LockoutPage />} />
+      {/* Not RequireAuth-guarded on purpose: logout clears auth state as part of its own
+          flow, which would otherwise race against RequireAuth's own reactive redirect to
+          login and strand the user there instead of on home. See App.logout.test.tsx. */}
+      <Route path="/logout" element={<LogoutPage />} />
 
       <Route
         element={
@@ -97,7 +101,6 @@ export default function App() {
         <Route path="/scores" element={<ScoresRoute />} />
         <Route path="/leaderboard" element={<LeaderboardRoute />} />
         <Route path="/auth" element={<AuthPage />} />
-        <Route path="/logout" element={<LogoutPage />} />
 
         <Route
           path="/admin"

--- a/Client.React/src/__tests__/App.logout.test.tsx
+++ b/Client.React/src/__tests__/App.logout.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Regression test for the logout race condition: clicking Logout must land the user on
+ * the home page without needing a manual refresh. Root cause was /logout being nested
+ * inside the RequireAuth-guarded route group in App.tsx — clearing auth state as part of
+ * logout raced against RequireAuth's own reactive redirect to /account/login, and
+ * RequireAuth sometimes won, unmounting LogoutPage mid-flight and stranding the user near
+ * a login page instead of home.
+ *
+ * Uses the real App route tree, real AuthProvider/RequireAuth/LogoutPage — only the leaf
+ * pages not under test (HomePage, LoginPage) and AppLayout's own peripheral dependencies
+ * are stubbed, so this exercises the actual routing fix rather than a hand-rolled mimic.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+
+vi.mock('../pages/HomePage', () => ({ default: () => <div>HOME_PAGE_MARKER</div> }));
+vi.mock('../pages/account/LoginPage', () => ({ default: () => <div>LOGIN_PAGE_MARKER</div> }));
+
+vi.mock('../services/session', () => ({
+  useSession: () => ({
+    currentLeague: null,
+    availableLeagues: [],
+    selectLeague: vi.fn(),
+    reloadLeagues: vi.fn(),
+    clearSession: vi.fn(),
+    hasNflAccess: true,
+    hasCfbAccess: false,
+    leaguesLoaded: true,
+    ownedLeagues: [],
+    pendingMembershipInvites: [],
+    refreshPendingInvites: vi.fn(),
+  }),
+}));
+vi.mock('../services/sport', () => ({ useSportContext: () => ({ sport: 'NFL', isCfb: false, isNfl: true }) }));
+vi.mock('../services/theme', () => ({ useThemeMode: () => ({ mode: 'light', toggleTheme: vi.fn() }) }));
+vi.mock('../services/toast', () => ({ useToast: () => ({ push: vi.fn() }) }));
+vi.mock('../utils/auth', () => ({ isAdmin: () => false }));
+
+vi.mock('../api/http', () => ({ http: { get: vi.fn(), post: vi.fn() } }));
+import { http } from '../api/http';
+
+import App from '../App';
+import { AuthProvider } from '../services/auth';
+
+const mockedHttp = http as unknown as {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+};
+
+function renderAtLogout() {
+  return render(
+    <MemoryRouter initialEntries={['/logout']}>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('Logout routing', () => {
+  beforeEach(() => {
+    mockedHttp.get.mockReset();
+    mockedHttp.post.mockReset();
+  });
+
+  it('lands on the home page after logout — never stranded on a login redirect', async () => {
+    mockedHttp.get.mockResolvedValue({ data: { userId: 'u1', name: 'Alice', claims: [] } });
+    mockedHttp.post.mockResolvedValue({ data: { ok: true } });
+
+    renderAtLogout();
+
+    await waitFor(() => expect(screen.getByText('HOME_PAGE_MARKER')).toBeInTheDocument());
+    expect(screen.queryByText('LOGIN_PAGE_MARKER')).not.toBeInTheDocument();
+  });
+});

--- a/Client.React/src/__tests__/AppLayout.test.tsx
+++ b/Client.React/src/__tests__/AppLayout.test.tsx
@@ -28,6 +28,8 @@ const sessionState = {
   hasCfbAccess: false,
   leaguesLoaded: true,
   ownedLeagues: [] as { id: number; leagueName: string; leagueType: string; ownerUserId: string; dateCreated: string }[],
+  pendingMembershipInvites: [] as { id: number; leagueId: number; leagueName: string; invitedByUserName: string | null; createdAt: string }[],
+  refreshPendingInvites: vi.fn(),
 };
 vi.mock('../services/session', () => ({ useSession: () => sessionState }));
 vi.mock('../services/sport',   () => ({ useSportContext: () => ({ sport: 'NFL', isCfb: false, isNfl: true }) }));

--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -53,6 +53,8 @@ vi.mock('../api/league', () => ({
   generateInviteLink: vi.fn(),
   getCurrentInviteLink: vi.fn().mockResolvedValue(null),
   getLeagueInvitations: vi.fn().mockResolvedValue([]),
+  getLeagueMembershipInvites: vi.fn().mockResolvedValue([]),
+  cancelMembershipInvite: vi.fn(),
 }));
 import {
   getLeagueUserMappings,
@@ -65,10 +67,13 @@ import {
   deleteLeague,
   getCurrentInviteLink,
   getLeagueInvitations,
+  getLeagueMembershipInvites,
+  cancelMembershipInvite,
   generateInviteLink,
   inviteToLeague,
   type LeagueInviteLinkDto,
   type InvitationDto,
+  type MembershipInviteStatusDto,
 } from '../api/league';
 
 const mockedGetMappings = vi.mocked(getLeagueUserMappings);
@@ -77,6 +82,8 @@ const mockedGetCost = vi.mocked(getLeagueCost);
 const mockedGetAllLeagues = vi.mocked(getAllLeagues);
 const mockedGetCurrentInviteLink = vi.mocked(getCurrentInviteLink);
 const mockedGetLeagueInvitations = vi.mocked(getLeagueInvitations);
+const mockedGetLeagueMembershipInvites = vi.mocked(getLeagueMembershipInvites);
+const mockedCancelMembershipInvite = vi.mocked(cancelMembershipInvite);
 const mockedGenerateInviteLink = vi.mocked(generateInviteLink);
 const mockedInviteToLeague = vi.mocked(inviteToLeague);
 const mockedGetUsers = vi.mocked(getUsers);
@@ -444,6 +451,19 @@ describe('LeaguePortalPage — invite link and sent invitations', () => {
     };
   }
 
+  function makeMembershipInvite(overrides: Partial<MembershipInviteStatusDto> = {}): MembershipInviteStatusDto {
+    return {
+      id: 1,
+      leagueId: 1,
+      invitedUserEmail: 'bob@example.com',
+      invitedUserName: 'bob',
+      status: 'Pending',
+      createdAt: new Date().toISOString(),
+      respondedAt: null,
+      ...overrides,
+    };
+  }
+
   beforeEach(() => {
     authState.user = OWNER_USER;
     sessionState.ownedLeagues = [makeLeague()];
@@ -453,6 +473,7 @@ describe('LeaguePortalPage — invite link and sent invitations', () => {
     // Default: no existing invite link, no sent invitations
     mockedGetCurrentInviteLink.mockResolvedValue(null);
     mockedGetLeagueInvitations.mockResolvedValue([]);
+    mockedGetLeagueMembershipInvites.mockResolvedValue([]);
     sessionState.reloadLeagues.mockClear();
     toastPush.mockClear();
   });
@@ -527,7 +548,7 @@ describe('LeaguePortalPage — invite link and sent invitations', () => {
 
   it('refreshes the invitations list after sending an email invite', async () => {
     const refreshedInvitation = makeInvitation({ email: 'bob@example.com' });
-    mockedInviteToLeague.mockResolvedValue({ email: 'bob@example.com', addedExistingUser: false });
+    mockedInviteToLeague.mockResolvedValue({ email: 'bob@example.com', outcome: 'NewUserInvitationSent' });
     mockedGetLeagueInvitations
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([refreshedInvitation]);
@@ -543,11 +564,10 @@ describe('LeaguePortalPage — invite link and sent invitations', () => {
     expect(await screen.findByText('bob@example.com')).toBeInTheDocument();
   });
 
-  it('inviting an already-registered email refreshes members, not invitations, with a distinct message', async () => {
-    // Someone who already has an account gets added to the league immediately — no dead
-    // "register again" invitation that can never be redeemed because the email is taken.
-    mockedInviteToLeague.mockResolvedValue({ email: 'bob@example.com', addedExistingUser: true });
-    mockedGetMappings.mockResolvedValue([makeMember()]);
+  it('inviting an already-registered email shows a pending-acceptance message, not an instant add', async () => {
+    // Someone who already has an account gets a pending invite they must explicitly accept —
+    // not added instantly with no consent. No members-list refresh: nobody was added yet.
+    mockedInviteToLeague.mockResolvedValue({ email: 'bob@example.com', outcome: 'ExistingUserInvitePending' });
 
     renderPage();
     await screen.findByText('frizat@example.com');
@@ -556,9 +576,8 @@ describe('LeaguePortalPage — invite link and sent invitations', () => {
     await userEvent.type(within(dialog).getByLabelText(/email/i), 'bob@example.com');
     await userEvent.click(within(dialog).getByRole('button', { name: /^send invite$/i }));
 
-    await waitFor(() => expect(toastPush).toHaveBeenCalledWith(expect.stringMatching(/added to the league/i), 'success'));
-    expect(mockedGetLeagueInvitations).toHaveBeenCalledTimes(1); // only the initial load, no refresh
-    await waitFor(() => expect(mockedGetMappings).toHaveBeenCalledTimes(2)); // initial load + refresh
+    await waitFor(() => expect(toastPush).toHaveBeenCalledWith(expect.stringMatching(/pending their acceptance/i), 'success'));
+    expect(mockedGetMappings).toHaveBeenCalledTimes(1); // only the initial load, no refresh
   });
 
   it('shows the server\'s specific conflict message when inviting someone already on the league', async () => {
@@ -591,5 +610,35 @@ describe('LeaguePortalPage — invite link and sent invitations', () => {
 
     await waitFor(() => expect(mockedGenerateInviteLink).toHaveBeenCalledWith(1));
     expect(await screen.findByRole('button', { name: /^copy$/i })).toBeInTheDocument();
+  });
+
+  it('shows a pending membership invite with a Cancel button, and cancels it', async () => {
+    mockedGetLeagueMembershipInvites
+      .mockResolvedValueOnce([makeMembershipInvite()])
+      .mockResolvedValueOnce([]);
+    mockedCancelMembershipInvite.mockResolvedValue(undefined);
+
+    renderPage();
+    await screen.findByText('frizat@example.com');
+
+    expect(await screen.findByText('bob@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+    await waitFor(() => expect(mockedCancelMembershipInvite).toHaveBeenCalledWith(1));
+    await waitFor(() => expect(mockedGetLeagueMembershipInvites).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not show a Cancel button for an already-accepted or declined membership invite', async () => {
+    mockedGetLeagueMembershipInvites.mockResolvedValue([
+      makeMembershipInvite({ id: 2, status: 'Accepted' }),
+    ]);
+
+    renderPage();
+    await screen.findByText('frizat@example.com');
+
+    expect(await screen.findByText('Accepted')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^cancel$/i })).not.toBeInTheDocument();
   });
 });

--- a/Client.React/src/__tests__/LoginPage.test.tsx
+++ b/Client.React/src/__tests__/LoginPage.test.tsx
@@ -15,9 +15,9 @@ vi.mock('../services/toast', () => ({ useToast: () => ({ push: pushMock }) }));
 
 import LoginPage from '../pages/account/LoginPage';
 
-function renderLogin() {
+function renderLogin(search = '') {
   return render(
-    <MemoryRouter initialEntries={['/account/login']}>
+    <MemoryRouter initialEntries={[`/account/login${search}`]}>
       <LoginPage />
     </MemoryRouter>,
   );
@@ -39,6 +39,15 @@ describe('LoginPage', () => {
   it('navigates to returnUrl on success', async () => {
     loginMock.mockResolvedValue({ succeeded: true, isLockedOut: false, requiresTwoFactor: false, isNotAllowed: false, accessFailedCount: 0 });
     renderLogin();
+
+    await submitLoginForm();
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/dashboard', { replace: true }));
+  });
+
+  it('ignores a crafted returnUrl=/logout — /logout is public and would immediately sign the user back out', async () => {
+    loginMock.mockResolvedValue({ succeeded: true, isLockedOut: false, requiresTwoFactor: false, isNotAllowed: false, accessFailedCount: 0 });
+    renderLogin('?returnUrl=%2Flogout');
 
     await submitLoginForm();
 

--- a/Client.React/src/__tests__/PendingInviteBanner.test.tsx
+++ b/Client.React/src/__tests__/PendingInviteBanner.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import PendingInviteBanner from '../components/PendingInviteBanner';
+import type { PendingMembershipInviteDto } from '../api/league';
+
+vi.mock('../api/league', () => ({
+  acceptMembershipInvite: vi.fn(),
+  declineMembershipInvite: vi.fn(),
+}));
+
+const toastPush = vi.fn();
+vi.mock('../services/toast', () => ({ useToast: () => ({ push: toastPush }) }));
+
+const refreshPendingInvites = vi.fn();
+const reloadLeagues = vi.fn();
+vi.mock('../services/session', () => ({
+  useSession: () => ({
+    pendingMembershipInvites: mockInvites,
+    refreshPendingInvites,
+    reloadLeagues,
+  }),
+}));
+
+import { acceptMembershipInvite, declineMembershipInvite } from '../api/league';
+const mockedAccept = vi.mocked(acceptMembershipInvite);
+const mockedDecline = vi.mocked(declineMembershipInvite);
+
+let mockInvites: PendingMembershipInviteDto[] = [];
+
+function makeInvite(overrides: Partial<PendingMembershipInviteDto> = {}): PendingMembershipInviteDto {
+  return {
+    id: 1,
+    leagueId: 10,
+    leagueName: 'Demo League',
+    invitedByUserName: 'commish',
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('PendingInviteBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInvites = [];
+    refreshPendingInvites.mockResolvedValue(undefined);
+    reloadLeagues.mockResolvedValue(undefined);
+  });
+
+  it('renders nothing when there are no pending invites', () => {
+    mockInvites = [];
+    const { container } = render(<PendingInviteBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows "You\'re being asked to join {League}" with Accept/Decline for each pending invite', () => {
+    mockInvites = [makeInvite({ leagueName: 'Demo League' })];
+    render(<PendingInviteBanner />);
+    expect(screen.getByRole('alert')).toHaveTextContent(/you're being asked to join.*demo league/i);
+    expect(screen.getByRole('button', { name: /accept/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /decline/i })).toBeInTheDocument();
+  });
+
+  it('clicking Accept calls the accept endpoint and refreshes leagues + invites', async () => {
+    mockInvites = [makeInvite({ id: 7 })];
+    mockedAccept.mockResolvedValue(undefined);
+    render(<PendingInviteBanner />);
+
+    await userEvent.click(screen.getByRole('button', { name: /accept/i }));
+
+    await waitFor(() => expect(mockedAccept).toHaveBeenCalledWith(7));
+    expect(reloadLeagues).toHaveBeenCalled();
+    expect(refreshPendingInvites).toHaveBeenCalled();
+  });
+
+  it('clicking Decline calls the decline endpoint and refreshes invites, without reloading leagues', async () => {
+    mockInvites = [makeInvite({ id: 7 })];
+    mockedDecline.mockResolvedValue(undefined);
+    render(<PendingInviteBanner />);
+
+    await userEvent.click(screen.getByRole('button', { name: /decline/i }));
+
+    await waitFor(() => expect(mockedDecline).toHaveBeenCalledWith(7));
+    expect(refreshPendingInvites).toHaveBeenCalled();
+    expect(reloadLeagues).not.toHaveBeenCalled();
+  });
+
+  it('shows an error toast when Accept fails, without crashing', async () => {
+    mockInvites = [makeInvite({ id: 7 })];
+    mockedAccept.mockRejectedValue(new Error('network down'));
+    render(<PendingInviteBanner />);
+
+    await userEvent.click(screen.getByRole('button', { name: /accept/i }));
+
+    await waitFor(() => expect(toastPush).toHaveBeenCalledWith(expect.stringMatching(/fail/i), 'error'));
+  });
+
+  it('does not show a "Failed to accept" error when Accept succeeds but the follow-up refresh fails', async () => {
+    // The accept itself already succeeded server-side — a flaky refresh afterward must not be
+    // reported as an accept failure, which would wrongly tell the user nothing happened.
+    mockInvites = [makeInvite({ id: 7 })];
+    mockedAccept.mockResolvedValue(undefined);
+    reloadLeagues.mockRejectedValue(new Error('network down'));
+    render(<PendingInviteBanner />);
+
+    await userEvent.click(screen.getByRole('button', { name: /accept/i }));
+
+    await waitFor(() => expect(mockedAccept).toHaveBeenCalledWith(7));
+    expect(toastPush).not.toHaveBeenCalled();
+  });
+
+  it('does not show a "Failed to decline" error when Decline succeeds but the follow-up refresh fails', async () => {
+    mockInvites = [makeInvite({ id: 7 })];
+    mockedDecline.mockResolvedValue(undefined);
+    refreshPendingInvites.mockRejectedValue(new Error('network down'));
+    render(<PendingInviteBanner />);
+
+    await userEvent.click(screen.getByRole('button', { name: /decline/i }));
+
+    await waitFor(() => expect(mockedDecline).toHaveBeenCalledWith(7));
+    expect(toastPush).not.toHaveBeenCalled();
+  });
+});

--- a/Client.React/src/__tests__/RegisterConfirmationPage.test.tsx
+++ b/Client.React/src/__tests__/RegisterConfirmationPage.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import RegisterConfirmationPage from '../pages/account/RegisterConfirmationPage';
+
+function renderWithSearch(search: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/account/registerconfirmation${search}`]}>
+      <RegisterConfirmationPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('RegisterConfirmationPage', () => {
+  it('shows the check-your-email step as a prominent alert, not easy-to-miss body text', () => {
+    // frizat: user testing live reported not noticing this step at all — the message
+    // existed but read as plain paragraph text with no visual weight.
+    renderWithSearch('?email=user%40test.com');
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Check user@test.com to confirm your account.');
+  });
+
+  it('still shows an alert with a generic message when no email param is present', () => {
+    renderWithSearch('');
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Please check your email to confirm your account.');
+  });
+});

--- a/Client.React/src/__tests__/RegisterPage.test.tsx
+++ b/Client.React/src/__tests__/RegisterPage.test.tsx
@@ -148,6 +148,18 @@ describe('RegisterPage — invite link flow', () => {
     await waitFor(() => expect(screen.getByLabelText(/^email$/i)).toHaveValue('invited@test.com'));
   });
 
+  it('shows a registering-and-joining banner (not a bare "invited" message) when the invite resolves to a league', async () => {
+    // New-user registration IS joining, in one step — the copy should say so explicitly rather
+    // than leaving the "what happens when I register" question unanswered.
+    vi.mocked(validateInvitation).mockResolvedValueOnce({
+      email: 'invited@test.com',
+      leagueName: 'Demo League',
+    } as Awaited<ReturnType<typeof validateInvitation>>);
+    renderWithSearch('?inviteCode=MYCODE');
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/registering for iv league and joining.*demo league/i));
+  });
+
   it('does not leave an unhandled rejection when the invitation preview lookup fails', async () => {
     // Same bug class this file's other tests guard against, in the same component: a 404 for
     // a stale/expired invite code must not become an unhandled promise rejection.
@@ -156,6 +168,6 @@ describe('RegisterPage — invite link flow', () => {
 
     await waitFor(() => expect(screen.getByRole('button', { name: /^register$/i })).toBeInTheDocument());
     // No league-name preview banner, and no unhandled rejection (vitest fails the test on one).
-    expect(screen.queryByText(/you've been invited to join/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/registering for iv league and joining/i)).not.toBeInTheDocument();
   });
 });

--- a/Client.React/src/__tests__/ResendEmailConfirmationPage.test.tsx
+++ b/Client.React/src/__tests__/ResendEmailConfirmationPage.test.tsx
@@ -70,4 +70,12 @@ describe('ResendEmailConfirmationPage', () => {
 
     expect(screen.getByLabelText(/email/i)).toHaveValue('blocked@test.com');
   });
+
+  it('explains why the user landed here instead of just saying "Enter your email"', () => {
+    // frizat: this page gave zero context — a user redirected here from a failed login had
+    // no idea why, which read as part of the "gross, unexplained" flow the user flagged.
+    renderResend();
+
+    expect(screen.getByText(/your account isn't confirmed yet/i)).toBeInTheDocument();
+  });
 });

--- a/Client.React/src/__tests__/session.test.tsx
+++ b/Client.React/src/__tests__/session.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { SessionProvider, useSession } from '../services/session';
+
+vi.mock('../services/auth', () => ({ useAuth: () => ({ user: { userId: 'u1', name: 'Alice', claims: [] } }) }));
+vi.mock('../services/sport', () => ({ useSportContext: () => ({ sport: 'NFL', isCfb: false, isNfl: true }) }));
+
+vi.mock('../api/league', () => ({
+  getLeagueUserMappingsForUser: vi.fn().mockResolvedValue([]),
+  getMyLeagues: vi.fn().mockResolvedValue([]),
+  getMyPendingMembershipInvites: vi.fn(),
+}));
+
+import { getMyPendingMembershipInvites } from '../api/league';
+const mockedGetPending = vi.mocked(getMyPendingMembershipInvites);
+
+function Consumer() {
+  const { pendingMembershipInvites } = useSession();
+  return (
+    <ul>
+      {pendingMembershipInvites.map((invite) => (
+        <li key={invite.id}>{invite.leagueName}</li>
+      ))}
+    </ul>
+  );
+}
+
+describe('SessionProvider — pending membership invites', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches and exposes the logged-in user\'s pending membership invites on load', async () => {
+    mockedGetPending.mockResolvedValue([
+      { id: 1, leagueId: 2, leagueName: 'Demo League', invitedByUserName: 'commish', createdAt: '2026-01-01T00:00:00Z' },
+    ]);
+
+    render(
+      <SessionProvider>
+        <Consumer />
+      </SessionProvider>
+    );
+
+    expect(await screen.findByText('Demo League')).toBeInTheDocument();
+  });
+
+  it('does not crash the session when the pending-invites fetch fails', async () => {
+    mockedGetPending.mockRejectedValue(new Error('network down'));
+
+    render(
+      <SessionProvider>
+        <Consumer />
+      </SessionProvider>
+    );
+
+    await waitFor(() => expect(mockedGetPending).toHaveBeenCalled());
+    expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
+  });
+});

--- a/Client.React/src/__tests__/sportAccess.test.tsx
+++ b/Client.React/src/__tests__/sportAccess.test.tsx
@@ -26,6 +26,8 @@ const sessionState = {
   hasCfbAccess: true,
   leaguesLoaded: true,
   ownedLeagues: [] as { id: number; leagueName: string; leagueType: string; ownerUserId: string; dateCreated: string }[],
+  pendingMembershipInvites: [] as { id: number; leagueId: number; leagueName: string; invitedByUserName: string | null; createdAt: string }[],
+  refreshPendingInvites: vi.fn(),
 };
 vi.mock('../services/session', () => ({ useSession: () => sessionState }));
 

--- a/Client.React/src/api/league.ts
+++ b/Client.React/src/api/league.ts
@@ -158,9 +158,11 @@ export async function deleteLeague(leagueId: number) {
   await http.delete(`/api/league/${leagueId}`);
 }
 
+export type LeagueInviteOutcome = 'NewUserInvitationSent' | 'ExistingUserInvitePending';
+
 export interface LeagueInviteResultDto {
   email: string;
-  addedExistingUser: boolean;
+  outcome: LeagueInviteOutcome;
 }
 
 export async function inviteToLeague(leagueId: number, email: string): Promise<LeagueInviteResultDto> {
@@ -234,4 +236,46 @@ export async function getLeagueInvitations(leagueId: number): Promise<Invitation
 
 export async function revokeInviteLink(leagueId: number): Promise<void> {
   await http.delete(`/api/league/${leagueId}/invite-link`);
+}
+
+export interface PendingMembershipInviteDto {
+  id: number;
+  leagueId: number;
+  leagueName: string;
+  invitedByUserName: string | null;
+  createdAt: string;
+}
+
+export async function getMyPendingMembershipInvites(): Promise<PendingMembershipInviteDto[]> {
+  const { data } = await http.get<PendingMembershipInviteDto[]>('/api/league/membership-invites/mine');
+  return data;
+}
+
+export async function acceptMembershipInvite(id: number): Promise<void> {
+  await http.post(`/api/league/membership-invites/${id}/accept`, {});
+}
+
+export async function declineMembershipInvite(id: number): Promise<void> {
+  await http.post(`/api/league/membership-invites/${id}/decline`, {});
+}
+
+export async function cancelMembershipInvite(id: number): Promise<void> {
+  await http.delete(`/api/league/membership-invites/${id}`);
+}
+
+export type MembershipInviteStatus = 'Pending' | 'Accepted' | 'Declined';
+
+export interface MembershipInviteStatusDto {
+  id: number;
+  leagueId: number;
+  invitedUserEmail: string;
+  invitedUserName: string | null;
+  status: MembershipInviteStatus;
+  createdAt: string;
+  respondedAt: string | null;
+}
+
+export async function getLeagueMembershipInvites(leagueId: number): Promise<MembershipInviteStatusDto[]> {
+  const { data } = await http.get<MembershipInviteStatusDto[]>(`/api/league/${leagueId}/membership-invites`);
+  return data;
 }

--- a/Client.React/src/components/PendingInviteBanner.tsx
+++ b/Client.React/src/components/PendingInviteBanner.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { Alert, Box, Button, Stack } from '@mui/material';
+import { acceptMembershipInvite, declineMembershipInvite } from '../api/league';
+import { useSession } from '../services/session';
+import { useToast } from '../services/toast';
+import { extractApiErrorMessage } from '../utils/apiError';
+
+export default function PendingInviteBanner() {
+  const { pendingMembershipInvites, refreshPendingInvites, reloadLeagues } = useSession();
+  const toast = useToast();
+  const [respondingId, setRespondingId] = useState<number | null>(null);
+
+  if (pendingMembershipInvites.length === 0) return null;
+
+  const handleAccept = async (id: number) => {
+    setRespondingId(id);
+    try {
+      await acceptMembershipInvite(id);
+    } catch (error) {
+      toast.push(extractApiErrorMessage(error, 'Failed to accept invite'), 'error');
+      setRespondingId(null);
+      return;
+    }
+    // The accept already succeeded server-side — a failed refresh here just means stale league/
+    // invite state until the next natural reload, not a failed accept. Don't tell the user
+    // otherwise.
+    await Promise.all([reloadLeagues(), refreshPendingInvites()]).catch(() => {});
+    setRespondingId(null);
+  };
+
+  const handleDecline = async (id: number) => {
+    setRespondingId(id);
+    try {
+      await declineMembershipInvite(id);
+    } catch (error) {
+      toast.push(extractApiErrorMessage(error, 'Failed to decline invite'), 'error');
+      setRespondingId(null);
+      return;
+    }
+    await refreshPendingInvites().catch(() => {});
+    setRespondingId(null);
+  };
+
+  return (
+    <Stack spacing={1} sx={{ mb: 2 }}>
+      {pendingMembershipInvites.map((invite) => (
+        <Alert key={invite.id} severity="info">
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 1 }}>
+            <span>You&apos;re being asked to join <strong>{invite.leagueName}</strong>.</span>
+            <Stack direction="row" spacing={1}>
+              <Button
+                size="small"
+                variant="contained"
+                disabled={respondingId === invite.id}
+                onClick={() => void handleAccept(invite.id)}
+              >
+                Accept
+              </Button>
+              <Button
+                size="small"
+                variant="outlined"
+                disabled={respondingId === invite.id}
+                onClick={() => void handleDecline(invite.id)}
+              >
+                Decline
+              </Button>
+            </Stack>
+          </Box>
+        </Alert>
+      ))}
+    </Stack>
+  );
+}

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -43,6 +43,7 @@ import { useAuth } from '../services/auth';
 import { useSportContext } from '../services/sport';
 import { useThemeMode } from '../services/theme';
 import { isAdmin } from '../utils/auth';
+import PendingInviteBanner from '../components/PendingInviteBanner';
 
 const drawerWidth = 260;
 
@@ -363,6 +364,7 @@ export default function AppLayout() {
       >
         <Toolbar />
         <Box className="page-shell" sx={{ flex: 1 }}>
+          <PendingInviteBanner />
           {noAccessContent ?? <Outlet />}
         </Box>
       </Box>

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import {
   Box,
   Button,
@@ -51,6 +51,8 @@ import {
   revokeInviteLink,
   getCurrentInviteLink,
   getLeagueInvitations,
+  getLeagueMembershipInvites,
+  cancelMembershipInvite,
   getAllLeagues,
   getUsers,
   createLeague,
@@ -59,6 +61,7 @@ import {
   deleteLeague,
   type LeagueInviteLinkDto,
   type InvitationDto,
+  type MembershipInviteStatusDto,
 } from '../api/league';
 import type { LeagueInfoDto, LeagueJuiceMappingDto, LeagueCostDto, UserSummaryDto } from '../types/admin';
 import type { LeagueUserMappingDto } from '../types/league';
@@ -124,6 +127,9 @@ export default function LeaguePortalPage() {
 
   // Email invitations sent to this league
   const [invitations, setInvitations] = useState<InvitationDto[]>([]);
+  // Pending/accepted/declined invites sent to already-registered users for this league
+  const [membershipInvites, setMembershipInvites] = useState<MembershipInviteStatusDto[]>([]);
+  const [cancelingMembershipInviteId, setCancelingMembershipInviteId] = useState<number | null>(null);
 
   // Juice settings
   const [juiceMappings, setJuiceMappings] = useState<LeagueJuiceMappingDto[]>([]);
@@ -230,6 +236,7 @@ export default function LeaguePortalPage() {
     void loadJuice(selectedLeague.id);
     getCurrentInviteLink(selectedLeague.id).then(setInviteLink).catch(() => setInviteLink(null));
     getLeagueInvitations(selectedLeague.id).then(setInvitations).catch(() => setInvitations([]));
+    getLeagueMembershipInvites(selectedLeague.id).then(setMembershipInvites).catch(() => setMembershipInvites([]));
   }, [selectedLeague, loadMembers, loadJuice]);
 
   const handleRemove = async () => {
@@ -252,9 +259,9 @@ export default function LeaguePortalPage() {
     setInviting(true);
     try {
       const result = await inviteToLeague(selectedLeague.id, inviteEmail.trim());
-      if (result.addedExistingUser) {
-        toast.push(`${inviteEmail} added to the league`, 'success');
-        loadMembers(selectedLeague.id).catch(() => {});
+      if (result.outcome === 'ExistingUserInvitePending') {
+        toast.push(`Invite sent to ${inviteEmail} — pending their acceptance`, 'success');
+        getLeagueMembershipInvites(selectedLeague.id).then(setMembershipInvites).catch(() => {});
       } else {
         toast.push(`Invitation sent to ${inviteEmail}`, 'success');
         getLeagueInvitations(selectedLeague.id).then(setInvitations).catch(() => {});
@@ -265,6 +272,20 @@ export default function LeaguePortalPage() {
       toast.push(extractApiErrorMessage(error, 'Failed to send invitation'), 'error');
     } finally {
       setInviting(false);
+    }
+  };
+
+  const handleCancelMembershipInvite = async (id: number) => {
+    if (!selectedLeague) return;
+    setCancelingMembershipInviteId(id);
+    try {
+      await cancelMembershipInvite(id);
+      toast.push('Invite canceled', 'success');
+      getLeagueMembershipInvites(selectedLeague.id).then(setMembershipInvites).catch(() => {});
+    } catch (error) {
+      toast.push(extractApiErrorMessage(error, 'Failed to cancel invite'), 'error');
+    } finally {
+      setCancelingMembershipInviteId(null);
     }
   };
 
@@ -491,6 +512,9 @@ export default function LeaguePortalPage() {
               onGenerateInviteLink={() => void handleGenerateInviteLink()}
               onRevokeInviteLink={() => void handleRevokeInviteLink()}
               invitations={invitations}
+              membershipInvites={membershipInvites}
+              cancelingMembershipInviteId={cancelingMembershipInviteId}
+              onCancelMembershipInvite={(id) => void handleCancelMembershipInvite(id)}
             />
           )}
           {tab === 1 && (
@@ -700,9 +724,12 @@ interface MembersTabProps {
   onGenerateInviteLink: () => void;
   onRevokeInviteLink: () => void;
   invitations: InvitationDto[];
+  membershipInvites: MembershipInviteStatusDto[];
+  cancelingMembershipInviteId: number | null;
+  onCancelMembershipInvite: (id: number) => void;
 }
 
-function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInvite, onAddUser, inviteLink, generatingLink, revokingLink, onGenerateInviteLink, onRevokeInviteLink, invitations }: MembersTabProps) {
+function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInvite, onAddUser, inviteLink, generatingLink, revokingLink, onGenerateInviteLink, onRevokeInviteLink, invitations, membershipInvites, cancelingMembershipInviteId, onCancelMembershipInvite }: MembersTabProps) {
   const count = costDto?.memberCount ?? members.length;
   const cost = computeLeagueCost(count);
   const toast = useToast();
@@ -834,43 +861,87 @@ function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInv
         </Box>
       )}
 
-      {invitations.length > 0 && (
-        <Box sx={{ mt: 3 }}>
-          <Typography variant="subtitle2" sx={{ mb: 1 }}>Sent Invitations</Typography>
-          <Box sx={{ overflowX: 'auto' }}>
-            <Table size="small">
-              <TableHead>
-                <TableRow>
-                  <TableCell>Email</TableCell>
-                  <TableCell>Sent</TableCell>
-                  <TableCell>Status</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {invitations.map((inv) => (
-                  <TableRow key={inv.id}>
-                    <TableCell>{inv.email}</TableCell>
-                    <TableCell>{new Date(inv.createdAt).toLocaleDateString()}</TableCell>
-                    <TableCell>
-                      {inv.isUsed ? (
-                        inv.registeredUserEmailConfirmed ? (
-                          <Chip label="Confirmed" color="success" size="small" />
-                        ) : (
-                          <Chip label="Pending Confirmation" color="warning" size="small" />
-                        )
-                      ) : inv.isExpired ? (
-                        <Chip label="Expired" color="default" size="small" />
-                      ) : (
-                        <Chip label="Pending" color="warning" size="small" />
-                      )}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </Box>
-        </Box>
-      )}
+      <InviteStatusTable
+        title="Sent Invitations"
+        rows={invitations.map((inv) => ({
+          id: inv.id,
+          email: inv.email,
+          createdAt: inv.createdAt,
+          chip: inv.isUsed
+            ? (inv.registeredUserEmailConfirmed
+              ? { label: 'Confirmed', color: 'success' as const }
+              : { label: 'Pending Confirmation', color: 'warning' as const })
+            : inv.isExpired
+              ? { label: 'Expired', color: 'default' as const }
+              : { label: 'Pending', color: 'warning' as const },
+        }))}
+      />
+
+      <InviteStatusTable
+        title="Invites to Existing Users"
+        rows={membershipInvites.map((inv) => ({
+          id: inv.id,
+          email: inv.invitedUserEmail,
+          createdAt: inv.createdAt,
+          chip: inv.status === 'Accepted'
+            ? { label: 'Accepted', color: 'success' as const }
+            : inv.status === 'Declined'
+              ? { label: 'Declined', color: 'error' as const }
+              : { label: 'Pending', color: 'warning' as const },
+          action: inv.status === 'Pending' ? (
+            <Button
+              size="small"
+              color="error"
+              disabled={cancelingMembershipInviteId === inv.id}
+              onClick={() => onCancelMembershipInvite(inv.id)}
+            >
+              Cancel
+            </Button>
+          ) : null,
+        }))}
+        showActions
+      />
+    </Box>
+  );
+}
+
+interface InviteStatusRow {
+  id: number;
+  email: string;
+  createdAt: string;
+  chip: { label: string; color: 'success' | 'warning' | 'error' | 'default' };
+  action?: ReactNode;
+}
+
+/** Shared "Email / Sent / Status[ / Actions]" table for both the Sent Invitations (email invites
+ * to new users) and Invites to Existing Users (membership invites) sections of the Members tab. */
+function InviteStatusTable({ title, rows, showActions = false }: { title: string; rows: InviteStatusRow[]; showActions?: boolean }) {
+  if (rows.length === 0) return null;
+  return (
+    <Box sx={{ mt: 3 }}>
+      <Typography variant="subtitle2" sx={{ mb: 1 }}>{title}</Typography>
+      <Box sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Email</TableCell>
+              <TableCell>Sent</TableCell>
+              <TableCell>Status</TableCell>
+              {showActions && <TableCell align="right">Actions</TableCell>}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row.id}>
+                <TableCell>{row.email}</TableCell>
+                <TableCell>{new Date(row.createdAt).toLocaleDateString()}</TableCell>
+                <TableCell><Chip label={row.chip.label} color={row.chip.color} size="small" /></TableCell>
+                {showActions && <TableCell align="right">{row.action}</TableCell>}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Box>
     </Box>
   );
 }

--- a/Client.React/src/pages/account/LoginPage.tsx
+++ b/Client.React/src/pages/account/LoginPage.tsx
@@ -26,6 +26,9 @@ export default function LoginPage() {
     const raw = params.get('returnUrl') ?? '/dashboard';
     if (!raw.startsWith('/')) return '/dashboard';
     if (raw.startsWith('//')) return '/dashboard';
+    // /logout is a public route (not RequireAuth-guarded — see App.tsx) that clears auth state
+    // as soon as it mounts. A crafted ?returnUrl=/logout would otherwise log a freshly
+    // authenticated user straight back out.
     if (raw === '/logout') return '/dashboard';
     return raw;
   }, [params]);

--- a/Client.React/src/pages/account/RegisterConfirmationPage.tsx
+++ b/Client.React/src/pages/account/RegisterConfirmationPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Button, Stack, Typography } from '@mui/material';
+import { Alert, Button, Stack, Typography } from '@mui/material';
 
 export default function RegisterConfirmationPage() {
   const location = useLocation();
@@ -11,9 +11,9 @@ export default function RegisterConfirmationPage() {
   return (
     <Stack spacing={2} sx={{ maxWidth: 520, margin: '0 auto', paddingTop: 6 }}>
       <Typography variant="h4">Register confirmation</Typography>
-      <Typography variant="body1">
+      <Alert severity="info">
         {email ? `Check ${email} to confirm your account.` : 'Please check your email to confirm your account.'}
-      </Typography>
+      </Alert>
       <Button variant="contained" onClick={() => navigate('/account/login')}>
         Go to login
       </Button>

--- a/Client.React/src/pages/account/RegisterPage.tsx
+++ b/Client.React/src/pages/account/RegisterPage.tsx
@@ -112,7 +112,7 @@ export default function RegisterPage() {
       <Typography variant="h4">Register</Typography>
       {leagueName && (
         <Alert severity="info">
-          You've been invited to join <strong>{leagueName}</strong>
+          You're registering for IV League and joining <strong>{leagueName}</strong>.
         </Alert>
       )}
       <Card>

--- a/Client.React/src/pages/account/ResendEmailConfirmationPage.tsx
+++ b/Client.React/src/pages/account/ResendEmailConfirmationPage.tsx
@@ -51,7 +51,9 @@ export default function ResendEmailConfirmationPage() {
   return (
     <Stack spacing={3} sx={{ maxWidth: 520, margin: '0 auto', paddingTop: 6 }}>
       <Typography variant="h4">Resend email confirmation</Typography>
-      <Typography variant="body1">Enter your email.</Typography>
+      <Typography variant="body1">
+        Your account isn't confirmed yet. Enter your email to get a new confirmation link.
+      </Typography>
       <StatusMessage message={message} severity={severity} />
       <Card>
         <CardContent>

--- a/Client.React/src/services/session.tsx
+++ b/Client.React/src/services/session.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { getLeagueUserMappingsForUser, getMyLeagues } from '../api/league';
+import { getLeagueUserMappingsForUser, getMyLeagues, getMyPendingMembershipInvites } from '../api/league';
+import type { PendingMembershipInviteDto } from '../api/league';
 import type { LeagueUserMappingDto } from '../types/league';
 import type { LeagueInfoDto } from '../types/admin';
 import { useAuth } from './auth';
@@ -15,6 +16,8 @@ interface SessionContextValue {
   hasCfbAccess: boolean;
   leaguesLoaded: boolean;
   ownedLeagues: LeagueInfoDto[];
+  pendingMembershipInvites: PendingMembershipInviteDto[];
+  refreshPendingInvites: () => Promise<void>;
 }
 
 const SessionContext = createContext<SessionContextValue | undefined>(undefined);
@@ -35,6 +38,7 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
   const [hasCfbAccess, setHasCfbAccess] = useState(false);
   const [leaguesLoaded, setLeaguesLoaded] = useState(false);
   const [ownedLeagues, setOwnedLeagues] = useState<LeagueInfoDto[]>([]);
+  const [pendingMembershipInvites, setPendingMembershipInvites] = useState<PendingMembershipInviteDto[]>([]);
 
   const persistLeague = useCallback((leagueId: number | null) => {
     if (leagueId === null) {
@@ -81,6 +85,18 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
     setLeaguesLoaded(true);
   }, [persistLeague, user, sport]);
 
+  const refreshPendingInvites = useCallback(async () => {
+    if (!user?.userId) {
+      setPendingMembershipInvites([]);
+      return;
+    }
+    try {
+      setPendingMembershipInvites(await getMyPendingMembershipInvites());
+    } catch {
+      setPendingMembershipInvites([]);
+    }
+  }, [user]);
+
   const selectLeague = useCallback(
     (leagueId: number) => {
       setCurrentLeague(leagueId);
@@ -93,6 +109,7 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
     setAvailableLeagues([]);
     setCurrentLeague(null);
     persistLeague(null);
+    setPendingMembershipInvites([]);
   }, [persistLeague]);
 
   useEffect(() => {
@@ -101,9 +118,21 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
     });
   }, [reloadLeagues]);
 
+  useEffect(() => {
+    void refreshPendingInvites();
+  }, [refreshPendingInvites]);
+
   const value = useMemo(
-    () => ({ availableLeagues, currentLeague, selectLeague, reloadLeagues, clearSession, hasNflAccess, hasCfbAccess, leaguesLoaded, ownedLeagues }),
-    [availableLeagues, clearSession, currentLeague, reloadLeagues, selectLeague, hasNflAccess, hasCfbAccess, leaguesLoaded, ownedLeagues]
+    () => ({
+      availableLeagues, currentLeague, selectLeague, reloadLeagues, clearSession,
+      hasNflAccess, hasCfbAccess, leaguesLoaded, ownedLeagues,
+      pendingMembershipInvites, refreshPendingInvites,
+    }),
+    [
+      availableLeagues, clearSession, currentLeague, reloadLeagues, selectLeague,
+      hasNflAccess, hasCfbAccess, leaguesLoaded, ownedLeagues,
+      pendingMembershipInvites, refreshPendingInvites,
+    ]
   );
 
   return <SessionContext.Provider value={value}>{children}</SessionContext.Provider>;

--- a/Client.React/src/setupTests.ts
+++ b/Client.React/src/setupTests.ts
@@ -1,5 +1,22 @@
 import '@testing-library/jest-dom/vitest';
 
+// Node 22+'s own experimental `--localstorage-file` global clobbers jsdom's window.localStorage
+// (they end up as the same broken object, missing getItem/setItem) — swap in a plain in-memory
+// Storage stub so code under test that reads localStorage directly doesn't crash.
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+  get length() { return this.store.size; }
+  clear() { this.store.clear(); }
+  getItem(key: string) { return this.store.has(key) ? this.store.get(key)! : null; }
+  key(index: number) { return Array.from(this.store.keys())[index] ?? null; }
+  removeItem(key: string) { this.store.delete(key); }
+  setItem(key: string, value: string) { this.store.set(key, String(value)); }
+}
+Object.defineProperty(globalThis, 'localStorage', {
+  value: new MemoryStorage(),
+  configurable: true,
+});
+
 if (!window.matchMedia) {
   window.matchMedia = ((query: string) => ({
     matches: false,

--- a/Server.UnitTests/LeagueControllerDtoTests.cs
+++ b/Server.UnitTests/LeagueControllerDtoTests.cs
@@ -34,7 +34,8 @@ public class LeagueControllerDtoTests
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
             Substitute.For<IInvitationService>(),
-            Substitute.For<ILeagueInviteLinkService>());
+            Substitute.For<ILeagueInviteLinkService>(),
+            Substitute.For<ILeagueMembershipInviteService>());
 
         controller.ControllerContext = new ControllerContext
         {

--- a/Server.UnitTests/LeagueInviteLinkTests.cs
+++ b/Server.UnitTests/LeagueInviteLinkTests.cs
@@ -5,6 +5,7 @@ using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models.Data.Dtos;
+using FourPlayWebApp.Shared.Models.Enum;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -28,7 +29,8 @@ public class LeagueInviteLinkTests
         ClaimsPrincipal principal,
         ILeagueRepository? repo = null,
         ILeagueInviteLinkService? linkService = null,
-        IInvitationService? invitationService = null)
+        IInvitationService? invitationService = null,
+        ILeagueMembershipInviteService? membershipInviteService = null)
     {
         var store = Substitute.For<IUserStore<ApplicationUser>>();
         var userManager = Substitute.For<UserManager<ApplicationUser>>(
@@ -42,7 +44,8 @@ public class LeagueInviteLinkTests
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
             invitationService ?? Substitute.For<IInvitationService>(),
-            linkService ?? Substitute.For<ILeagueInviteLinkService>());
+            linkService ?? Substitute.For<ILeagueInviteLinkService>(),
+            membershipInviteService ?? Substitute.For<ILeagueMembershipInviteService>());
 
         controller.ControllerContext = new ControllerContext
         {
@@ -366,6 +369,64 @@ public class LeagueInviteLinkTests
         var controller = BuildController(BuildPrincipal("admin-user", isAdmin: true), repo: repo, invitationService: invSvc);
 
         var result = await controller.GetLeagueInvitations(1);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    // ── GetLeagueMembershipInvites ────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetLeagueMembershipInvites_ReturnsForbid_WhenCallerIsNotOwnerOrAdmin()
+    {
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "TestLeague" });
+
+        var controller = BuildController(BuildPrincipal(StrangerId), repo: repo);
+
+        var result = await controller.GetLeagueMembershipInvites(1);
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetLeagueMembershipInvites_ReturnsOk_WithMappedDtos()
+    {
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "TestLeague" });
+
+        var membershipSvc = Substitute.For<ILeagueMembershipInviteService>();
+        membershipSvc.GetByLeagueAsync(1).Returns(new List<LeagueMembershipInvite>
+        {
+            new() {
+                Id = 5, LeagueId = 1, InvitedUserId = "invitee-1",
+                InvitedUser = new ApplicationUser { UserName = "bob", Email = "bob@test.com" },
+                Status = MembershipInviteStatus.Pending,
+            }
+        });
+
+        var controller = BuildController(BuildPrincipal(OwnerId), repo: repo, membershipInviteService: membershipSvc);
+
+        var result = await controller.GetLeagueMembershipInvites(1);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var list = Assert.IsAssignableFrom<IEnumerable<MembershipInviteStatusDto>>(ok.Value);
+        var item = Assert.Single(list);
+        Assert.Equal("bob@test.com", item.InvitedUserEmail);
+        Assert.Equal(MembershipInviteStatus.Pending, item.Status);
+    }
+
+    [Fact]
+    public async Task GetLeagueMembershipInvites_ReturnsOk_WhenCallerIsAdmin()
+    {
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "TestLeague" });
+
+        var membershipSvc = Substitute.For<ILeagueMembershipInviteService>();
+        membershipSvc.GetByLeagueAsync(1).Returns(new List<LeagueMembershipInvite>());
+
+        var controller = BuildController(BuildPrincipal("admin-user", isAdmin: true), repo: repo, membershipInviteService: membershipSvc);
+
+        var result = await controller.GetLeagueMembershipInvites(1);
 
         Assert.IsType<OkObjectResult>(result.Result);
     }

--- a/Server.UnitTests/LeagueMembershipInviteServiceTests.cs
+++ b/Server.UnitTests/LeagueMembershipInviteServiceTests.cs
@@ -1,0 +1,332 @@
+using FourPlayWebApp.Server.Data;
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Models.Identity;
+using FourPlayWebApp.Server.Services;
+using FourPlayWebApp.Shared.Models.Enum;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Xunit;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+/// <summary>
+/// Service-level tests for LeagueMembershipInviteService. Mirrors LeagueInviteLinkServiceTests'
+/// SQLite-in-memory-with-shared-cache setup — no ExecuteUpdateAsync/ExecuteDeleteAsync here (all
+/// writes go through tracked entities + SaveChangesAsync), so SQLite is a faithful stand-in.
+/// </summary>
+public class LeagueMembershipInviteServiceTests
+{
+    private static ApplicationDbContext OpenDb(string dbName) =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite($"Data Source={dbName};Mode=Memory;Cache=Shared")
+            .Options);
+
+    private static IDbContextFactory<ApplicationDbContext> BuildFactory(string dbName)
+    {
+        var factory = Substitute.For<IDbContextFactory<ApplicationDbContext>>();
+        factory.CreateDbContextAsync().Returns(_ => Task.FromResult(OpenDb(dbName)));
+        return factory;
+    }
+
+    private static async Task WithDb(string dbName, Func<IDbContextFactory<ApplicationDbContext>, Task> action)
+    {
+        await using var keepAlive = new SqliteConnection($"Data Source={dbName};Mode=Memory;Cache=Shared");
+        await keepAlive.OpenAsync();
+        await using (var init = OpenDb(dbName)) { await init.Database.EnsureCreatedAsync(); }
+        await action(BuildFactory(dbName));
+    }
+
+    private static async Task SeedUser(ApplicationDbContext db, string userId, string? email = null)
+    {
+        db.Users.Add(new ApplicationUser
+        {
+            Id = userId,
+            UserName = userId,
+            NormalizedUserName = userId.ToUpperInvariant(),
+            Email = email ?? $"{userId}@example.com",
+            SecurityStamp = Guid.NewGuid().ToString(),
+            ConcurrencyStamp = Guid.NewGuid().ToString(),
+        });
+        await db.SaveChangesAsync();
+    }
+
+    // ── CreateOrReopenAsync ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateOrReopenAsync_NoExistingInvite_CreatesPendingRow()
+    {
+        var db = nameof(CreateOrReopenAsync_NoExistingInvite_CreatesPendingRow);
+        await WithDb(db, async factory =>
+        {
+            await using (var seed = OpenDb(db))
+            {
+                await SeedUser(seed, "owner");
+                await SeedUser(seed, "invitee");
+                seed.LeagueInfo.Add(new LeagueInfo { Id = 1, LeagueName = "Test", OwnerUserId = "owner" });
+                await seed.SaveChangesAsync();
+            }
+
+            await new LeagueMembershipInviteService(factory).CreateOrReopenAsync(1, "invitee", "owner");
+
+            await using var verify = OpenDb(db);
+            var invite = await verify.LeagueMembershipInvites.SingleAsync();
+            Assert.Equal(1, invite.LeagueId);
+            Assert.Equal("invitee", invite.InvitedUserId);
+            Assert.Equal("owner", invite.InvitedByUserId);
+            Assert.Equal(MembershipInviteStatus.Pending, invite.Status);
+            Assert.Null(invite.RespondedAt);
+        });
+    }
+
+    [Fact]
+    public async Task CreateOrReopenAsync_ConcurrentCallsForSameNewPair_BothSucceed_ExactlyOneRowCreated()
+    {
+        // TOCTOU: two concurrent invites for a not-yet-invited user racing the unique index on
+        // (LeagueId, InvitedUserId) — the loser's insert must be swallowed, not thrown, since the
+        // winner's row already lands as Pending, which is exactly the outcome both callers wanted.
+        var db = nameof(CreateOrReopenAsync_ConcurrentCallsForSameNewPair_BothSucceed_ExactlyOneRowCreated);
+        await WithDb(db, async factory =>
+        {
+            await using (var seed = OpenDb(db))
+            {
+                await SeedUser(seed, "owner");
+                await SeedUser(seed, "invitee");
+                seed.LeagueInfo.Add(new LeagueInfo { Id = 1, LeagueName = "Test", OwnerUserId = "owner" });
+                await seed.SaveChangesAsync();
+            }
+
+            var serviceA = new LeagueMembershipInviteService(factory);
+            var serviceB = new LeagueMembershipInviteService(factory);
+
+            await Task.WhenAll(
+                serviceA.CreateOrReopenAsync(1, "invitee", "owner"),
+                serviceB.CreateOrReopenAsync(1, "invitee", "owner"));
+
+            await using var verify = OpenDb(db);
+            Assert.Equal(1, await verify.LeagueMembershipInvites.CountAsync());
+            var invite = await verify.LeagueMembershipInvites.SingleAsync();
+            Assert.Equal(MembershipInviteStatus.Pending, invite.Status);
+        });
+    }
+
+    [Fact]
+    public async Task CreateOrReopenAsync_PreviouslyDeclinedInvite_ResetsToPending_WithoutDuplicateRow()
+    {
+        var db = nameof(CreateOrReopenAsync_PreviouslyDeclinedInvite_ResetsToPending_WithoutDuplicateRow);
+        await WithDb(db, async factory =>
+        {
+            await using (var seed = OpenDb(db))
+            {
+                await SeedUser(seed, "owner");
+                await SeedUser(seed, "invitee");
+                seed.LeagueInfo.Add(new LeagueInfo { Id = 1, LeagueName = "Test", OwnerUserId = "owner" });
+                seed.LeagueMembershipInvites.Add(new LeagueMembershipInvite
+                {
+                    LeagueId = 1, InvitedUserId = "invitee", InvitedByUserId = "owner",
+                    Status = MembershipInviteStatus.Declined, RespondedAt = DateTimeOffset.UtcNow.AddDays(-1),
+                });
+                await seed.SaveChangesAsync();
+            }
+
+            await new LeagueMembershipInviteService(factory).CreateOrReopenAsync(1, "invitee", "owner");
+
+            await using var verify = OpenDb(db);
+            Assert.Equal(1, await verify.LeagueMembershipInvites.CountAsync());
+            var invite = await verify.LeagueMembershipInvites.SingleAsync();
+            Assert.Equal(MembershipInviteStatus.Pending, invite.Status);
+            Assert.Null(invite.RespondedAt);
+        });
+    }
+
+    // ── GetByIdAsync ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNull_WhenNotFound()
+    {
+        await WithDb(nameof(GetByIdAsync_ReturnsNull_WhenNotFound), async factory =>
+        {
+            var result = await new LeagueMembershipInviteService(factory).GetByIdAsync(999);
+            Assert.Null(result);
+        });
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsTheInvite_WhenFound()
+    {
+        var db = nameof(GetByIdAsync_ReturnsTheInvite_WhenFound);
+        await WithDb(db, async factory =>
+        {
+            int id;
+            await using (var seed = OpenDb(db))
+            {
+                await SeedUser(seed, "owner");
+                await SeedUser(seed, "invitee");
+                seed.LeagueInfo.Add(new LeagueInfo { Id = 1, LeagueName = "Test League", OwnerUserId = "owner" });
+                var invite = new LeagueMembershipInvite { LeagueId = 1, InvitedUserId = "invitee", InvitedByUserId = "owner" };
+                seed.LeagueMembershipInvites.Add(invite);
+                await seed.SaveChangesAsync();
+                id = invite.Id;
+            }
+
+            var result = await new LeagueMembershipInviteService(factory).GetByIdAsync(id);
+
+            Assert.NotNull(result);
+            Assert.Equal(1, result!.LeagueId);
+            Assert.Equal("invitee", result.InvitedUserId);
+        });
+    }
+
+    // ── GetPendingForUserAsync ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetPendingForUserAsync_ReturnsOnlyPendingInvitesForThatUser()
+    {
+        var db = nameof(GetPendingForUserAsync_ReturnsOnlyPendingInvitesForThatUser);
+        await WithDb(db, async factory =>
+        {
+            await using (var seed = OpenDb(db))
+            {
+                await SeedUser(seed, "owner");
+                await SeedUser(seed, "invitee");
+                await SeedUser(seed, "other-user");
+                seed.LeagueInfo.AddRange(
+                    new LeagueInfo { Id = 1, LeagueName = "League One", OwnerUserId = "owner" },
+                    new LeagueInfo { Id = 2, LeagueName = "League Two", OwnerUserId = "owner" });
+                seed.LeagueMembershipInvites.AddRange(
+                    new LeagueMembershipInvite { LeagueId = 1, InvitedUserId = "invitee", InvitedByUserId = "owner", Status = MembershipInviteStatus.Pending },
+                    new LeagueMembershipInvite { LeagueId = 2, InvitedUserId = "invitee", InvitedByUserId = "owner", Status = MembershipInviteStatus.Accepted },
+                    new LeagueMembershipInvite { LeagueId = 1, InvitedUserId = "other-user", InvitedByUserId = "owner", Status = MembershipInviteStatus.Pending });
+                await seed.SaveChangesAsync();
+            }
+
+            var result = await new LeagueMembershipInviteService(factory).GetPendingForUserAsync("invitee");
+
+            var invite = Assert.Single(result);
+            Assert.Equal(1, invite.LeagueId);
+        });
+    }
+
+    // ── MarkAcceptedAsync / MarkDeclinedAsync ────────────────────────────────
+
+    [Fact]
+    public async Task MarkAcceptedAsync_SetsStatusAndRespondedAt()
+    {
+        var db = nameof(MarkAcceptedAsync_SetsStatusAndRespondedAt);
+        await WithDb(db, async factory =>
+        {
+            int id;
+            await using (var seed = OpenDb(db))
+            {
+                await SeedUser(seed, "owner");
+                await SeedUser(seed, "invitee");
+                seed.LeagueInfo.Add(new LeagueInfo { Id = 1, LeagueName = "Test", OwnerUserId = "owner" });
+                var invite = new LeagueMembershipInvite { LeagueId = 1, InvitedUserId = "invitee", InvitedByUserId = "owner" };
+                seed.LeagueMembershipInvites.Add(invite);
+                await seed.SaveChangesAsync();
+                id = invite.Id;
+            }
+
+            await new LeagueMembershipInviteService(factory).MarkAcceptedAsync(id);
+
+            await using var verify = OpenDb(db);
+            var updated = await verify.LeagueMembershipInvites.SingleAsync();
+            Assert.Equal(MembershipInviteStatus.Accepted, updated.Status);
+            Assert.NotNull(updated.RespondedAt);
+        });
+    }
+
+    [Fact]
+    public async Task MarkDeclinedAsync_SetsStatusAndRespondedAt()
+    {
+        var db = nameof(MarkDeclinedAsync_SetsStatusAndRespondedAt);
+        await WithDb(db, async factory =>
+        {
+            int id;
+            await using (var seed = OpenDb(db))
+            {
+                await SeedUser(seed, "owner");
+                await SeedUser(seed, "invitee");
+                seed.LeagueInfo.Add(new LeagueInfo { Id = 1, LeagueName = "Test", OwnerUserId = "owner" });
+                var invite = new LeagueMembershipInvite { LeagueId = 1, InvitedUserId = "invitee", InvitedByUserId = "owner" };
+                seed.LeagueMembershipInvites.Add(invite);
+                await seed.SaveChangesAsync();
+                id = invite.Id;
+            }
+
+            await new LeagueMembershipInviteService(factory).MarkDeclinedAsync(id);
+
+            await using var verify = OpenDb(db);
+            var updated = await verify.LeagueMembershipInvites.SingleAsync();
+            Assert.Equal(MembershipInviteStatus.Declined, updated.Status);
+            Assert.NotNull(updated.RespondedAt);
+        });
+    }
+
+    // ── DeleteAsync ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteAsync_RemovesTheInvite()
+    {
+        var db = nameof(DeleteAsync_RemovesTheInvite);
+        await WithDb(db, async factory =>
+        {
+            int id;
+            await using (var seed = OpenDb(db))
+            {
+                await SeedUser(seed, "owner");
+                await SeedUser(seed, "invitee");
+                seed.LeagueInfo.Add(new LeagueInfo { Id = 1, LeagueName = "Test", OwnerUserId = "owner" });
+                var invite = new LeagueMembershipInvite { LeagueId = 1, InvitedUserId = "invitee", InvitedByUserId = "owner" };
+                seed.LeagueMembershipInvites.Add(invite);
+                await seed.SaveChangesAsync();
+                id = invite.Id;
+            }
+
+            await new LeagueMembershipInviteService(factory).DeleteAsync(id);
+
+            await using var verify = OpenDb(db);
+            Assert.Equal(0, await verify.LeagueMembershipInvites.CountAsync());
+        });
+    }
+
+    [Fact]
+    public async Task DeleteAsync_NonExistentId_DoesNotThrow()
+    {
+        await WithDb(nameof(DeleteAsync_NonExistentId_DoesNotThrow), async factory =>
+        {
+            await new LeagueMembershipInviteService(factory).DeleteAsync(999);
+        });
+    }
+
+    // ── GetByLeagueAsync ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetByLeagueAsync_ReturnsAllStatusesForThatLeague_NewestFirst()
+    {
+        var db = nameof(GetByLeagueAsync_ReturnsAllStatusesForThatLeague_NewestFirst);
+        await WithDb(db, async factory =>
+        {
+            await using (var seed = OpenDb(db))
+            {
+                await SeedUser(seed, "owner");
+                await SeedUser(seed, "invitee-1", "invitee1@example.com");
+                await SeedUser(seed, "invitee-2", "invitee2@example.com");
+                seed.LeagueInfo.AddRange(
+                    new LeagueInfo { Id = 1, LeagueName = "League One", OwnerUserId = "owner" },
+                    new LeagueInfo { Id = 2, LeagueName = "League Two", OwnerUserId = "owner" });
+                seed.LeagueMembershipInvites.AddRange(
+                    new LeagueMembershipInvite { LeagueId = 1, InvitedUserId = "invitee-1", InvitedByUserId = "owner", Status = MembershipInviteStatus.Pending },
+                    new LeagueMembershipInvite { LeagueId = 1, InvitedUserId = "invitee-2", InvitedByUserId = "owner", Status = MembershipInviteStatus.Declined },
+                    new LeagueMembershipInvite { LeagueId = 2, InvitedUserId = "invitee-1", InvitedByUserId = "owner", Status = MembershipInviteStatus.Pending });
+                await seed.SaveChangesAsync();
+            }
+
+            var result = await new LeagueMembershipInviteService(factory).GetByLeagueAsync(1);
+
+            Assert.Equal(2, result.Count);
+            Assert.All(result, i => Assert.Equal(1, i.LeagueId));
+            Assert.All(result, i => Assert.NotNull(i.InvitedUser?.Email));
+        });
+    }
+}

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -42,7 +42,8 @@ public class LeagueOwnershipTests
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
             Substitute.For<IInvitationService>(),
-            Substitute.For<ILeagueInviteLinkService>());
+            Substitute.For<ILeagueInviteLinkService>(),
+            Substitute.For<ILeagueMembershipInviteService>());
 
         controller.ControllerContext = new ControllerContext
         {
@@ -99,7 +100,8 @@ public class LeagueOwnershipTests
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
             Substitute.For<IInvitationService>(),
-            Substitute.For<ILeagueInviteLinkService>());
+            Substitute.For<ILeagueInviteLinkService>(),
+            Substitute.For<ILeagueMembershipInviteService>());
 
         controller.ControllerContext = new ControllerContext
         {
@@ -132,7 +134,8 @@ public class LeagueOwnershipTests
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
             Substitute.For<IInvitationService>(),
-            Substitute.For<ILeagueInviteLinkService>());
+            Substitute.For<ILeagueInviteLinkService>(),
+            Substitute.For<ILeagueMembershipInviteService>());
 
         controller.ControllerContext = new ControllerContext
         {
@@ -146,11 +149,12 @@ public class LeagueOwnershipTests
 
     // ─── Commissioner Portal: owner-scoped endpoint tests ───────────────────
 
-    private static (LeagueController ctrl, ILeagueRepository repo, UserManager<ApplicationUser> userManager, IInvitationService invitationService)
+    private static (LeagueController ctrl, ILeagueRepository repo, UserManager<ApplicationUser> userManager, IInvitationService invitationService, ILeagueMembershipInviteService membershipInviteService)
         BuildFullController(ClaimsPrincipal principal)
     {
         var repo = Substitute.For<ILeagueRepository>();
         var invSvc = Substitute.For<IInvitationService>();
+        var membershipInviteSvc = Substitute.For<ILeagueMembershipInviteService>();
         var store = Substitute.For<IUserStore<ApplicationUser>>();
         var userManager = Substitute.For<UserManager<ApplicationUser>>(
             store, null, null, null, null, null, null, null, null);
@@ -162,17 +166,18 @@ public class LeagueOwnershipTests
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
             invSvc,
-            Substitute.For<ILeagueInviteLinkService>());
+            Substitute.For<ILeagueInviteLinkService>(),
+            membershipInviteSvc);
         ctrl.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext { User = principal }
         };
-        return (ctrl, repo, userManager, invSvc);
+        return (ctrl, repo, userManager, invSvc, membershipInviteSvc);
     }
 
     private static (LeagueController ctrl, ILeagueRepository repo) BuildControllerWithRepo(ClaimsPrincipal principal)
     {
-        var (ctrl, repo, _, _) = BuildFullController(principal);
+        var (ctrl, repo, _, _, _) = BuildFullController(principal);
         return (ctrl, repo);
     }
 
@@ -620,7 +625,8 @@ public class LeagueOwnershipTests
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
             invSvc,
-            Substitute.For<ILeagueInviteLinkService>());
+            Substitute.For<ILeagueInviteLinkService>(),
+            Substitute.For<ILeagueMembershipInviteService>());
         ctrl.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext { User = BuildPrincipal(OwnerId) }
@@ -652,7 +658,8 @@ public class LeagueOwnershipTests
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
             invSvc,
-            Substitute.For<ILeagueInviteLinkService>());
+            Substitute.For<ILeagueInviteLinkService>(),
+            Substitute.For<ILeagueMembershipInviteService>());
         ctrl.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext { User = BuildPrincipal(OwnerId) }
@@ -663,17 +670,17 @@ public class LeagueOwnershipTests
         await invSvc.Received(1).CreateInvitationAsync("target@example.com", OwnerId, 1, baseUrl: "https://ivleague.com");
     }
 
-    private static (LeagueController ctrl, ILeagueRepository repo, UserManager<ApplicationUser> userManager, IInvitationService invitationService)
+    private static (LeagueController ctrl, ILeagueRepository repo, UserManager<ApplicationUser> userManager, IInvitationService invitationService, ILeagueMembershipInviteService membershipInviteService)
         BuildControllerWithUserManager(ClaimsPrincipal principal) => BuildFullController(principal);
 
     [Fact]
-    public async Task InviteToLeague_ExistingUser_NotYetMember_AddsDirectly_WithoutCreatingInvitation()
+    public async Task InviteToLeague_ExistingUser_NotYetMember_CreatesPendingMembershipInvite_NoEmailNoDirectAdd()
     {
         // The whole point: someone who already has an IV League account (whether they own a
-        // league or belong to one) must be addable to a NEW league without re-registering —
-        // previously InviteToLeague always created an Invitation, and re-registering with an
-        // email that already exists fails with "User already exists", leaving a dead invite.
-        var (ctrl, repo, userManager, invSvc) = BuildControllerWithUserManager(BuildPrincipal(OwnerId));
+        // league or belong to one) must be addable to a NEW league without re-registering — but
+        // unlike a brand-new user (registering IS joining), an existing user must explicitly
+        // accept a pending invite rather than being added instantly with no consent.
+        var (ctrl, repo, userManager, invSvc, membershipSvc) = BuildControllerWithUserManager(BuildPrincipal(OwnerId));
         repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
         var existingUser = new ApplicationUser { Id = "existing-user-1", Email = "already-registered@example.com" };
         userManager.FindByEmailAsync("already-registered@example.com").Returns(existingUser);
@@ -683,16 +690,16 @@ public class LeagueOwnershipTests
 
         var ok = Assert.IsType<OkObjectResult>(result);
         var dto = Assert.IsType<LeagueInviteResultDto>(ok.Value);
-        Assert.True(dto.AddedExistingUser);
-        await repo.Received(1).AddLeagueUserMappingAsync(
-            Arg.Is<LeagueUserMapping>(m => m.UserId == "existing-user-1" && m.LeagueId == 1));
+        Assert.Equal(LeagueInviteOutcome.ExistingUserInvitePending, dto.Outcome);
+        await membershipSvc.Received(1).CreateOrReopenAsync(1, "existing-user-1", OwnerId);
+        await repo.DidNotReceiveWithAnyArgs().AddLeagueUserMappingAsync(default!);
         await invSvc.DidNotReceiveWithAnyArgs().CreateInvitationAsync(default!, default!, default, default);
     }
 
     [Fact]
-    public async Task InviteToLeague_ExistingUser_AlreadyMember_ReturnsConflict_WithoutDuplicateMapping()
+    public async Task InviteToLeague_ExistingUser_AlreadyMember_ReturnsConflict_WithoutCreatingInvite()
     {
-        var (ctrl, repo, userManager, invSvc) = BuildControllerWithUserManager(BuildPrincipal(OwnerId));
+        var (ctrl, repo, userManager, invSvc, membershipSvc) = BuildControllerWithUserManager(BuildPrincipal(OwnerId));
         repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
         var existingUser = new ApplicationUser { Id = "existing-user-1", Email = "already-member@example.com" };
         userManager.FindByEmailAsync("already-member@example.com").Returns(existingUser);
@@ -701,27 +708,172 @@ public class LeagueOwnershipTests
         var result = await ctrl.InviteToLeague(1, new LeagueInviteDto("already-member@example.com"));
 
         Assert.IsType<ConflictObjectResult>(result);
+        await membershipSvc.DidNotReceiveWithAnyArgs().CreateOrReopenAsync(default, default!, default!);
         await repo.DidNotReceiveWithAnyArgs().AddLeagueUserMappingAsync(default!);
         await invSvc.DidNotReceiveWithAnyArgs().CreateInvitationAsync(default!, default!, default, default);
     }
 
-    [Fact]
-    public async Task InviteToLeague_ExistingUser_ConcurrentAddRace_ReturnsConflict_NotUnhandledException()
-    {
-        // TOCTOU: UserExistsInLeagueAsync says "not yet a member", but a concurrent request wins
-        // the insert first — the unique-constraint violation must surface as a 409, same as
-        // JoinViaLink already guards against, not an unhandled 500.
-        var (ctrl, repo, userManager, _) = BuildControllerWithUserManager(BuildPrincipal(OwnerId));
-        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
-        var existingUser = new ApplicationUser { Id = "existing-user-1", Email = "race@example.com" };
-        userManager.FindByEmailAsync("race@example.com").Returns(existingUser);
-        repo.UserExistsInLeagueAsync("existing-user-1", 1).Returns(false);
-        repo.AddLeagueUserMappingAsync(Arg.Any<LeagueUserMapping>())
-            .Returns(Task.FromException(new DbUpdateException("unique constraint", new Exception("inner"))));
+    // ── GET membership-invites/mine ─────────────────────────────────────────
 
-        var result = await ctrl.InviteToLeague(1, new LeagueInviteDto("race@example.com"));
+    [Fact]
+    public async Task GetMyPendingMembershipInvites_ReturnsWhatTheServiceProvidesForCaller()
+    {
+        var (ctrl, _, _, _, membershipSvc) = BuildControllerWithUserManager(BuildPrincipal(OwnerId));
+        var invite = new LeagueMembershipInvite {
+            Id = 5,
+            LeagueId = 1,
+            League = new LeagueInfo { Id = 1, OwnerUserId = "someone-else", LeagueName = "L" },
+            InvitedUserId = OwnerId,
+            InvitedByUser = new ApplicationUser { UserName = "commish" },
+        };
+        membershipSvc.GetPendingForUserAsync(OwnerId).Returns([invite]);
+
+        var result = await ctrl.GetMyPendingMembershipInvites();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dtos = Assert.IsAssignableFrom<IReadOnlyList<PendingMembershipInviteDto>>(ok.Value);
+        Assert.Single(dtos);
+        Assert.Equal(5, dtos[0].Id);
+        Assert.Equal("L", dtos[0].LeagueName);
+        Assert.Equal("commish", dtos[0].InvitedByUserName);
+    }
+
+    // ── POST membership-invites/{id}/accept ─────────────────────────────────
+
+    [Fact]
+    public async Task AcceptMembershipInvite_ReturnsNotFound_WhenInviteDoesNotExist()
+    {
+        var (ctrl, _, _, _, membershipSvc) = BuildControllerWithUserManager(BuildPrincipal(OwnerId));
+        membershipSvc.GetByIdAsync(999).Returns((LeagueMembershipInvite?)null);
+
+        var result = await ctrl.AcceptMembershipInvite(999);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task AcceptMembershipInvite_ReturnsForbid_WhenCallerIsNotTheInvitedUser()
+    {
+        var (ctrl, _, _, _, membershipSvc) = BuildControllerWithUserManager(BuildPrincipal(AttackerId));
+        membershipSvc.GetByIdAsync(5).Returns(new LeagueMembershipInvite {
+            Id = 5, LeagueId = 1, InvitedUserId = OwnerId, Status = MembershipInviteStatus.Pending,
+        });
+
+        var result = await ctrl.AcceptMembershipInvite(5);
+
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public async Task AcceptMembershipInvite_ReturnsConflict_WhenAlreadyResponded()
+    {
+        var (ctrl, _, _, _, membershipSvc) = BuildControllerWithUserManager(BuildPrincipal(OwnerId));
+        membershipSvc.GetByIdAsync(5).Returns(new LeagueMembershipInvite {
+            Id = 5, LeagueId = 1, InvitedUserId = OwnerId, Status = MembershipInviteStatus.Declined,
+        });
+
+        var result = await ctrl.AcceptMembershipInvite(5);
 
         Assert.IsType<ConflictObjectResult>(result);
+        await membershipSvc.DidNotReceiveWithAnyArgs().MarkAcceptedAsync(default);
+    }
+
+    [Fact]
+    public async Task AcceptMembershipInvite_AddsMembershipAndMarksAccepted_WhenPendingAndOwnedByCaller()
+    {
+        var (ctrl, repo, _, _, membershipSvc) = BuildControllerWithUserManager(BuildPrincipal(OwnerId));
+        membershipSvc.GetByIdAsync(5).Returns(new LeagueMembershipInvite {
+            Id = 5, LeagueId = 1, InvitedUserId = OwnerId, Status = MembershipInviteStatus.Pending,
+        });
+        repo.UserExistsInLeagueAsync(OwnerId, 1).Returns(false);
+
+        var result = await ctrl.AcceptMembershipInvite(5);
+
+        Assert.IsType<NoContentResult>(result);
+        await repo.Received(1).AddLeagueUserMappingAsync(
+            Arg.Is<LeagueUserMapping>(m => m.UserId == OwnerId && m.LeagueId == 1));
+        await membershipSvc.Received(1).MarkAcceptedAsync(5);
+    }
+
+    [Fact]
+    public async Task AcceptMembershipInvite_AlreadyAMemberViaAnotherPath_StillMarksAccepted_NotStuckPending()
+    {
+        // The invite's goal state (membership) is already achieved if the invitee joined via a
+        // share link or a second concurrent accept — it must resolve, not stay Pending forever.
+        var (ctrl, repo, _, _, membershipSvc) = BuildControllerWithUserManager(BuildPrincipal(OwnerId));
+        membershipSvc.GetByIdAsync(5).Returns(new LeagueMembershipInvite {
+            Id = 5, LeagueId = 1, InvitedUserId = OwnerId, Status = MembershipInviteStatus.Pending,
+        });
+        repo.UserExistsInLeagueAsync(OwnerId, 1).Returns(true);
+
+        var result = await ctrl.AcceptMembershipInvite(5);
+
+        Assert.IsType<NoContentResult>(result);
+        await repo.DidNotReceiveWithAnyArgs().AddLeagueUserMappingAsync(default!);
+        await membershipSvc.Received(1).MarkAcceptedAsync(5);
+    }
+
+    // ── POST membership-invites/{id}/decline ────────────────────────────────
+
+    [Fact]
+    public async Task DeclineMembershipInvite_ReturnsForbid_WhenCallerIsNotTheInvitedUser()
+    {
+        var (ctrl, _, _, _, membershipSvc) = BuildControllerWithUserManager(BuildPrincipal(AttackerId));
+        membershipSvc.GetByIdAsync(5).Returns(new LeagueMembershipInvite {
+            Id = 5, LeagueId = 1, InvitedUserId = OwnerId, Status = MembershipInviteStatus.Pending,
+        });
+
+        var result = await ctrl.DeclineMembershipInvite(5);
+
+        Assert.IsType<ForbidResult>(result);
+        await membershipSvc.DidNotReceiveWithAnyArgs().MarkDeclinedAsync(default);
+    }
+
+    [Fact]
+    public async Task DeclineMembershipInvite_MarksDeclined_WithoutAddingMembership_WhenPendingAndOwnedByCaller()
+    {
+        var (ctrl, repo, _, _, membershipSvc) = BuildControllerWithUserManager(BuildPrincipal(OwnerId));
+        membershipSvc.GetByIdAsync(5).Returns(new LeagueMembershipInvite {
+            Id = 5, LeagueId = 1, InvitedUserId = OwnerId, Status = MembershipInviteStatus.Pending,
+        });
+
+        var result = await ctrl.DeclineMembershipInvite(5);
+
+        Assert.IsType<NoContentResult>(result);
+        await membershipSvc.Received(1).MarkDeclinedAsync(5);
+        await repo.DidNotReceiveWithAnyArgs().AddLeagueUserMappingAsync(default!);
+    }
+
+    // ── DELETE membership-invites/{id} (commissioner cancel) ────────────────
+
+    [Fact]
+    public async Task CancelMembershipInvite_ReturnsForbid_WhenCallerIsNotOwnerOrAdmin()
+    {
+        var (ctrl, repo, _, _, membershipSvc) = BuildControllerWithUserManager(BuildPrincipal(AttackerId));
+        membershipSvc.GetByIdAsync(5).Returns(new LeagueMembershipInvite {
+            Id = 5, LeagueId = 1, InvitedUserId = "someone-invited",
+        });
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
+
+        var result = await ctrl.CancelMembershipInvite(5);
+
+        Assert.IsType<ForbidResult>(result);
+        await membershipSvc.DidNotReceiveWithAnyArgs().DeleteAsync(default);
+    }
+
+    [Fact]
+    public async Task CancelMembershipInvite_DeletesInvite_WhenCallerIsOwner()
+    {
+        var (ctrl, repo, _, _, membershipSvc) = BuildControllerWithUserManager(BuildPrincipal(OwnerId));
+        membershipSvc.GetByIdAsync(5).Returns(new LeagueMembershipInvite {
+            Id = 5, LeagueId = 1, InvitedUserId = "someone-invited",
+        });
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
+
+        var result = await ctrl.CancelMembershipInvite(5);
+
+        Assert.IsType<NoContentResult>(result);
+        await membershipSvc.Received(1).DeleteAsync(5);
     }
 
     [Fact]

--- a/Server.UnitTests/NflCurrentWeekEndpointTests.cs
+++ b/Server.UnitTests/NflCurrentWeekEndpointTests.cs
@@ -35,7 +35,8 @@ public class NflCurrentWeekEndpointTests
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
             Substitute.For<IInvitationService>(),
-            Substitute.For<ILeagueInviteLinkService>());
+            Substitute.For<ILeagueInviteLinkService>(),
+            Substitute.For<ILeagueMembershipInviteService>());
 
         controller.ControllerContext = new ControllerContext
         {

--- a/Server.UnitTests/PicksTests.cs
+++ b/Server.UnitTests/PicksTests.cs
@@ -54,7 +54,8 @@ public class PicksTests
             Substitute.For<ISpreadCalculatorBuilder>(),
             espnCacheService,
             Substitute.For<IInvitationService>(),
-            Substitute.For<ILeagueInviteLinkService>());
+            Substitute.For<ILeagueInviteLinkService>(),
+            Substitute.For<ILeagueMembershipInviteService>());
 
         var httpContext = new DefaultHttpContext();
         if (principal is not null)

--- a/Server.UnitTests/SpreadLockScheduleEndpointTests.cs
+++ b/Server.UnitTests/SpreadLockScheduleEndpointTests.cs
@@ -38,7 +38,8 @@ public class SpreadLockScheduleEndpointTests
             Substitute.For<ISpreadCalculatorBuilder>(),
             Substitute.For<IEspnCacheService>(),
             Substitute.For<IInvitationService>(),
-            Substitute.For<ILeagueInviteLinkService>());
+            Substitute.For<ILeagueInviteLinkService>(),
+            Substitute.For<ILeagueMembershipInviteService>());
 
         controller.ControllerContext = new ControllerContext
         {

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -36,7 +36,8 @@ public class LeagueController(
     ISpreadCalculatorBuilder spreadCalculatorBuilder,
     IEspnCacheService espnCacheService,
     IInvitationService invitationService,
-    ILeagueInviteLinkService leagueInviteLinkService) : ControllerBase {
+    ILeagueInviteLinkService leagueInviteLinkService,
+    ILeagueMembershipInviteService membershipInviteService) : ControllerBase {
     // Mirrors CfbPicksController.GetCurrentSlate's role for CFB — exposes NflCurrentWeekService's
     // existing off-season/pre-season fallback (already used internally by NflSpreadJob and
     // EspnCacheService) to the frontend, so nflAdapter.ts no longer falls back to
@@ -933,6 +934,20 @@ public class LeagueController(
         return Ok(invitations.ToDtoList());
     }
 
+    [HttpGet("{leagueId:int}/membership-invites")]
+    [ProducesResponseType(typeof(IReadOnlyList<MembershipInviteStatusDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<IReadOnlyList<MembershipInviteStatusDto>>> GetLeagueMembershipInvites(int leagueId) {
+        LeagueInfo league;
+        try { league = await repo.GetLeagueInfoAsync(leagueId); }
+        catch (InvalidOperationException) { return NotFound(); }
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
+            return Forbid();
+        var invites = await membershipInviteService.GetByLeagueAsync(leagueId);
+        return Ok(invites.ToStatusDtoList());
+    }
+
     [HttpPost("{leagueId:int}/invite")]
     [ProducesResponseType(typeof(LeagueInviteResultDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -949,15 +964,89 @@ public class LeagueController(
         // Someone who already has an account (owns a league or belongs to one) must be
         // addable to a NEW league directly — routing them through CreateInvitationAsync would
         // require them to "register" with an email that already exists, which always fails.
+        // Unlike a brand-new user (registering IS joining, one step), an existing user gets a
+        // pending invite they must explicitly accept — no email; it surfaces as a banner on
+        // their next login. See LeagueMembershipInvite.
         var existingUser = await userManager.FindByEmailAsync(dto.Email);
         if (existingUser != null) {
-            if (!await TryAddUserToLeagueAsync(existingUser.Id, leagueId))
+            if (await repo.UserExistsInLeagueAsync(existingUser.Id, leagueId))
                 return Conflict($"{dto.Email} is already a member of this league.");
-            return Ok(new LeagueInviteResultDto(dto.Email, AddedExistingUser: true));
+            await membershipInviteService.CreateOrReopenAsync(leagueId, existingUser.Id, callerId);
+            return Ok(new LeagueInviteResultDto(dto.Email, LeagueInviteOutcome.ExistingUserInvitePending));
         }
 
         await invitationService.CreateInvitationAsync(dto.Email, callerId, leagueId, baseUrl: dto.BaseUrl);
-        return Ok(new LeagueInviteResultDto(dto.Email, AddedExistingUser: false));
+        return Ok(new LeagueInviteResultDto(dto.Email, LeagueInviteOutcome.NewUserInvitationSent));
+    }
+
+    [HttpGet("membership-invites/mine")]
+    [ProducesResponseType(typeof(IReadOnlyList<PendingMembershipInviteDto>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IReadOnlyList<PendingMembershipInviteDto>>> GetMyPendingMembershipInvites() {
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        var invites = await membershipInviteService.GetPendingForUserAsync(callerId);
+        return Ok(invites.ToPendingDtoList());
+    }
+
+    [HttpPost("membership-invites/{id:int}/accept")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> AcceptMembershipInvite(int id) {
+        var (invite, error) = await LoadOwnPendingMembershipInviteAsync(id);
+        if (error is not null) return error;
+
+        // TryAddUserToLeagueAsync no-ops (returns false) if they're already a member via another
+        // path (e.g. a share link, or a second concurrent accept) — but the invite's goal state
+        // (membership) is already achieved either way, so mark it Accepted rather than leaving it
+        // stuck Pending forever with no way to resolve it short of a commissioner cancel.
+        await TryAddUserToLeagueAsync(invite!.InvitedUserId, invite.LeagueId);
+        await membershipInviteService.MarkAcceptedAsync(id);
+        return NoContent();
+    }
+
+    [HttpPost("membership-invites/{id:int}/decline")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> DeclineMembershipInvite(int id) {
+        var (_, error) = await LoadOwnPendingMembershipInviteAsync(id);
+        if (error is not null) return error;
+
+        await membershipInviteService.MarkDeclinedAsync(id);
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Shared Accept/Decline preamble: 404 if the invite doesn't exist, 403 if it isn't the
+    /// caller's own invite, 409 if it's already been responded to.
+    /// </summary>
+    private async Task<(LeagueMembershipInvite? invite, IActionResult? error)> LoadOwnPendingMembershipInviteAsync(int id) {
+        var invite = await membershipInviteService.GetByIdAsync(id);
+        if (invite is null) return (null, NotFound());
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        if (invite.InvitedUserId != callerId) return (null, Forbid());
+        if (invite.Status != MembershipInviteStatus.Pending)
+            return (null, Conflict("This invite has already been responded to."));
+        return (invite, null);
+    }
+
+    [HttpDelete("membership-invites/{id:int}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> CancelMembershipInvite(int id) {
+        var invite = await membershipInviteService.GetByIdAsync(id);
+        if (invite is null) return NotFound();
+        LeagueInfo league;
+        try { league = await repo.GetLeagueInfoAsync(invite.LeagueId); }
+        catch (InvalidOperationException) { return NotFound(); }
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
+            return Forbid();
+
+        await membershipInviteService.DeleteAsync(id);
+        return NoContent();
     }
 
 }

--- a/Server/Data/ApplicationDbContext.cs
+++ b/Server/Data/ApplicationDbContext.cs
@@ -26,6 +26,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     public DbSet<NflSeasonWeekConfig> NflSeasonWeekConfigs { get; set; }
     public DbSet<CfbRanking> CfbRankings { get; set; }
     public DbSet<LeagueInviteLink> LeagueInviteLinks { get; set; }
+    public DbSet<LeagueMembershipInvite> LeagueMembershipInvites { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder) {
         base.OnModelCreating(modelBuilder);

--- a/Server/Data/Configurations/LeagueMembershipInviteConfiguration.cs
+++ b/Server/Data/Configurations/LeagueMembershipInviteConfiguration.cs
@@ -1,0 +1,31 @@
+using FourPlayWebApp.Server.Models.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FourPlayWebApp.Server.Data.Configurations;
+
+public class LeagueMembershipInviteConfiguration : IEntityTypeConfiguration<LeagueMembershipInvite>
+{
+    public void Configure(EntityTypeBuilder<LeagueMembershipInvite> entity)
+    {
+        // Mirrors InvitationConfiguration's reasoning: the row belongs to the INVITEE (and the
+        // league) — deleting either really does mean "this invite no longer refers to anything."
+        // Deleting the inviter shouldn't destroy the invitee's still-active pending invite.
+        entity.HasOne(e => e.InvitedUser)
+            .WithMany()
+            .HasForeignKey(e => e.InvitedUserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        entity.HasOne(e => e.InvitedByUser)
+            .WithMany()
+            .HasForeignKey(e => e.InvitedByUserId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        entity.HasOne(e => e.League)
+            .WithMany()
+            .HasForeignKey(e => e.LeagueId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        entity.HasIndex(e => new { e.LeagueId, e.InvitedUserId }).IsUnique();
+    }
+}

--- a/Server/Migrations/20260820173951_AddLeagueMembershipInvites.Designer.cs
+++ b/Server/Migrations/20260820173951_AddLeagueMembershipInvites.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260820173951_AddLeagueMembershipInvites")]
+    partial class AddLeagueMembershipInvites
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/20260820173951_AddLeagueMembershipInvites.cs
+++ b/Server/Migrations/20260820173951_AddLeagueMembershipInvites.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLeagueMembershipInvites : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LeagueMembershipInvites",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    LeagueId = table.Column<int>(type: "integer", nullable: false),
+                    InvitedUserId = table.Column<string>(type: "text", nullable: false),
+                    InvitedByUserId = table.Column<string>(type: "text", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    RespondedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LeagueMembershipInvites", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_LeagueMembershipInvites_AspNetUsers_InvitedByUserId",
+                        column: x => x.InvitedByUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_LeagueMembershipInvites_AspNetUsers_InvitedUserId",
+                        column: x => x.InvitedUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_LeagueMembershipInvites_LeagueInfo_LeagueId",
+                        column: x => x.LeagueId,
+                        principalTable: "LeagueInfo",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeagueMembershipInvites_InvitedByUserId",
+                table: "LeagueMembershipInvites",
+                column: "InvitedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeagueMembershipInvites_InvitedUserId",
+                table: "LeagueMembershipInvites",
+                column: "InvitedUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeagueMembershipInvites_LeagueId_InvitedUserId",
+                table: "LeagueMembershipInvites",
+                columns: new[] { "LeagueId", "InvitedUserId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LeagueMembershipInvites");
+        }
+    }
+}

--- a/Server/Models/Data/LeagueMembershipInvite.cs
+++ b/Server/Models/Data/LeagueMembershipInvite.cs
@@ -1,0 +1,39 @@
+using FourPlayWebApp.Server.Models.Identity;
+using FourPlayWebApp.Shared.Models.Enum;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace FourPlayWebApp.Server.Models.Data;
+
+// A commissioner inviting an ALREADY-REGISTERED user to their league. Distinct from
+// Invitation (new-user registration flow — registering IS joining, one step) and
+// LeagueInviteLink (shareable, non-personalized link) — this is personalized, in-app only,
+// and requires the invitee to explicitly accept or decline. No token: acceptance is always
+// by the already-authenticated invitee, never via an emailed link.
+public class LeagueMembershipInvite
+{
+    [Key]
+    public int Id { get; set; }
+
+    public int LeagueId { get; set; }
+
+    [ForeignKey("LeagueId")]
+    public LeagueInfo League { get; set; } = null!;
+
+    [Required]
+    public string InvitedUserId { get; set; } = null!;
+
+    [ForeignKey("InvitedUserId")]
+    public ApplicationUser InvitedUser { get; set; } = null!;
+
+    public string? InvitedByUserId { get; set; }
+
+    [ForeignKey("InvitedByUserId")]
+    public ApplicationUser? InvitedByUser { get; set; }
+
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public MembershipInviteStatus Status { get; set; } = MembershipInviteStatus.Pending;
+
+    public DateTimeOffset? RespondedAt { get; set; }
+}

--- a/Server/Models/Mappers/LeagueMembershipInviteMapper.cs
+++ b/Server/Models/Mappers/LeagueMembershipInviteMapper.cs
@@ -1,0 +1,41 @@
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Shared.Models.Data.Dtos;
+
+namespace FourPlayWebApp.Server.Models.Mappers;
+
+public static class LeagueMembershipInviteMapper
+{
+    public static PendingMembershipInviteDto ToPendingDto(this LeagueMembershipInvite invite)
+    {
+        return new PendingMembershipInviteDto(
+            invite.Id,
+            invite.LeagueId,
+            invite.League?.LeagueName ?? string.Empty,
+            invite.InvitedByUser?.UserName,
+            invite.CreatedAt
+        );
+    }
+
+    public static List<PendingMembershipInviteDto> ToPendingDtoList(this IEnumerable<LeagueMembershipInvite> invites)
+    {
+        return invites.Select(i => i.ToPendingDto()).ToList();
+    }
+
+    public static MembershipInviteStatusDto ToStatusDto(this LeagueMembershipInvite invite)
+    {
+        return new MembershipInviteStatusDto(
+            invite.Id,
+            invite.LeagueId,
+            invite.InvitedUser?.Email ?? string.Empty,
+            invite.InvitedUser?.UserName,
+            invite.Status,
+            invite.CreatedAt,
+            invite.RespondedAt
+        );
+    }
+
+    public static List<MembershipInviteStatusDto> ToStatusDtoList(this IEnumerable<LeagueMembershipInvite> invites)
+    {
+        return invites.Select(i => i.ToStatusDto()).ToList();
+    }
+}

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -248,6 +248,7 @@ builder.Services.AddCors(options =>
 // Add Invitation Service
 builder.Services.AddScoped<IInvitationService, InvitationService>();
 builder.Services.AddScoped<ILeagueInviteLinkService, LeagueInviteLinkService>();
+builder.Services.AddScoped<ILeagueMembershipInviteService, LeagueMembershipInviteService>();
 
 builder.Services.AddScoped<ISpreadCalculatorBuilder, SpreadCalculatorBuilder>();
 builder.Services.AddSingleton<ILeaderboardService, LeaderboardService>();

--- a/Server/Services/Interfaces/ILeagueMembershipInviteService.cs
+++ b/Server/Services/Interfaces/ILeagueMembershipInviteService.cs
@@ -1,0 +1,14 @@
+using FourPlayWebApp.Server.Models.Data;
+
+namespace FourPlayWebApp.Server.Services.Interfaces;
+
+public interface ILeagueMembershipInviteService
+{
+    Task CreateOrReopenAsync(int leagueId, string invitedUserId, string invitedByUserId);
+    Task<LeagueMembershipInvite?> GetByIdAsync(int id);
+    Task<List<LeagueMembershipInvite>> GetPendingForUserAsync(string userId);
+    Task<List<LeagueMembershipInvite>> GetByLeagueAsync(int leagueId);
+    Task MarkAcceptedAsync(int id);
+    Task MarkDeclinedAsync(int id);
+    Task DeleteAsync(int id);
+}

--- a/Server/Services/LeagueMembershipInviteService.cs
+++ b/Server/Services/LeagueMembershipInviteService.cs
@@ -1,0 +1,103 @@
+using FourPlayWebApp.Server.Data;
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Shared.Models.Enum;
+using Microsoft.EntityFrameworkCore;
+
+namespace FourPlayWebApp.Server.Services;
+
+public class LeagueMembershipInviteService(IDbContextFactory<ApplicationDbContext> dbContextFactory)
+    : ILeagueMembershipInviteService
+{
+    public async Task CreateOrReopenAsync(int leagueId, string invitedUserId, string invitedByUserId)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+
+        // Unique on (LeagueId, InvitedUserId) — mirrors InvitationService.CreateInvitationAsync's
+        // upsert: re-inviting someone who previously declined resets them back to Pending instead
+        // of throwing on the duplicate-key violation.
+        var existing = await db.LeagueMembershipInvites
+            .FirstOrDefaultAsync(i => i.LeagueId == leagueId && i.InvitedUserId == invitedUserId);
+
+        if (existing is not null) {
+            existing.Status = MembershipInviteStatus.Pending;
+            existing.InvitedByUserId = invitedByUserId;
+            existing.CreatedAt = DateTimeOffset.UtcNow;
+            existing.RespondedAt = null;
+            await db.SaveChangesAsync();
+            return;
+        }
+
+        db.LeagueMembershipInvites.Add(new LeagueMembershipInvite {
+            LeagueId = leagueId,
+            InvitedUserId = invitedUserId,
+            InvitedByUserId = invitedByUserId,
+        });
+        try {
+            await db.SaveChangesAsync();
+        } catch (DbUpdateException) {
+            // TOCTOU: a concurrent request already inserted this exact (LeagueId, InvitedUserId)
+            // pair between our read and write — same race TryAddUserToLeagueAsync (LeagueController)
+            // guards against. Their row lands as Pending by default (the entity's default value),
+            // which is exactly the state we wanted too, so there's nothing left to do.
+        }
+    }
+
+    // No includes — every caller (accept/decline ownership + status checks) only reads scalar
+    // columns (InvitedUserId, LeagueId, Status). Callers that need League or InvitedByUser fetch
+    // them separately (see CancelMembershipInvite's repo.GetLeagueInfoAsync call).
+    public async Task<LeagueMembershipInvite?> GetByIdAsync(int id)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+        return await db.LeagueMembershipInvites.FirstOrDefaultAsync(i => i.Id == id);
+    }
+
+    public async Task<List<LeagueMembershipInvite>> GetPendingForUserAsync(string userId)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+        return await db.LeagueMembershipInvites
+            .Where(i => i.InvitedUserId == userId && i.Status == MembershipInviteStatus.Pending)
+            .Include(i => i.League)
+            .Include(i => i.InvitedByUser)
+            // Order by Id, not CreatedAt — SQLite (used in tests) can't translate ORDER BY on
+            // DateTimeOffset; Id increases monotonically with insertion order anyway. See
+            // LeagueInviteLinkService.GetCurrentAsync for the same workaround.
+            .OrderByDescending(i => i.Id)
+            .ToListAsync();
+    }
+
+    // Only InvitedUser is included — the sole caller (ToStatusDtoList, for the commissioner-side
+    // status table) reads InvitedUser.Email/UserName and never touches League or InvitedByUser.
+    public async Task<List<LeagueMembershipInvite>> GetByLeagueAsync(int leagueId)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+        return await db.LeagueMembershipInvites
+            .Where(i => i.LeagueId == leagueId)
+            .Include(i => i.InvitedUser)
+            .OrderByDescending(i => i.Id)
+            .ToListAsync();
+    }
+
+    public Task MarkAcceptedAsync(int id) => SetStatusAsync(id, MembershipInviteStatus.Accepted);
+
+    public Task MarkDeclinedAsync(int id) => SetStatusAsync(id, MembershipInviteStatus.Declined);
+
+    private async Task SetStatusAsync(int id, MembershipInviteStatus status)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+        var invite = await db.LeagueMembershipInvites.FindAsync(id);
+        if (invite is null) return;
+        invite.Status = status;
+        invite.RespondedAt = DateTimeOffset.UtcNow;
+        await db.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+        var invite = await db.LeagueMembershipInvites.FindAsync(id);
+        if (invite is null) return;
+        db.LeagueMembershipInvites.Remove(invite);
+        await db.SaveChangesAsync();
+    }
+}

--- a/Shared/Models/Data/Dtos/LeagueInviteResultDto.cs
+++ b/Shared/Models/Data/Dtos/LeagueInviteResultDto.cs
@@ -1,6 +1,10 @@
+using System.Text.Json.Serialization;
+
 namespace FourPlayWebApp.Shared.Models.Data.Dtos;
+
+public enum LeagueInviteOutcome { NewUserInvitationSent, ExistingUserInvitePending }
 
 public record LeagueInviteResultDto(
     string Email,
-    bool AddedExistingUser
+    [property: JsonConverter(typeof(JsonStringEnumConverter))] LeagueInviteOutcome Outcome
 );

--- a/Shared/Models/Data/Dtos/MembershipInviteStatusDto.cs
+++ b/Shared/Models/Data/Dtos/MembershipInviteStatusDto.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+using FourPlayWebApp.Shared.Models.Enum;
+
+namespace FourPlayWebApp.Shared.Models.Data.Dtos;
+
+public record MembershipInviteStatusDto(
+    int Id,
+    int LeagueId,
+    string InvitedUserEmail,
+    string? InvitedUserName,
+    [property: JsonConverter(typeof(JsonStringEnumConverter))] MembershipInviteStatus Status,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset? RespondedAt
+);

--- a/Shared/Models/Data/Dtos/PendingMembershipInviteDto.cs
+++ b/Shared/Models/Data/Dtos/PendingMembershipInviteDto.cs
@@ -1,0 +1,9 @@
+namespace FourPlayWebApp.Shared.Models.Data.Dtos;
+
+public record PendingMembershipInviteDto(
+    int Id,
+    int LeagueId,
+    string LeagueName,
+    string? InvitedByUserName,
+    DateTimeOffset CreatedAt
+);

--- a/Shared/Models/Enum/MembershipInviteStatus.cs
+++ b/Shared/Models/Enum/MembershipInviteStatus.cs
@@ -1,0 +1,7 @@
+namespace FourPlayWebApp.Shared.Models.Enum;
+
+public enum MembershipInviteStatus {
+    Pending,
+    Accepted,
+    Declined
+}


### PR DESCRIPTION
## Summary
- **Logout race**: `/logout` was nested inside `RequireAuth`, which raced its own reactive redirect against `LogoutPage`'s navigate-home, sometimes stranding the user near login instead of landing on home. Moved it to a public top-level route.
- **Registration confirmation copy**: `RegisterConfirmationPage`'s "check your email" message now renders as a prominent `Alert` instead of plain body text; `ResendEmailConfirmationPage` now explains *why* the user landed there.
- **Existing-user league invites — real consent flow**: last session's invite-an-existing-user feature added them to the league instantly with no acceptance step. This PR replaces that with a proper pending/accept/decline flow:
  - New `LeagueMembershipInvite` entity/table (unique on `LeagueId`+`InvitedUserId`), service, and endpoints: `GET membership-invites/mine`, `POST .../accept`, `POST .../decline`, `DELETE membership-invites/{id}` (commissioner cancel), `GET {leagueId}/membership-invites` (commissioner status view).
  - `InviteToLeague`'s existing-user branch now creates a Pending invite instead of adding membership directly — no email sent; it surfaces as a banner (`PendingInviteBanner`, wired via `SessionProvider`) on the invitee's next authenticated page load.
  - Commissioner-side "Invites to Existing Users" table in `LeaguePortalPage` with per-row Cancel, sharing a new `InviteStatusTable` component with the existing "Sent Invitations" table.
  - New-user registration is unchanged — registering still joins the inviting league in one step; only the already-registered-user path now requires explicit consent. (Deliberately not gating self-serve league creation or new-user auto-join — discussed and decided out of scope.)

Went through two rounds of hardening after `/simplify` and `/code-review`:
- Unified a duplicate status enum, extracted a shared invite-status-table component and a shared controller preamble, trimmed unneeded EF includes, fixed an accidental double-refresh regression, parallelized two independent awaits.
- Fixed a real TOCTOU race in `CreateOrReopenAsync` (concurrent invites to the same not-yet-invited user), fixed `AcceptMembershipInvite` getting permanently stuck Pending if the user was already a member via another path, fixed a misleading "Failed to accept" toast when the accept succeeded but a follow-up refresh failed, restored a `returnUrl=/logout` guard in `LoginPage` that the route-restructuring made newly reachable, and added missing e2e coverage for the invitee-facing banner.

## Test plan
- [x] `dotnet test` — 621 passed
- [x] `npm run typecheck` — clean
- [x] `npm run test -- --run` — 370 passed
- [x] `npm run test:e2e -- --project=chromium` — 77 passed
- [ ] Live-verify on dev.ivleague.xyz via real browser after deploy: logout redirects cleanly, register→confirm messaging, an existing-user invite shows as a banner with working Accept/Decline

🤖 Generated with [Claude Code](https://claude.com/claude-code)