### PR TITLE
fix: eliminate concurrency race in UserManagerJob.SyncAdminPassword

### DIFF
--- a/Server.UnitTests/UserManagerJobConfigTests.cs
+++ b/Server.UnitTests/UserManagerJobConfigTests.cs
@@ -90,6 +90,34 @@ public class UserManagerJobConfigTests
         Assert.NotEqual("frizat", capturedUser.UserName); // belt-and-suspenders
     }
 
+    // frizat: SyncAdminPassword used to call RemovePasswordAsync then AddPasswordAsync — two
+    // separate SaveChanges against the same row, racing against any other concurrent write to
+    // that user (real incident: a redeploy's own concurrent request hit this exact window and
+    // left the admin account passwordless when the second write lost an EF optimistic-concurrency
+    // check). Setting PasswordHash directly and calling UpdateAsync once is atomic — no window.
+    [Fact]
+    public async Task SyncAdminPassword_UpdatesPasswordHashInASingleAtomicWrite_NotRemoveThenAdd()
+    {
+        var (userManager, roleManager) = BuildMocks();
+        var adminUser = new ApplicationUser { Email = "admin@example.com", UserName = "admin" };
+        userManager.FindByEmailAsync("admin@example.com").Returns(adminUser);
+        var hasher = Substitute.For<IPasswordHasher<ApplicationUser>>();
+        hasher.HashPassword(adminUser, "NewPass!123").Returns("hashed-value");
+        userManager.PasswordHasher = hasher;
+        userManager.UpdateAsync(Arg.Any<ApplicationUser>()).Returns(IdentityResult.Success);
+
+        var config = BuildConfig("admin@example.com", "admin", "NewPass!123");
+        var services = Substitute.For<IServiceProvider>();
+        var job = new UserManagerJob(roleManager, userManager, config, services);
+
+        await job.SyncAdminPassword("admin@example.com");
+
+        Assert.Equal("hashed-value", adminUser.PasswordHash);
+        await userManager.Received(1).UpdateAsync(adminUser);
+        await userManager.DidNotReceive().RemovePasswordAsync(Arg.Any<ApplicationUser>());
+        await userManager.DidNotReceive().AddPasswordAsync(Arg.Any<ApplicationUser>(), Arg.Any<string>());
+    }
+
     /// <summary>
     /// frizat-uvi: AddUserToRole must not silently succeed when the user is not found.
     /// Previously logged "Admin User Found" with a null value — now logs an error.

--- a/Server/Jobs/UserManagerJob.cs
+++ b/Server/Jobs/UserManagerJob.cs
@@ -42,12 +42,17 @@ public class UserManagerJob(
     /// <summary>
     /// Sync admin password from configuration on every startup so env var changes take effect on redeploy.
     /// </summary>
+    // frizat: RemovePasswordAsync then AddPasswordAsync used to do this as two separate writes to
+    // the same row — a real incident hit an EF optimistic-concurrency conflict on the second write
+    // (something else touched the row between the two SaveChanges) and left the admin account
+    // passwordless until the next redeploy. Hashing directly and writing PasswordHash via a single
+    // UpdateAsync closes that window entirely — one write, nothing in between to race against.
     internal async Task SyncAdminPassword(string emailAddress) {
         var adminPassword = configuration["ADMIN_PASSWORD"] ?? throw new InvalidOperationException("ADMIN_PASSWORD not set");
         var adminUser = await userManager.FindByEmailAsync(emailAddress);
         if (adminUser == null) return;
-        await userManager.RemovePasswordAsync(adminUser);
-        var result = await userManager.AddPasswordAsync(adminUser, adminPassword);
+        adminUser.PasswordHash = userManager.PasswordHasher.HashPassword(adminUser, adminPassword);
+        var result = await userManager.UpdateAsync(adminUser);
         if (result.Succeeded)
             Log.Information("Admin password synced for {Email}", emailAddress);
         else


### PR DESCRIPTION
## Summary
- `SyncAdminPassword` did `RemovePasswordAsync` then `AddPasswordAsync` — two separate writes (SaveChanges) to the same `ApplicationUser` row.
- **Real incident**: during the PR #250 merge's dev redeploy, the second write hit an EF Core optimistic-concurrency conflict (\`"Optimistic concurrency failure, object has been modified"\`) and failed after the first (remove) had already succeeded — leaving the real admin account **passwordless** for ~30 minutes until the next redeploy self-healed it. Confirmed via Railway deploy logs.
- Fix: hash the password directly via \`userManager.PasswordHasher\` and set \`PasswordHash\`, then a single \`UpdateAsync\` call. One write, no window for anything else to race against.

## Test plan
- [x] TDD: new test \`SyncAdminPassword_UpdatesPasswordHashInASingleAtomicWrite_NotRemoveThenAdd\` written RED first, confirmed failing against old implementation (NRE from unmocked Remove/AddPasswordAsync), now green
- [x] \`dotnet test\` — 629 passed
- Frontend/e2e unaffected (backend-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)