### PR TITLE
feat: share scoreboard/standings

### DIFF
--- a/Client.React/src/__tests__/leaderboard.test.tsx
+++ b/Client.React/src/__tests__/leaderboard.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { alpha, ThemeProvider } from '@mui/material';
 import LeaderboardPage from '../pages/LeaderboardPage';
 import { vi } from 'vitest';
@@ -6,6 +7,9 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { createLeaderboardEntry, createLeaderboardWeekResult } from '../test/fixtures';
 import type { SportAdapter } from '../services/sportAdapter';
 import { createAppTheme } from '../app/theme';
+
+const toastPush = vi.fn();
+vi.mock('../services/toast', () => ({ useToast: () => ({ push: toastPush }) }));
 
 const sessionState = {
   currentLeague: 1 as number | null,
@@ -74,6 +78,22 @@ describe('LeaderboardPage', () => {
     await screen.findByText(/TestUser/i);
     expect(screen.getByText(/TestUser/i)).toBeInTheDocument();
     expect(screen.getByText('25')).toBeInTheDocument();
+  });
+
+  it('Share button calls navigator.share with a standings title and the page url', async () => {
+    const shareMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', { value: shareMock, configurable: true });
+    mockedGetLeaderboard.mockResolvedValue([
+      createLeaderboardEntry({ userId: '123', userName: 'TestUser', rank: '1', total: 5, weekResults: [] }),
+    ]);
+
+    renderPage();
+    await screen.findByText(/TestUser/i);
+    await userEvent.click(screen.getByRole('button', { name: /^share$/i }));
+
+    await waitFor(() => expect(shareMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: expect.stringMatching(/standings/i), url: window.location.href })
+    ));
   });
 
   it('renders without crash when users have ragged weekResults', async () => {

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -150,6 +150,19 @@ describe('ScoresPage', () => {
     ));
   });
 
+  it('Share button uses the postseason round name, not "Week N", during the playoffs', async () => {
+    const shareMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', { value: shareMock, configurable: true });
+    await setupDefaults({ week: 1, postSeason: true });
+    await renderPage();
+
+    await userEvent.click(screen.getByRole('button', { name: /^share$/i }));
+
+    await waitFor(() => expect(shareMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: expect.stringMatching(/wild card/i), url: window.location.href })
+    ));
+  });
+
   it('shows postseason wild card title', async () => {
     await setupDefaults({ week: 1, postSeason: true });
     await renderPage();

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -45,6 +45,8 @@ vi.mock('../api/cfb', () => ({
   addCfbPicks: vi.fn(), deleteCfbPicks: vi.fn(),
 }));
 vi.mock('../services/spreadRelease', () => ({ getNextSpreadJob: vi.fn().mockResolvedValue(null) }));
+const toastPush = vi.fn();
+vi.mock('../services/toast', () => ({ useToast: () => ({ push: toastPush }) }));
 
 import { loadScoresWithRetry, getLiveGames, getWeekScores, loadCfbScoresWithRetry, getCfbLiveGames } from '../api/espn';
 import { doOddsExist, getLeaguePicks, spreadBatch } from '../api/league';
@@ -133,6 +135,19 @@ describe('ScoresPage', () => {
     await setupDefaults({ week: 5 });
     await renderPage();
     expect(screen.getAllByText(/Week 5/i).length).toBeGreaterThan(0);
+  });
+
+  it('Share button calls navigator.share with the week in the title and the page url', async () => {
+    const shareMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', { value: shareMock, configurable: true });
+    await setupDefaults({ week: 5 });
+    await renderPage();
+
+    await userEvent.click(screen.getByRole('button', { name: /^share$/i }));
+
+    await waitFor(() => expect(shareMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: expect.stringMatching(/week 5/i), url: window.location.href })
+    ));
   });
 
   it('shows postseason wild card title', async () => {

--- a/Client.React/src/__tests__/useShareLink.test.tsx
+++ b/Client.React/src/__tests__/useShareLink.test.tsx
@@ -50,6 +50,21 @@ describe('useShareLink', () => {
     expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
   });
 
+  it('share() does not throw an unhandled rejection when the user cancels the native share sheet', async () => {
+    const shareMock = vi.fn().mockRejectedValue(new DOMException('Abort', 'AbortError'));
+    Object.defineProperty(navigator, 'share', { value: shareMock, configurable: true });
+    const onUnhandledRejection = vi.fn();
+    window.addEventListener('unhandledrejection', onUnhandledRejection);
+
+    const { result } = renderHook(() => useShareLink());
+    result.current.share('Week 5 scores', 'https://ivleague.com/scores');
+
+    await waitFor(() => expect(shareMock).toHaveBeenCalled());
+    await new Promise(resolve => setTimeout(resolve, 0));
+    window.removeEventListener('unhandledrejection', onUnhandledRejection);
+    expect(onUnhandledRejection).not.toHaveBeenCalled();
+  });
+
   it('share() falls back to copy() when navigator.share is unavailable', async () => {
     Object.defineProperty(navigator, 'share', { value: undefined, configurable: true });
 

--- a/Client.React/src/__tests__/useShareLink.test.tsx
+++ b/Client.React/src/__tests__/useShareLink.test.tsx
@@ -1,0 +1,62 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { useShareLink } from '../utils/useShareLink';
+
+const toastPush = vi.fn();
+vi.mock('../services/toast', () => ({ useToast: () => ({ push: toastPush }) }));
+
+describe('useShareLink', () => {
+  const originalShare = navigator.share;
+  const originalClipboard = navigator.clipboard;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'share', { value: originalShare, configurable: true });
+    Object.defineProperty(navigator, 'clipboard', { value: originalClipboard, configurable: true });
+  });
+
+  it('copy() writes the url to the clipboard and shows a success toast', async () => {
+    const { result } = renderHook(() => useShareLink());
+    await result.current.copy('https://ivleague.com/scores');
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('https://ivleague.com/scores');
+    expect(toastPush).toHaveBeenCalledWith('Link copied', 'info');
+  });
+
+  it('copy() shows an error toast when the clipboard write fails', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
+      configurable: true,
+    });
+    const { result } = renderHook(() => useShareLink());
+    await result.current.copy('https://ivleague.com/scores');
+    expect(toastPush).toHaveBeenCalledWith('Failed to copy link', 'error');
+  });
+
+  it('share() calls navigator.share with title and url when available', async () => {
+    const shareMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', { value: shareMock, configurable: true });
+
+    const { result } = renderHook(() => useShareLink());
+    result.current.share('Week 5 scores', 'https://ivleague.com/scores');
+
+    await waitFor(() => expect(shareMock).toHaveBeenCalledWith({ title: 'Week 5 scores', url: 'https://ivleague.com/scores' }));
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+  });
+
+  it('share() falls back to copy() when navigator.share is unavailable', async () => {
+    Object.defineProperty(navigator, 'share', { value: undefined, configurable: true });
+
+    const { result } = renderHook(() => useShareLink());
+    result.current.share('Week 5 scores', 'https://ivleague.com/scores');
+
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith('https://ivleague.com/scores'));
+    expect(toastPush).toHaveBeenCalledWith('Link copied', 'info');
+  });
+});

--- a/Client.React/src/components/PageHeader.tsx
+++ b/Client.React/src/components/PageHeader.tsx
@@ -1,16 +1,21 @@
-import { Box, Typography } from '@mui/material';
+import type { ReactNode } from 'react';
+import { Box, Stack, Typography } from '@mui/material';
 
 interface PageHeaderProps {
   title: string;
   subtitle?: string;
+  action?: ReactNode;
 }
 
-export default function PageHeader({ title, subtitle }: PageHeaderProps) {
+export default function PageHeader({ title, subtitle, action }: PageHeaderProps) {
   return (
     <Box sx={{ mb: 3 }}>
-      <Typography variant="h4" className="section-title">
-        {title}
-      </Typography>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2}>
+        <Typography variant="h4" className="section-title">
+          {title}
+        </Typography>
+        {action}
+      </Stack>
       {subtitle && (
         <Typography variant="body1" color="text.secondary">
           {subtitle}

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -3,6 +3,7 @@ import { Navigate } from 'react-router-dom';
 import {
   alpha,
   Box,
+  Button,
   Card,
   CardContent,
   CircularProgress,
@@ -15,6 +16,7 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
+import IosShareIcon from '@mui/icons-material/IosShare';
 import PageHeader from '../components/PageHeader';
 import { useSession } from '../services/session';
 import { useAuth } from '../services/auth';
@@ -22,6 +24,7 @@ import { getLeaderboard } from '../api/leaderboard';
 import type { LeaderboardDto } from '../types/leaderboard';
 import type { SportAdapter } from '../services/sportAdapter';
 import { stickyColumnSx } from '../utils/tableStyles';
+import { useShareLink } from '../utils/useShareLink';
 
 interface LeaderboardPageProps {
   adapter: SportAdapter;
@@ -31,6 +34,7 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
   const theme = useTheme();
   const { currentLeague, leaguesLoaded } = useSession();
   const { user } = useAuth();
+  const { share } = useShareLink();
   const [loading, setLoading] = useState(true);
   const [leaderboard, setLeaderboard] = useState<LeaderboardDto[]>([]);
 
@@ -119,7 +123,19 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
 
   return (
     <Box>
-      <PageHeader title="Leaderboard" />
+      <PageHeader
+        title="Leaderboard"
+        action={
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<IosShareIcon />}
+            onClick={() => share('IV League Standings', window.location.href)}
+          >
+            Share
+          </Button>
+        }
+      />
       {leaderboard.length === 0 && (
         <Typography variant="body2" color="text.secondary" sx={{ mt: 4, textAlign: 'center' }}>
           No leaderboard data yet for this season.

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -39,6 +39,7 @@ import { useAuth } from '../services/auth';
 import { useToast } from '../services/toast';
 import { isAdmin } from '../utils/auth';
 import { extractApiErrorMessage } from '../utils/apiError';
+import { useShareLink } from '../utils/useShareLink';
 import {
   getLeagueUserMappings,
   getLeagueJuice,
@@ -732,26 +733,9 @@ interface MembersTabProps {
 function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInvite, onAddUser, inviteLink, generatingLink, revokingLink, onGenerateInviteLink, onRevokeInviteLink, invitations, membershipInvites, cancelingMembershipInviteId, onCancelMembershipInvite }: MembersTabProps) {
   const count = costDto?.memberCount ?? members.length;
   const cost = computeLeagueCost(count);
-  const toast = useToast();
+  const { share, copy } = useShareLink();
 
   const inviteUrl = inviteLink ? `${window.location.origin}/join/${inviteLink.token}` : '';
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(inviteUrl);
-      toast.push('Link copied', 'info');
-    } catch {
-      toast.push('Failed to copy link', 'error');
-    }
-  };
-
-  const handleShare = () => {
-    if (navigator.share) {
-      void navigator.share({ title: 'Join my league', url: inviteUrl });
-    } else {
-      void handleCopy();
-    }
-  };
 
   const linkExpired = inviteLink ? new Date(inviteLink.expiresAt) < new Date() : false;
   const expiresLabel = inviteLink
@@ -795,10 +779,10 @@ function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInv
             )}
             {!linkExpired && (
               <Stack direction="row" spacing={1} flexWrap="wrap">
-                <Button size="small" startIcon={<ContentCopyIcon />} variant="outlined" onClick={() => void handleCopy()}>
+                <Button size="small" startIcon={<ContentCopyIcon />} variant="outlined" onClick={() => void copy(inviteUrl)}>
                   Copy
                 </Button>
-                <Button size="small" startIcon={<IosShareIcon />} variant="contained" color="secondary" onClick={handleShare}>
+                <Button size="small" startIcon={<IosShareIcon />} variant="contained" color="secondary" onClick={() => share('Join my league', inviteUrl)}>
                   Share
                 </Button>
                 <Button

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -237,7 +237,11 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
             size="small"
             variant="outlined"
             startIcon={<IosShareIcon />}
-            onClick={() => share(`Week ${data.week} Scores`, window.location.href)}
+            onClick={() => {
+              const weekLabel = adapter.weekSelectorConfig.weekLabelFn?.(data.week, isPostSeason)
+                ?? `Week ${data.week}`;
+              share(`${weekLabel} Scores`, window.location.href);
+            }}
           >
             Share
           </Button>

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -9,6 +9,7 @@ import GppBadIcon from '@mui/icons-material/GppBad';
 import GppMaybeIcon from '@mui/icons-material/GppMaybe';
 import ArrowCircleUpIcon from '@mui/icons-material/ArrowCircleUp';
 import ArrowCircleDownIcon from '@mui/icons-material/ArrowCircleDown';
+import IosShareIcon from '@mui/icons-material/IosShare';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import PageHeader from '../components/PageHeader';
 import WeekYearSelector from '../components/WeekYearSelector';
@@ -21,6 +22,7 @@ import FieldPosition from '../components/FieldPosition';
 import { useSession } from '../services/session';
 import { useAuth } from '../services/auth';
 import { spreadLabel } from '../utils/gameHelpers';
+import { useShareLink } from '../utils/useShareLink';
 import type { SportAdapter, GameView, WeekState } from '../services/sportAdapter';
 
 // GameView.gameStatus is canonical GameStatusValue — use === directly, no string parsing
@@ -63,6 +65,7 @@ interface ScoresPageProps {
 export default function ScoresPage({ adapter }: ScoresPageProps) {
   const { currentLeague, leaguesLoaded } = useSession();
   const { user } = useAuth();
+  const { share } = useShareLink();
 
   // null = live current week (polls in background); non-null = historical navigation
   const [weekState, setWeekState] = useState<WeekState | null>(null);
@@ -227,7 +230,19 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
 
   return (
     <Box>
-      <PageHeader title="Scores" />
+      <PageHeader
+        title="Scores"
+        action={
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<IosShareIcon />}
+            onClick={() => share(`Week ${data.week} Scores`, window.location.href)}
+          >
+            Share
+          </Button>
+        }
+      />
 
       <Box sx={{ mb: 3 }}>
         <WeekYearSelector

--- a/Client.React/src/utils/useShareLink.ts
+++ b/Client.React/src/utils/useShareLink.ts
@@ -1,0 +1,28 @@
+import { useToast } from '../services/toast';
+
+/**
+ * Native-share-with-clipboard-fallback, shared by every "Share"/"Copy" button in the app.
+ * Mirrors the pattern originally written for the league invite link.
+ */
+export function useShareLink() {
+  const toast = useToast();
+
+  const copy = async (url: string) => {
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.push('Link copied', 'info');
+    } catch {
+      toast.push('Failed to copy link', 'error');
+    }
+  };
+
+  const share = (title: string, url: string) => {
+    if (navigator.share) {
+      void navigator.share({ title, url });
+    } else {
+      void copy(url);
+    }
+  };
+
+  return { share, copy };
+}

--- a/Client.React/src/utils/useShareLink.ts
+++ b/Client.React/src/utils/useShareLink.ts
@@ -18,7 +18,8 @@ export function useShareLink() {
 
   const share = (title: string, url: string) => {
     if (navigator.share) {
-      void navigator.share({ title, url });
+      // Cancelling the native share sheet rejects with AbortError — routine, not an error.
+      navigator.share({ title, url }).catch(() => {});
     } else {
       void copy(url);
     }


### PR DESCRIPTION
## Summary
Extends the existing navigator.share/clipboard-fallback pattern (previously only on the league invite link in LeaguePortalPage) to ScoresPage and LeaderboardPage — a "Share" button in the page header shares a title (with week number for Scores) + the current page URL, falling back to clipboard copy on browsers without the Web Share API.

- New `utils/useShareLink.ts` hook, extracted since this is now the 3rd call site (invite link + 2 new ones).
- `PageHeader` gains an optional `action` slot (backward compatible — every other usage is unaffected).
- Refactored `LeaguePortalPage`'s invite-link Copy/Share buttons onto the shared hook too — behavior-preserving, same toast copy.

No image/screenshot sharing — there's no canvas/rasterization capability anywhere in the app today, so that's out of scope; text+URL matches the proven existing pattern.

## Test plan
- [x] `npm run test -- --run` — 376 passed (4 new: hook unit tests + Share button on Scores + Share button on Leaderboard)
- [x] `npm run typecheck` — clean
- [x] `npm run test:e2e -- --project=chromium` — 77 passed, no regressions
- [x] `dotnet test` — 621 passed (no backend changes, sanity check)
- [ ] Live-verify on dev.ivleague.xyz

🤖 Generated with [Claude Code](https://claude.com/claude-code)