### PR TITLE
security: fix ADMIN_PASSWORD example placeholder that matched a real deployed password

### DIFF
--- a/.env.backend.example
+++ b/.env.backend.example
@@ -11,9 +11,13 @@ FOURPLAY_EMAIL_PASS=your-app-password
 
 ADMIN_EMAIL=your-admin@email.com
 ADMIN_USERNAME=frizat
-# Use a simple password without special chars (!, $, etc.) for local dev
-# The actual prod password stays in Railway — this is local only
-ADMIN_PASSWORD=DemoPass@123
+# Use a simple password without special chars (!, $, etc.) for local dev.
+# CRITICAL: this value is a local-only placeholder — never paste it into Railway's
+# ADMIN_PASSWORD variable for dev/main. UserManagerJob.SyncAdminPassword overwrites the
+# real admin account's password with whatever ADMIN_PASSWORD is configured on EVERY app
+# startup, so a copy-pasted example value becomes the live admin password on that deploy.
+# Generate a unique, strong value for each real (Railway) environment instead.
+ADMIN_PASSWORD=LocalDevOnlyPlaceholder123
 
 APP_URL=http://localhost:5174
 # Do NOT set COOKIE_DOMAIN locally. Prod/staging set it (e.g. .ivleague.com) so a login on


### PR DESCRIPTION
## Summary
- \`.env.backend.example\`'s \`ADMIN_PASSWORD\` placeholder was the literal string \`DemoPass@123\` — identical to \`DemoDataSeeder\`'s hardcoded \`@demo.local\` seed-user password, both public in this repo.
- Railway's **dev** environment \`ADMIN_PASSWORD\` had been copy-pasted from this example without changing it. \`UserManagerJob.SyncAdminPassword\` (\`Server/Jobs/UserManagerJob.cs:45-54\`) force-syncs the real admin account's password to whatever \`ADMIN_PASSWORD\` is configured on *every app startup* — so the real admin account's live password on dev matched a value published in this public repo's source and example config.
- **Verified and remediated**: dev admin password has been rotated (old value now fails login, confirmed via curl against \`dev.ivleague.xyz\`); **production was confirmed unaffected** (the compromised value never worked on \`ivleague.xyz\`); ran GitHub secret scanning + full-history \`gitleaks\` audit — no other exposed secrets found, and no real \`.env\*\` file was ever committed to git history.
- This PR: changes the example value to something that can't be mistaken for a real usable password, and adds an explicit warning comment referencing the exact mechanism (\`SyncAdminPassword\`) so this can't recur silently.

## Test plan
- [x] Confirmed old dev admin password fails login post-rotation
- [x] Confirmed new dev admin password succeeds
- [x] Confirmed production admin account was never affected
- [x] GitHub secret-scanning alerts: none
- [x] \`gitleaks\` full-history scan (existing CI job): passes
- Docs-only change, no app code touched — no test suite impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)