### PR TITLE
chore(ci): run DB Migrate on every push to dev/main

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,11 +1,14 @@
 name: DB Migrate
 
 on:
+  # No paths filter, deliberately: `dotnet ef database update` is idempotent (a ~5s no-op when
+  # nothing's pending), and path-filtered push events have proven unreliable on this repo — a
+  # squash-merged PR that added a migration didn't fire this workflow at all, leaving Railway
+  # crash-looping against a stale schema until the miss was caught and fixed manually. Running
+  # unconditionally on every push to main/dev costs one extra minute of CI per merge and removes
+  # that failure mode entirely.
   push:
     branches: [main, dev]
-    paths:
-      - 'Server/Migrations/**'
-      - 'Server/Data/**'
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
## Summary
Drops the \`paths:\` filter on \`.github/workflows/migrate.yml\` so it runs \`dotnet ef database update\` on **every** push to \`dev\`/\`main\`, not just ones that touch \`Server/Migrations/**\`/\`Server/Data/**\`.

\`dotnet ef database update\` is idempotent — a no-op in ~5s when nothing's pending. The path filter it replaces just caused a real incident: PR #242's squash-merge push didn't fire this workflow at all, so its new migration was never applied to the Neon dev DB, and Railway crash-looped for 30+ min against a stale schema once the app itself deployed (separately-diagnosed squash-merge deploy-trigger issue) until it was caught and fixed by hand.

## Test plan
- [ ] Merge as a **regular merge** (not squash — squash merges don't reliably trigger pushed-triggered workflows/deploys on this repo, still under investigation upstream)
- [ ] Confirm DB Migrate fires automatically on the dev merge (no manual \`workflow_dispatch\` needed this time)
- [ ] Confirm Railway/Vercel dev both deploy automatically
- [ ] Live-check dev.ivleague.xyz

🤖 Generated with [Claude Code](https://claude.com/claude-code)