### PR TITLE
docs: fix stale deploy-trigger info, add a fast stuck-deploy diagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,17 +112,19 @@ CI runs on every PR to `dev` and `main`.
 
 ### Railway (Backend)
 
-- Connects to this repo, deploys `Server/` on push to `main`
-- Set all env vars from `.env.example` in Railway service settings
+- Connects to this repo; the `development` environment auto-deploys `Server/` on push to `dev`, the `production` environment on push to `main`
+- Set all env vars from `.env.example` in Railway service settings (per environment)
 - `RAILWAY_URL` must be set in Vercel (see below)
 
 ### Vercel (Frontend)
 
-- Connects to this repo, deploys `Client.React/` on push to `main`
+- Connects to this repo; `dev.ivleague.xyz` / `cfb.dev.ivleague.xyz` track pushes to `dev`, `ivleague.xyz` / `cfb.ivleague.xyz` track pushes to `main`
 - Set `RAILWAY_URL` to your Railway service URL (e.g. `https://yourapp.up.railway.app`)
 - Do **not** set `VITE_API_BASE_URL` — leave it unset so the Vercel proxy handles `/api/*` routing
 
 The `vercel.json` rewrites `/api/*` to Railway at the CDN layer, keeping cookies same-origin (required for Safari ITP compatibility).
+
+If a push to `dev` or `main` doesn't show up on Railway/Vercel within a minute or two, check each platform's deployment history for the commit — an entry that's `SKIPPED`/`FAILED` means the platform saw the push but declined to build; no entry at all for that commit means the trigger never fired (check `gh api repos/<owner>/<repo>/deployments?sha=<sha>` — both platforms register a GitHub Deployment record when they pick up a push, so a missing record here is a fast way to tell "never triggered" from "triggered but stuck").
 
 ## Branch Flow
 


### PR DESCRIPTION
## Summary
- README's Deployment section said Railway/Vercel deploy on push to \`main\` only — actually, Railway's \`development\` environment and \`dev.ivleague.xyz\`/\`cfb.dev.ivleague.xyz\` on Vercel are wired to \`dev\`. Fixed.
- Documents the GitHub Deployments API check (\`gh api repos/<owner>/<repo>/deployments?sha=<sha>\`) as a fast way to tell "never triggered" from "triggered but stuck" — found this while diagnosing PR #242 not deploying.

## Also: intentional test
PR #242 was squash-merged and never triggered a deployment on either platform (confirmed via GitHub's Deployments API — zero records for that commit, versus a record on both platforms within seconds for each of the last 3 regular merges). I'm merging **this** PR as a regular merge (not squash) to see whether that's the actual variable. Will report back either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)