### PR TITLE
feat: admin platform-wide league cost dashboard

### DIFF
--- a/Client.React/e2e/admin.spec.ts
+++ b/Client.React/e2e/admin.spec.ts
@@ -40,6 +40,19 @@ test.describe('Admin pages (administrator role)', () => {
   });
 
   // -----------------------------------------------------------------------
+  // League Costs
+  // -----------------------------------------------------------------------
+  test('League Costs page renders heading, league row, and total', async ({ page }) => {
+    await adminAuth(page, '/admin/leagueCosts');
+    await waitForSpinner(page);
+
+    await expect(page.getByRole('heading', { name: /league costs/i })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('cell', { name: 'Test League' })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('commish')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('$120').first()).toBeVisible({ timeout: 5000 });
+  });
+
+  // -----------------------------------------------------------------------
   // My Leagues — admin-only actions (Create League / Add User / Change Owner)
   // -----------------------------------------------------------------------
   test('My Leagues — Create League button opens Create League dialog', async ({ page }) => {

--- a/Client.React/e2e/helpers/routes.ts
+++ b/Client.React/e2e/helpers/routes.ts
@@ -350,6 +350,17 @@ export async function setupRoutes(page: Page, options: SetupRoutesOptions = {}):
       return;
     }
 
+    if (url.includes('/api/league/all-leagues-cost') && method === 'GET') {
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { leagueId: TEST_LEAGUE_ID, leagueName: 'Test League', ownerUserName: 'commish', leagueType: 'Nfl', memberCount: 12, cost: 120 },
+        ]),
+      });
+      return;
+    }
+
     if (url.includes('/api/league/all-leagues') && method === 'GET') {
       void route.fulfill({
         status: 200,

--- a/Client.React/src/App.tsx
+++ b/Client.React/src/App.tsx
@@ -59,6 +59,7 @@ import { RequireAdmin, RequireAuth } from './services/auth';
 import AdminJobManagerPage from './pages/admin/JobManagerPage';
 import AdminUserManagementPage from './pages/admin/UserManagementPage';
 import AdminInvitationsPage from './pages/admin/InvitationsPage';
+import AdminLeagueCostsPage from './pages/admin/LeagueCostsPage';
 import LogoutPage from './pages/LogoutPage';
 import AuthPage from './pages/AuthPage';
 import RulesPage from './pages/RulesPage';
@@ -132,6 +133,15 @@ export default function App() {
           element={
             <RequireAdmin>
               <AdminInvitationsPage />
+            </RequireAdmin>
+          }
+        />
+        <Route
+          path="/admin/leagueCosts"
+          caseSensitive={false}
+          element={
+            <RequireAdmin>
+              <AdminLeagueCostsPage />
             </RequireAdmin>
           }
         />

--- a/Client.React/src/__tests__/LeagueCostsPage.test.tsx
+++ b/Client.React/src/__tests__/LeagueCostsPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { vi } from 'vitest';
 import AdminLeagueCostsPage from '../pages/admin/LeagueCostsPage';
 import type { AdminLeagueCostDto } from '../types/admin';
@@ -8,6 +9,15 @@ vi.mock('../api/league', () => ({ getAllLeaguesCost: vi.fn() }));
 import { getAllLeaguesCost } from '../api/league';
 
 const mockedGetAllLeaguesCost = vi.mocked(getAllLeaguesCost);
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: Infinity } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AdminLeagueCostsPage />
+    </QueryClientProvider>
+  );
+}
 
 function makeCost(overrides: Partial<AdminLeagueCostDto> = {}): AdminLeagueCostDto {
   return {
@@ -32,7 +42,7 @@ describe('AdminLeagueCostsPage', () => {
       makeCost({ leagueId: 2, leagueName: 'CFB League', leagueType: 'Cfb', ownerUserName: 'bob', memberCount: 8, cost: 100 }),
     ]);
 
-    render(<AdminLeagueCostsPage />);
+    renderPage();
 
     expect(await screen.findByText('NFL League')).toBeInTheDocument();
     expect(screen.getByText('CFB League')).toBeInTheDocument();
@@ -44,7 +54,7 @@ describe('AdminLeagueCostsPage', () => {
   it('shows an empty state when there are no leagues', async () => {
     mockedGetAllLeaguesCost.mockResolvedValue([]);
 
-    render(<AdminLeagueCostsPage />);
+    renderPage();
 
     expect(await screen.findByText(/no leagues/i)).toBeInTheDocument();
   });
@@ -52,7 +62,7 @@ describe('AdminLeagueCostsPage', () => {
   it('shows an error state with a retry button when the request fails', async () => {
     mockedGetAllLeaguesCost.mockRejectedValue(new Error('network error'));
 
-    render(<AdminLeagueCostsPage />);
+    renderPage();
 
     expect(await screen.findByText(/couldn.t load/i)).toBeInTheDocument();
     const retryButton = screen.getByRole('button', { name: /retry/i });
@@ -65,7 +75,7 @@ describe('AdminLeagueCostsPage', () => {
 
   it('refetches with the newly selected season when the season selector changes', async () => {
     mockedGetAllLeaguesCost.mockResolvedValue([makeCost()]);
-    render(<AdminLeagueCostsPage />);
+    renderPage();
     await screen.findByText('Demo League');
 
     const currentYear = new Date().getFullYear();

--- a/Client.React/src/__tests__/LeagueCostsPage.test.tsx
+++ b/Client.React/src/__tests__/LeagueCostsPage.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import AdminLeagueCostsPage from '../pages/admin/LeagueCostsPage';
+import type { AdminLeagueCostDto } from '../types/admin';
+
+vi.mock('../api/league', () => ({ getAllLeaguesCost: vi.fn() }));
+import { getAllLeaguesCost } from '../api/league';
+
+const mockedGetAllLeaguesCost = vi.mocked(getAllLeaguesCost);
+
+function makeCost(overrides: Partial<AdminLeagueCostDto> = {}): AdminLeagueCostDto {
+  return {
+    leagueId: 1,
+    leagueName: 'Demo League',
+    ownerUserName: 'alice',
+    leagueType: 'Nfl',
+    memberCount: 12,
+    cost: 120,
+    ...overrides,
+  };
+}
+
+describe('AdminLeagueCostsPage', () => {
+  beforeEach(() => {
+    mockedGetAllLeaguesCost.mockReset();
+  });
+
+  it('shows each league with its owner, sport, member count, and cost, plus a total row', async () => {
+    mockedGetAllLeaguesCost.mockResolvedValue([
+      makeCost({ leagueId: 1, leagueName: 'NFL League', leagueType: 'Nfl', ownerUserName: 'alice', memberCount: 12, cost: 120 }),
+      makeCost({ leagueId: 2, leagueName: 'CFB League', leagueType: 'Cfb', ownerUserName: 'bob', memberCount: 8, cost: 100 }),
+    ]);
+
+    render(<AdminLeagueCostsPage />);
+
+    expect(await screen.findByText('NFL League')).toBeInTheDocument();
+    expect(screen.getByText('CFB League')).toBeInTheDocument();
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('bob')).toBeInTheDocument();
+    expect(screen.getByText('$220')).toBeInTheDocument(); // total: 120 + 100
+  });
+
+  it('shows an empty state when there are no leagues', async () => {
+    mockedGetAllLeaguesCost.mockResolvedValue([]);
+
+    render(<AdminLeagueCostsPage />);
+
+    expect(await screen.findByText(/no leagues/i)).toBeInTheDocument();
+  });
+
+  it('shows an error state with a retry button when the request fails', async () => {
+    mockedGetAllLeaguesCost.mockRejectedValue(new Error('network error'));
+
+    render(<AdminLeagueCostsPage />);
+
+    expect(await screen.findByText(/couldn.t load/i)).toBeInTheDocument();
+    const retryButton = screen.getByRole('button', { name: /retry/i });
+
+    mockedGetAllLeaguesCost.mockResolvedValue([makeCost()]);
+    await userEvent.click(retryButton);
+
+    expect(await screen.findByText('Demo League')).toBeInTheDocument();
+  });
+
+  it('refetches with the newly selected season when the season selector changes', async () => {
+    mockedGetAllLeaguesCost.mockResolvedValue([makeCost()]);
+    render(<AdminLeagueCostsPage />);
+    await screen.findByText('Demo League');
+
+    const currentYear = new Date().getFullYear();
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(await screen.findByRole('option', { name: String(currentYear - 1) }));
+
+    await waitFor(() => expect(mockedGetAllLeaguesCost).toHaveBeenCalledWith(currentYear - 1));
+  });
+});

--- a/Client.React/src/api/league.ts
+++ b/Client.React/src/api/league.ts
@@ -11,6 +11,7 @@ import type {
   LeagueInfoDto,
   LeagueJuiceMappingDto,
   LeagueCostDto,
+  AdminLeagueCostDto,
   LeagueJuiceUpdateDto,
   LeagueCreateDto,
   UserSummaryDto,
@@ -140,6 +141,11 @@ export async function getAllLeagues() {
 export async function getLeagueCost(leagueId: number) {
   const { data } = await http.get<LeagueCostDto>(`/api/league/${leagueId}/cost`);
   return data;
+}
+
+export async function getAllLeaguesCost(season: number) {
+  const { data } = await http.get<AdminLeagueCostDto[]>('/api/league/all-leagues-cost', { params: { season } });
+  return data ?? [];
 }
 
 export async function updateLeagueJuice(leagueId: number, season: number, dto: LeagueJuiceUpdateDto) {

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -38,6 +38,7 @@ import LogoutIcon from '@mui/icons-material/Logout';
 import WorkIcon from '@mui/icons-material/Work';
 import PersonIcon from '@mui/icons-material/Person';
 import MailIcon from '@mui/icons-material/Mail';
+import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import { useSession } from '../services/session';
 import { useAuth } from '../services/auth';
@@ -358,6 +359,17 @@ export default function AppLayout() {
                         <MailIcon sx={{ fontSize: 20 }} />
                       </ListItemIcon>
                       <ListItemText primary="Invitations" />
+                    </ListItemButton>
+                    <ListItemButton
+                      component={NavLink}
+                      to="/admin/leagueCosts"
+                      sx={adminNavItemSx}
+                      onClick={() => handleNavClick('/admin/leagueCosts')}
+                    >
+                      <ListItemIcon sx={{ minWidth: 36 }}>
+                        <AttachMoneyIcon sx={{ fontSize: 20 }} />
+                      </ListItemIcon>
+                      <ListItemText primary="League Costs" />
                     </ListItemButton>
                   </List>
                 </Collapse>

--- a/Client.React/src/pages/admin/LeagueCostsPage.tsx
+++ b/Client.React/src/pages/admin/LeagueCostsPage.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import PageHeader from '../../components/PageHeader';
+import { getAllLeaguesCost } from '../../api/league';
+import type { AdminLeagueCostDto } from '../../types/admin';
+
+const SEASON_OPTIONS_BACK = 2;
+const SEASON_OPTIONS_FORWARD = 1;
+
+export default function AdminLeagueCostsPage() {
+  const currentYear = new Date().getFullYear();
+  const seasonOptions = useMemo(
+    () => Array.from(
+      { length: SEASON_OPTIONS_BACK + SEASON_OPTIONS_FORWARD + 1 },
+      (_, i) => currentYear + SEASON_OPTIONS_FORWARD - i
+    ),
+    [currentYear]
+  );
+
+  const [season, setSeason] = useState(currentYear);
+  const [costs, setCosts] = useState<AdminLeagueCostDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const data = await getAllLeaguesCost(season);
+      setCosts(data);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [season]);
+
+  const total = costs.reduce((sum, c) => sum + c.cost, 0);
+
+  return (
+    <Box>
+      <PageHeader title="League Costs" />
+
+      <FormControl sx={{ minWidth: 140, mb: 3 }}>
+        <InputLabel>Season</InputLabel>
+        <Select
+          value={season}
+          label="Season"
+          onChange={(e) => setSeason(Number(e.target.value))}
+        >
+          {seasonOptions.map((year) => (
+            <MenuItem key={year} value={year}>{year}</MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      {loading && (
+        <Stack alignItems="center" sx={{ mt: 4 }}>
+          <CircularProgress />
+        </Stack>
+      )}
+
+      {!loading && error && (
+        <Alert
+          severity="error"
+          action={<Button color="inherit" size="small" onClick={() => void load()}>Retry</Button>}
+        >
+          Couldn&apos;t load league costs. Check your connection and try again.
+        </Alert>
+      )}
+
+      {!loading && !error && costs.length === 0 && (
+        <Typography color="text.secondary" sx={{ textAlign: 'center', mt: 4 }}>
+          No leagues found for {season}.
+        </Typography>
+      )}
+
+      {!loading && !error && costs.length > 0 && (
+        <Paper sx={{ p: 2 }}>
+          <Box sx={{ overflowX: 'auto' }}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>League</TableCell>
+                  <TableCell>Sport</TableCell>
+                  <TableCell>Owner</TableCell>
+                  <TableCell>Members</TableCell>
+                  <TableCell>Cost</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {costs.map((c) => (
+                  <TableRow key={c.leagueId}>
+                    <TableCell>{c.leagueName}</TableCell>
+                    <TableCell>{c.leagueType.toUpperCase()}</TableCell>
+                    <TableCell>{c.ownerUserName}</TableCell>
+                    <TableCell>{c.memberCount}</TableCell>
+                    <TableCell>${c.cost}</TableCell>
+                  </TableRow>
+                ))}
+                <TableRow>
+                  <TableCell colSpan={4} sx={{ fontWeight: 700 }}>Total</TableCell>
+                  <TableCell sx={{ fontWeight: 700 }}>${total}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </Box>
+        </Paper>
+      )}
+    </Box>
+  );
+}

--- a/Client.React/src/pages/admin/LeagueCostsPage.tsx
+++ b/Client.React/src/pages/admin/LeagueCostsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useState } from 'react';
 import {
   Alert,
   Box,
@@ -17,47 +17,22 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
+import { useQuery } from '@tanstack/react-query';
 import PageHeader from '../../components/PageHeader';
 import { getAllLeaguesCost } from '../../api/league';
-import type { AdminLeagueCostDto } from '../../types/admin';
 
-const SEASON_OPTIONS_BACK = 2;
-const SEASON_OPTIONS_FORWARD = 1;
+const CURRENT_YEAR = new Date().getFullYear();
+const SEASON_OPTIONS = [CURRENT_YEAR + 1, CURRENT_YEAR, CURRENT_YEAR - 1, CURRENT_YEAR - 2];
 
 export default function AdminLeagueCostsPage() {
-  const currentYear = new Date().getFullYear();
-  const seasonOptions = useMemo(
-    () => Array.from(
-      { length: SEASON_OPTIONS_BACK + SEASON_OPTIONS_FORWARD + 1 },
-      (_, i) => currentYear + SEASON_OPTIONS_FORWARD - i
-    ),
-    [currentYear]
-  );
+  const [season, setSeason] = useState(CURRENT_YEAR);
 
-  const [season, setSeason] = useState(currentYear);
-  const [costs, setCosts] = useState<AdminLeagueCostDto[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
+  const { data: costs, isLoading, isError, refetch } = useQuery({
+    queryKey: ['all-leagues-cost', season],
+    queryFn: () => getAllLeaguesCost(season),
+  });
 
-  const load = async () => {
-    setLoading(true);
-    setError(false);
-    try {
-      const data = await getAllLeaguesCost(season);
-      setCosts(data);
-    } catch {
-      setError(true);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    void load();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [season]);
-
-  const total = costs.reduce((sum, c) => sum + c.cost, 0);
+  const total = (costs ?? []).reduce((sum, c) => sum + c.cost, 0);
 
   return (
     <Box>
@@ -70,34 +45,34 @@ export default function AdminLeagueCostsPage() {
           label="Season"
           onChange={(e) => setSeason(Number(e.target.value))}
         >
-          {seasonOptions.map((year) => (
+          {SEASON_OPTIONS.map((year) => (
             <MenuItem key={year} value={year}>{year}</MenuItem>
           ))}
         </Select>
       </FormControl>
 
-      {loading && (
+      {isLoading && (
         <Stack alignItems="center" sx={{ mt: 4 }}>
           <CircularProgress />
         </Stack>
       )}
 
-      {!loading && error && (
+      {!isLoading && isError && (
         <Alert
           severity="error"
-          action={<Button color="inherit" size="small" onClick={() => void load()}>Retry</Button>}
+          action={<Button color="inherit" size="small" onClick={() => void refetch()}>Retry</Button>}
         >
           Couldn&apos;t load league costs. Check your connection and try again.
         </Alert>
       )}
 
-      {!loading && !error && costs.length === 0 && (
+      {!isLoading && !isError && costs?.length === 0 && (
         <Typography color="text.secondary" sx={{ textAlign: 'center', mt: 4 }}>
           No leagues found for {season}.
         </Typography>
       )}
 
-      {!loading && !error && costs.length > 0 && (
+      {!isLoading && !isError && costs && costs.length > 0 && (
         <Paper sx={{ p: 2 }}>
           <Box sx={{ overflowX: 'auto' }}>
             <Table size="small">

--- a/Client.React/src/types/admin.ts
+++ b/Client.React/src/types/admin.ts
@@ -71,6 +71,15 @@ export interface LeagueCostDto {
   cost: number;
 }
 
+export interface AdminLeagueCostDto {
+  leagueId: number;
+  leagueName: string;
+  ownerUserName: string;
+  leagueType: string;
+  memberCount: number;
+  cost: number;
+}
+
 export interface LeagueJuiceUpdateDto {
   juice: number;
   juiceDivisional: number;

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -1,3 +1,4 @@
+using FourPlayWebApp.Server.Auth;
 using FourPlayWebApp.Server.Controllers;
 using FourPlayWebApp.Server.Models;
 using FourPlayWebApp.Server.Models.Data;
@@ -320,6 +321,95 @@ public class LeagueOwnershipTests
 
         var dto = Assert.IsType<LeagueCostDto>(result!.Value);
         Assert.Equal(120m, dto.Cost);  // $100 + 2 * $10
+    }
+
+    [Fact]
+    public async Task GetLeagueCost_WithSeason_UsesSeasonAwareMemberCount()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L", LeagueType = LeagueType.Nfl });
+        repo.GetLeagueMemberCountAsync(1, 2024, LeagueType.Nfl).Returns(15);
+
+        var result = await ctrl.GetLeagueCost(1, season: 2024) as OkObjectResult;
+
+        var dto = Assert.IsType<LeagueCostDto>(result!.Value);
+        Assert.Equal(15, dto.MemberCount);
+        Assert.Equal(150m, dto.Cost); // $100 + 5 * $10
+        await repo.DidNotReceive().GetLeagueMemberCountAsync(1);
+    }
+
+    [Fact]
+    public async Task GetLeagueCost_WithoutSeason_PreservesCurrentMemberCountBehavior()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L", LeagueType = LeagueType.Nfl });
+        repo.GetLeagueMemberCountAsync(1).Returns(8);
+
+        var result = await ctrl.GetLeagueCost(1, season: null) as OkObjectResult;
+
+        var dto = Assert.IsType<LeagueCostDto>(result!.Value);
+        Assert.Equal(8, dto.MemberCount);
+        await repo.DidNotReceive().GetLeagueMemberCountAsync(1, Arg.Any<int>(), Arg.Any<LeagueType>());
+    }
+
+    // ── GetAllLeaguesCost (admin platform-wide cost dashboard, frizat-fug) ──────
+
+    [Fact]
+    public async Task GetAllLeaguesCost_ReturnsForbid_WhenCallerIsNotAdmin()
+    {
+        var method = typeof(LeagueController).GetMethod(nameof(LeagueController.GetAllLeaguesCost));
+        Assert.NotNull(method);
+        var roleAttr = method!.GetCustomAttributes<AuthorizeAttribute>().FirstOrDefault(a => a.Roles is not null);
+        Assert.Equal(AppRoles.Administrator, roleAttr?.Roles);
+    }
+
+    [Fact]
+    public async Task GetAllLeaguesCost_ReturnsCostPerLeague_WithOwnerNamesAndCorrectAggregation()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId, isAdmin: true));
+        repo.GetAllLeaguesAsync().Returns(
+        [
+            new LeagueInfo { Id = 1, LeagueName = "NFL League", OwnerUserId = "owner-nfl", LeagueType = LeagueType.Nfl },
+            new LeagueInfo { Id = 2, LeagueName = "CFB League", OwnerUserId = "owner-cfb", LeagueType = LeagueType.Cfb },
+        ]);
+        repo.GetLeagueMemberCountsAsync(2024).Returns(new Dictionary<int, int> { [1] = 15, [2] = 8 });
+        repo.GetUsersAsync().Returns([
+            new ApplicationUser { Id = "owner-nfl", UserName = "nfl-owner" },
+            new ApplicationUser { Id = "owner-cfb", UserName = "cfb-owner" },
+        ]);
+
+        var result = await ctrl.GetAllLeaguesCost(2024) as OkObjectResult;
+
+        var dtos = Assert.IsAssignableFrom<IEnumerable<AdminLeagueCostDto>>(result!.Value).ToList();
+        Assert.Equal(2, dtos.Count);
+        var nfl = dtos.Single(d => d.LeagueId == 1);
+        Assert.Equal("nfl-owner", nfl.OwnerUserName);
+        Assert.Equal(15, nfl.MemberCount);
+        Assert.Equal(150m, nfl.Cost); // $100 + 5 * $10
+        var cfb = dtos.Single(d => d.LeagueId == 2);
+        Assert.Equal("cfb-owner", cfb.OwnerUserName);
+        Assert.Equal(8, cfb.MemberCount);
+        Assert.Equal(100m, cfb.Cost); // base tier, no overage
+    }
+
+    [Fact]
+    public async Task GetAllLeaguesCost_DefaultsMemberCountToZero_ForLeagueMissingFromCountsMap()
+    {
+        // A league whose sport has no season-week-config rows for the requested season (e.g. a
+        // future season not seeded yet) — GetLeagueMemberCountsAsync omits it entirely rather than
+        // guessing; the endpoint must show $0/0 members, not throw a KeyNotFoundException.
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId, isAdmin: true));
+        repo.GetAllLeaguesAsync().Returns([
+            new LeagueInfo { Id = 1, LeagueName = "L", OwnerUserId = "owner-1", LeagueType = LeagueType.Nfl },
+        ]);
+        repo.GetLeagueMemberCountsAsync(2099).Returns(new Dictionary<int, int>());
+        repo.GetUsersAsync().Returns([new ApplicationUser { Id = "owner-1", UserName = "owner" }]);
+
+        var result = await ctrl.GetAllLeaguesCost(2099) as OkObjectResult;
+
+        var dtos = Assert.IsAssignableFrom<IEnumerable<AdminLeagueCostDto>>(result!.Value).ToList();
+        Assert.Equal(0, dtos[0].MemberCount);
+        Assert.Equal(100m, dtos[0].Cost);
     }
 
     [Fact]

--- a/Server.UnitTests/LeagueRepositoryTests.cs
+++ b/Server.UnitTests/LeagueRepositoryTests.cs
@@ -3,6 +3,7 @@ using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Repositories;
 using FourPlayWebApp.Shared.Models.Data;
+using FourPlayWebApp.Shared.Models.Enum;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
@@ -186,6 +187,130 @@ public class LeagueRepositoryTests
         var count = await repo.GetLeagueMemberCountAsync(1);
 
         Assert.Equal(1, count);
+    }
+
+    // ── Season-aware member count (admin cost dashboard, frizat-fug) ────────────
+    // frizat: "cost owed for season Y" must count members whose membership WINDOW overlapped
+    // season Y's date range — not just currently-active members — so a past season's cost isn't
+    // silently zeroed out by members who have since left. Window = [DateCreated, RemovedAt ?? now).
+
+    private static async Task SeedNflSeasonAsync(DbContextFactoryStub factory, int season, DateTime start, DateTime end)
+    {
+        var db = factory.CreateDbContext();
+        db.NflSeasonWeekConfigs.Add(new NflSeasonWeekConfig {
+            Season = season, WeekId = 1, WeekLabel = "Week 1",
+            WeekStartDatetime = start, WeekEndDatetime = end,
+        });
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetLeagueMemberCountAsync_SeasonAware_CountsMemberActiveDuringThatSeason_ExcludingLaterRemoval()
+    {
+        var factory = new DbContextFactoryStub(nameof(GetLeagueMemberCountAsync_SeasonAware_CountsMemberActiveDuringThatSeason_ExcludingLaterRemoval));
+        await SeedNflSeasonAsync(factory, 2024, new DateTime(2024, 9, 1), new DateTime(2025, 2, 1));
+        var seedDb = factory.CreateDbContext();
+        // Joined before the 2024 season and removed after it ended — was present the whole season.
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping {
+            LeagueId = 1, UserId = "still-counted",
+            DateCreated = new DateTimeOffset(2024, 8, 1, 0, 0, 0, TimeSpan.Zero),
+            RemovedAt = new DateTimeOffset(2025, 3, 1, 0, 0, 0, TimeSpan.Zero), IsActive = false,
+        });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        var count = await repo.GetLeagueMemberCountAsync(1, 2024, LeagueType.Nfl);
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task GetLeagueMemberCountAsync_SeasonAware_ExcludesMemberWhoLeftEntirelyBeforeTheSeasonStarted()
+    {
+        var factory = new DbContextFactoryStub(nameof(GetLeagueMemberCountAsync_SeasonAware_ExcludesMemberWhoLeftEntirelyBeforeTheSeasonStarted));
+        await SeedNflSeasonAsync(factory, 2024, new DateTime(2024, 9, 1), new DateTime(2025, 2, 1));
+        var seedDb = factory.CreateDbContext();
+        // Joined and left in 2023, well before the 2024 season window — must not count toward 2024.
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping {
+            LeagueId = 1, UserId = "left-before-season",
+            DateCreated = new DateTimeOffset(2023, 8, 1, 0, 0, 0, TimeSpan.Zero),
+            RemovedAt = new DateTimeOffset(2023, 12, 1, 0, 0, 0, TimeSpan.Zero), IsActive = false,
+        });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        var count = await repo.GetLeagueMemberCountAsync(1, 2024, LeagueType.Nfl);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task GetLeagueMemberCountAsync_SeasonAware_ExcludesMemberWhoJoinedAfterTheSeasonEnded()
+    {
+        var factory = new DbContextFactoryStub(nameof(GetLeagueMemberCountAsync_SeasonAware_ExcludesMemberWhoJoinedAfterTheSeasonEnded));
+        await SeedNflSeasonAsync(factory, 2024, new DateTime(2024, 9, 1), new DateTime(2025, 2, 1));
+        var seedDb = factory.CreateDbContext();
+        // Joined in the 2025 season, after the 2024 window ended — must not count toward 2024.
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping {
+            LeagueId = 1, UserId = "joined-next-season",
+            DateCreated = new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero),
+        });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        var count = await repo.GetLeagueMemberCountAsync(1, 2024, LeagueType.Nfl);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task GetLeagueMemberCountAsync_SeasonAware_CountsCurrentlyActiveMemberWhoJoinedMidSeason()
+    {
+        var factory = new DbContextFactoryStub(nameof(GetLeagueMemberCountAsync_SeasonAware_CountsCurrentlyActiveMemberWhoJoinedMidSeason));
+        await SeedNflSeasonAsync(factory, 2024, new DateTime(2024, 9, 1), new DateTime(2025, 2, 1));
+        var seedDb = factory.CreateDbContext();
+        // Joined mid-2024-season and never left — still active today.
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping {
+            LeagueId = 1, UserId = "joined-mid-season",
+            DateCreated = new DateTimeOffset(2024, 10, 1, 0, 0, 0, TimeSpan.Zero),
+        });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        var count = await repo.GetLeagueMemberCountAsync(1, 2024, LeagueType.Nfl);
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task GetLeagueMemberCountsAsync_ReturnsCountsPerLeague_AcrossBothSports()
+    {
+        var factory = new DbContextFactoryStub(nameof(GetLeagueMemberCountsAsync_ReturnsCountsPerLeague_AcrossBothSports));
+        await SeedNflSeasonAsync(factory, 2024, new DateTime(2024, 9, 1), new DateTime(2025, 2, 1));
+        var seedDb = factory.CreateDbContext();
+        seedDb.CfbSeasonWeekConfigs.Add(new CfbSeasonWeekConfig {
+            Season = 2024, EspnWeekNumber = 1, IvLeagueWeekNumber = 1,
+            WeekStartDate = new DateOnly(2024, 8, 20), WeekEndDate = new DateOnly(2025, 1, 15),
+        });
+        seedDb.LeagueInfo.AddRange(
+            new LeagueInfo { Id = 1, LeagueName = "NFL League", OwnerUserId = "owner-1", LeagueType = LeagueType.Nfl },
+            new LeagueInfo { Id = 2, LeagueName = "CFB League", OwnerUserId = "owner-2", LeagueType = LeagueType.Cfb });
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping {
+            LeagueId = 1, UserId = "nfl-member", DateCreated = new DateTimeOffset(2024, 9, 15, 0, 0, 0, TimeSpan.Zero),
+        });
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping {
+            LeagueId = 2, UserId = "cfb-member-1", DateCreated = new DateTimeOffset(2024, 9, 1, 0, 0, 0, TimeSpan.Zero),
+        });
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping {
+            LeagueId = 2, UserId = "cfb-member-2", DateCreated = new DateTimeOffset(2024, 9, 1, 0, 0, 0, TimeSpan.Zero),
+        });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        var counts = await repo.GetLeagueMemberCountsAsync(2024);
+
+        Assert.Equal(1, counts[1]);
+        Assert.Equal(2, counts[2]);
     }
 
     [Fact]

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -752,9 +752,13 @@ public class LeagueController(
     [Authorize(Roles = AppRoles.Administrator)]
     [ProducesResponseType(typeof(List<AdminLeagueCostDto>), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetAllLeaguesCost(int season) {
-        var leagues = await repo.GetAllLeaguesAsync();
-        var counts = await repo.GetLeagueMemberCountsAsync(season);
-        var owners = (await repo.GetUsersAsync()).ToDictionary(u => u.Id, u => u.UserName ?? u.Id);
+        var leaguesTask = repo.GetAllLeaguesAsync();
+        var countsTask = repo.GetLeagueMemberCountsAsync(season);
+        var usersTask = repo.GetUsersAsync();
+        await Task.WhenAll(leaguesTask, countsTask, usersTask);
+        var leagues = leaguesTask.Result;
+        var counts = countsTask.Result;
+        var owners = usersTask.Result.ToDictionary(u => u.Id, u => u.UserName ?? u.Id);
         return Ok(leagues.Select(l => {
             var count = counts.GetValueOrDefault(l.Id, 0);
             return new AdminLeagueCostDto(

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -737,15 +737,35 @@ public class LeagueController(
 
     [HttpGet("{leagueId:int}/cost")]
     [ProducesResponseType(typeof(LeagueCostDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetLeagueCost(int leagueId) {
+    public async Task<IActionResult> GetLeagueCost(int leagueId, int? season = null) {
         var league = await repo.GetLeagueInfoAsync(leagueId);
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != userId)
             return Forbid();
-        var count = await repo.GetLeagueMemberCountAsync(leagueId);
+        var count = season.HasValue
+            ? await repo.GetLeagueMemberCountAsync(leagueId, season.Value, league.LeagueType)
+            : await repo.GetLeagueMemberCountAsync(leagueId);
+        return Ok(new LeagueCostDto(count, ComputeLeagueCost(count)));
+    }
+
+    [HttpGet("all-leagues-cost")]
+    [Authorize(Roles = AppRoles.Administrator)]
+    [ProducesResponseType(typeof(List<AdminLeagueCostDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetAllLeaguesCost(int season) {
+        var leagues = await repo.GetAllLeaguesAsync();
+        var counts = await repo.GetLeagueMemberCountsAsync(season);
+        var owners = (await repo.GetUsersAsync()).ToDictionary(u => u.Id, u => u.UserName ?? u.Id);
+        return Ok(leagues.Select(l => {
+            var count = counts.GetValueOrDefault(l.Id, 0);
+            return new AdminLeagueCostDto(
+                l.Id, l.LeagueName, owners.GetValueOrDefault(l.OwnerUserId, l.OwnerUserId),
+                l.LeagueType, count, ComputeLeagueCost(count));
+        }).ToList());
+    }
+
+    private static decimal ComputeLeagueCost(int memberCount) {
         const int baseCost = 100, baseMembers = 10, perHead = 10;
-        var cost = baseCost + Math.Max(0, count - baseMembers) * perHead;
-        return Ok(new LeagueCostDto(count, cost));
+        return baseCost + Math.Max(0, memberCount - baseMembers) * perHead;
     }
 
     [HttpPut("{leagueId:int}/juice/{season:int}")]

--- a/Server/Services/Repositories/Interfaces/ILeagueRepository.cs
+++ b/Server/Services/Repositories/Interfaces/ILeagueRepository.cs
@@ -1,6 +1,7 @@
 using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Shared.Models.Data;
+using FourPlayWebApp.Shared.Models.Enum;
 
 namespace FourPlayWebApp.Server.Services.Repositories.Interfaces;
 public interface ILeagueRepository : ISpreadRepository<NflSpreads> {
@@ -38,6 +39,10 @@ public interface ILeagueRepository : ISpreadRepository<NflSpreads> {
     Task UpdateLeagueJuiceMappingAsync(LeagueJuiceMapping mapping);
     Task RemoveLeagueUserMappingAsync(int leagueId, string userId);
     Task<int> GetLeagueMemberCountAsync(int leagueId);
+    // Season-aware: counts members whose (DateCreated, RemovedAt) membership window overlapped
+    // the given season's date range for that league's sport — not just currently-active members.
+    Task<int> GetLeagueMemberCountAsync(int leagueId, int season, LeagueType leagueType);
+    Task<Dictionary<int, int>> GetLeagueMemberCountsAsync(int season);
     Task DeleteLeagueAsync(int leagueId);
 
     // Add operations

--- a/Server/Services/Repositories/LeagueRepository.cs
+++ b/Server/Services/Repositories/LeagueRepository.cs
@@ -5,6 +5,7 @@ using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models.Data;
 using FourPlayWebApp.Shared.Models.Enum;
 using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
 
 namespace FourPlayWebApp.Server.Services.Repositories;
 
@@ -292,8 +293,10 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
         var range = await GetSeasonDateRangeAsync(db, season, leagueType);
         if (range is null) return 0;
         var (start, end) = range.Value;
-        return await db.LeagueUserMapping.CountAsync(m =>
-            m.LeagueId == leagueId && m.DateCreated <= end && (m.RemovedAt == null || m.RemovedAt >= start));
+        return await db.LeagueUserMapping
+            .Where(m => m.LeagueId == leagueId)
+            .Where(ActiveDuringWindow(start, end))
+            .CountAsync();
     }
 
     public async Task<Dictionary<int, int>> GetLeagueMemberCountsAsync(int season) {
@@ -303,9 +306,9 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
             var range = await GetSeasonDateRangeAsync(db, season, sport);
             if (range is null) continue;
             var (start, end) = range.Value;
-            var leagueIds = await db.LeagueInfo.Where(l => l.LeagueType == sport).Select(l => l.Id).ToListAsync();
             var counts = await db.LeagueUserMapping
-                .Where(m => leagueIds.Contains(m.LeagueId) && m.DateCreated <= end && (m.RemovedAt == null || m.RemovedAt >= start))
+                .Where(m => m.League.LeagueType == sport)
+                .Where(ActiveDuringWindow(start, end))
                 .GroupBy(m => m.LeagueId)
                 .Select(g => new { LeagueId = g.Key, Count = g.Count() })
                 .ToListAsync();
@@ -313,6 +316,9 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
         }
         return result;
     }
+
+    private static Expression<Func<LeagueUserMapping, bool>> ActiveDuringWindow(DateTimeOffset start, DateTimeOffset end) =>
+        m => m.DateCreated <= end && (m.RemovedAt == null || m.RemovedAt >= start);
 
     // Computed client-side (not ORDER BY in SQL) — avoids the SQLite/EF DateTimeOffset ORDER BY
     // translation gap that bit LeagueMembershipInviteService; MIN/MAX over an already-materialized

--- a/Server/Services/Repositories/LeagueRepository.cs
+++ b/Server/Services/Repositories/LeagueRepository.cs
@@ -3,6 +3,7 @@ using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models.Data;
+using FourPlayWebApp.Shared.Models.Enum;
 using Microsoft.EntityFrameworkCore;
 
 namespace FourPlayWebApp.Server.Services.Repositories;
@@ -284,6 +285,51 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
     public async Task<int> GetLeagueMemberCountAsync(int leagueId) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
         return await db.LeagueUserMapping.CountAsync(m => m.LeagueId == leagueId && m.IsActive);
+    }
+
+    public async Task<int> GetLeagueMemberCountAsync(int leagueId, int season, LeagueType leagueType) {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+        var range = await GetSeasonDateRangeAsync(db, season, leagueType);
+        if (range is null) return 0;
+        var (start, end) = range.Value;
+        return await db.LeagueUserMapping.CountAsync(m =>
+            m.LeagueId == leagueId && m.DateCreated <= end && (m.RemovedAt == null || m.RemovedAt >= start));
+    }
+
+    public async Task<Dictionary<int, int>> GetLeagueMemberCountsAsync(int season) {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+        var result = new Dictionary<int, int>();
+        foreach (var sport in new[] { LeagueType.Nfl, LeagueType.Cfb }) {
+            var range = await GetSeasonDateRangeAsync(db, season, sport);
+            if (range is null) continue;
+            var (start, end) = range.Value;
+            var leagueIds = await db.LeagueInfo.Where(l => l.LeagueType == sport).Select(l => l.Id).ToListAsync();
+            var counts = await db.LeagueUserMapping
+                .Where(m => leagueIds.Contains(m.LeagueId) && m.DateCreated <= end && (m.RemovedAt == null || m.RemovedAt >= start))
+                .GroupBy(m => m.LeagueId)
+                .Select(g => new { LeagueId = g.Key, Count = g.Count() })
+                .ToListAsync();
+            foreach (var c in counts) result[c.LeagueId] = c.Count;
+        }
+        return result;
+    }
+
+    // Computed client-side (not ORDER BY in SQL) — avoids the SQLite/EF DateTimeOffset ORDER BY
+    // translation gap that bit LeagueMembershipInviteService; MIN/MAX over an already-materialized
+    // list sidesteps it entirely and this table is small (one row per week per season).
+    private static async Task<(DateTimeOffset Start, DateTimeOffset End)?> GetSeasonDateRangeAsync(
+        ApplicationDbContext db, int season, LeagueType leagueType) {
+        if (leagueType == LeagueType.Cfb) {
+            var weeks = await db.CfbSeasonWeekConfigs.Where(c => c.Season == season).ToListAsync();
+            if (weeks.Count == 0) return null;
+            var start = weeks.Min(w => w.WeekStartDate).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+            var end = weeks.Max(w => w.WeekEndDate).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+            return (start, end);
+        } else {
+            var weeks = await db.NflSeasonWeekConfigs.Where(c => c.Season == season).ToListAsync();
+            if (weeks.Count == 0) return null;
+            return (weeks.Min(w => w.WeekStartDatetime), weeks.Max(w => w.WeekEndDatetime));
+        }
     }
 
     // Add operations

--- a/Shared/Models/Data/Dtos/LeagueCreateDto.cs
+++ b/Shared/Models/Data/Dtos/LeagueCreateDto.cs
@@ -16,4 +16,13 @@ public record LeagueCreateDto(
 
 public record LeagueCostDto(int MemberCount, decimal Cost);
 
+public record AdminLeagueCostDto(
+    int LeagueId,
+    string LeagueName,
+    string OwnerUserName,
+    [property: JsonConverter(typeof(JsonStringEnumConverter))] LeagueType LeagueType,
+    int MemberCount,
+    decimal Cost
+);
+
 public record LeagueJuiceUpdateDto(int Juice, int JuiceDivisional, int JuiceConference, int WeeklyCost);


### PR DESCRIPTION
## Summary
- Admins could see cost/member counts per-league only from inside each owner's own portal; there was no platform-wide view to reconcile costs owed across all leagues/sports each season (bead frizat-fug / GitHub #103).
- `GetLeagueCost` gains a season-aware path (`GetLeagueMemberCountAsync(leagueId, season, leagueType)`), counting members whose membership window overlapped that season's date range — not just currently-active members — using existing `NflSeasonWeekConfig`/`CfbSeasonWeekConfig` rows to derive the season boundary (no new schema, per review).
- New admin-only `GET /api/league/all-leagues-cost?season=` and `Client.React/src/pages/admin/LeagueCostsPage.tsx` — season selector, per-league table (league/sport/owner/members/cost), total row, nav entry under Admin.

## Test plan
- [x] `dotnet test` — 628 passed
- [x] `npm run test -- --run` — 386 passed
- [x] `npm run test:e2e -- --project=chromium` — 78 passed (includes new admin.spec.ts case)
- [x] `/simplify` (4 parallel review agents) — applied: extracted shared membership-window predicate, dropped an extra DB round trip via navigation-property filtering, parallelized independent repo calls with `Task.WhenAll`, switched the new page to `useQuery` matching `OwnerCostSummary`'s existing pattern
- [x] `/code-review` — no blocking findings; reviewed and consciously deferred (documented in PR discussion): InMemory-vs-Postgres testing isn't the documented `ExecuteDelete`/`ExecuteUpdate` gotcha, a pre-existing `LeagueType` string/int convention split unrelated to this diff, and the season-aware single-league path is intentionally unwired from any caller (the new admin page uses the platform-wide endpoint instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)