### PR TITLE
feat: share Leaderboard standings as a branded image, not a link

### DIFF
--- a/Client.React/e2e/leaderboard.spec.ts
+++ b/Client.React/e2e/leaderboard.spec.ts
@@ -53,8 +53,8 @@ test.describe('Leaderboard page (authenticated)', () => {
 
   test('shows standings table with user rows', async ({ page }) => {
     await gotoLeaderboard(page, sampleLeaderboard);
-    await expect(page.getByText(TEST_USER.name)).toBeVisible({ timeout: 5000 });
-    await expect(page.getByText('Alice')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('cell', { name: TEST_USER.name })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('cell', { name: 'Alice' })).toBeVisible({ timeout: 5000 });
   });
 
   test('shows rank and total columns', async ({ page }) => {

--- a/Client.React/e2e/leaderboard.spec.ts
+++ b/Client.React/e2e/leaderboard.spec.ts
@@ -69,4 +69,17 @@ test.describe('Leaderboard page (authenticated)', () => {
     await expect(page.getByRole('heading', { name: 'Leaderboard' })).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('Standings')).not.toBeVisible();
   });
+
+  test('Share button renders the standings card and shares it (falls back to download when the browser cannot share files)', async ({ page }) => {
+    // Force the download-fallback branch deterministically, rather than relying on whatever
+    // Web Share API support this Chromium build happens to have.
+    await page.addInitScript(() => {
+      Object.defineProperty(window.navigator, 'canShare', { value: () => false, configurable: true });
+    });
+
+    await gotoLeaderboard(page, sampleLeaderboard);
+    await page.getByRole('button', { name: /^share$/i }).click();
+
+    await expect(page.getByRole('alert')).toContainText(/downloaded/i, { timeout: 5000 });
+  });
 });

--- a/Client.React/package-lock.json
+++ b/Client.React/package-lock.json
@@ -17,6 +17,7 @@
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
         "axios": "^1.13.5",
+        "html-to-image": "^1.11.13",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-hook-form": "^7.71.2",
@@ -5029,6 +5030,12 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
     },
     "node_modules/http-proxy-agent": {

--- a/Client.React/package.json
+++ b/Client.React/package.json
@@ -27,6 +27,7 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "axios": "^1.13.5",
+    "html-to-image": "^1.11.13",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.71.2",

--- a/Client.React/src/__tests__/ShareableStandingsCard.test.tsx
+++ b/Client.React/src/__tests__/ShareableStandingsCard.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import ShareableStandingsCard from '../components/ShareableStandingsCard';
+
+describe('ShareableStandingsCard', () => {
+  it('renders the league name, user name, rank, and total', () => {
+    render(
+      <ShareableStandingsCard
+        ref={createRef<HTMLDivElement>()}
+        leagueName="Demo League"
+        userName="Carlos"
+        rank="1"
+        total={45}
+      />
+    );
+
+    expect(screen.getByText('Demo League')).toBeInTheDocument();
+    expect(screen.getByText('Carlos')).toBeInTheDocument();
+    expect(screen.getByText(/#1/)).toBeInTheDocument();
+    expect(screen.getByText('+45')).toBeInTheDocument();
+  });
+
+  it('shows a negative total without a leading plus sign', () => {
+    render(
+      <ShareableStandingsCard
+        ref={createRef<HTMLDivElement>()}
+        leagueName="Demo League"
+        userName="Bob"
+        rank="4"
+        total={-12}
+      />
+    );
+
+    expect(screen.getByText('-12')).toBeInTheDocument();
+  });
+
+  it('shows zero without a sign', () => {
+    render(
+      <ShareableStandingsCard
+        ref={createRef<HTMLDivElement>()}
+        leagueName="Demo League"
+        userName="Eve"
+        rank="5"
+        total={0}
+      />
+    );
+
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+});

--- a/Client.React/src/__tests__/leaderboard.test.tsx
+++ b/Client.React/src/__tests__/leaderboard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { alpha, ThemeProvider } from '@mui/material';
 import LeaderboardPage from '../pages/LeaderboardPage';
@@ -11,9 +11,12 @@ import { createAppTheme } from '../app/theme';
 const toastPush = vi.fn();
 vi.mock('../services/toast', () => ({ useToast: () => ({ push: toastPush }) }));
 
+const mockedToBlob = vi.fn();
+vi.mock('html-to-image', () => ({ toBlob: (...args: unknown[]) => mockedToBlob(...args) }));
+
 const sessionState = {
   currentLeague: 1 as number | null,
-  availableLeagues: [],
+  availableLeagues: [{ leagueId: 1, leagueName: 'Demo League' }] as { leagueId: number; leagueName: string }[],
   selectLeague: vi.fn(),
   reloadLeagues: vi.fn(),
   clearSession: vi.fn(),
@@ -75,25 +78,47 @@ describe('LeaderboardPage', () => {
     ]);
 
     renderPage();
-    await screen.findByText(/TestUser/i);
-    expect(screen.getByText(/TestUser/i)).toBeInTheDocument();
+    const table = await screen.findByRole('table');
+    expect(within(table).getByText('TestUser')).toBeInTheDocument();
     expect(screen.getByText('25')).toBeInTheDocument();
   });
 
-  it('Share button calls navigator.share with a standings title and the page url', async () => {
+  it('Share button shares a rendered standings-card image, not a link', async () => {
     const shareMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'canShare', { value: () => true, configurable: true });
     Object.defineProperty(navigator, 'share', { value: shareMock, configurable: true });
+    mockedToBlob.mockResolvedValue(new Blob(['fake-png'], { type: 'image/png' }));
     mockedGetLeaderboard.mockResolvedValue([
       createLeaderboardEntry({ userId: '123', userName: 'TestUser', rank: '1', total: 5, weekResults: [] }),
     ]);
 
     renderPage();
-    await screen.findByText(/TestUser/i);
+    await screen.findByRole('table');
+    await userEvent.click(screen.getByRole('button', { name: /^share$/i }));
+
+    await waitFor(() => expect(shareMock).toHaveBeenCalled());
+    const call = shareMock.mock.calls[0][0];
+    expect(call.files).toHaveLength(1);
+    expect(call.files[0].type).toBe('image/png');
+    expect(call.url).toBeUndefined();
+  });
+
+  it('Share button falls back to link-share when the viewer is not on the leaderboard', async () => {
+    const shareMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'canShare', { value: () => true, configurable: true });
+    Object.defineProperty(navigator, 'share', { value: shareMock, configurable: true });
+    mockedGetLeaderboard.mockResolvedValue([
+      createLeaderboardEntry({ userId: '999', userName: 'SomeoneElse', rank: '1', total: 5, weekResults: [] }),
+    ]);
+
+    renderPage();
+    await screen.findByText(/SomeoneElse/i);
     await userEvent.click(screen.getByRole('button', { name: /^share$/i }));
 
     await waitFor(() => expect(shareMock).toHaveBeenCalledWith(
       expect.objectContaining({ title: expect.stringMatching(/standings/i), url: window.location.href })
     ));
+    expect(mockedToBlob).not.toHaveBeenCalled();
   });
 
   it('renders without crash when users have ragged weekResults', async () => {
@@ -110,7 +135,7 @@ describe('LeaderboardPage', () => {
     ]);
 
     renderPage();
-    await screen.findByText(/TestUser/i);
+    await screen.findByRole('table');
     expect(screen.getByText(/NewUser/i)).toBeInTheDocument();
   });
 

--- a/Client.React/src/__tests__/nativeShare.test.ts
+++ b/Client.React/src/__tests__/nativeShare.test.ts
@@ -1,0 +1,34 @@
+import { vi } from 'vitest';
+import { shareViaNavigator } from '../utils/nativeShare';
+
+describe('shareViaNavigator', () => {
+  const originalShare = navigator.share;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'share', { value: originalShare, configurable: true });
+  });
+
+  it('calls navigator.share with the given data', () => {
+    const shareMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', { value: shareMock, configurable: true });
+
+    shareViaNavigator({ title: 'Hello', url: 'https://example.com' });
+
+    expect(shareMock).toHaveBeenCalledWith({ title: 'Hello', url: 'https://example.com' });
+  });
+
+  it('does not throw an unhandled rejection when the user cancels the native share sheet', async () => {
+    Object.defineProperty(navigator, 'share', {
+      value: vi.fn().mockRejectedValue(new DOMException('Abort', 'AbortError')),
+      configurable: true,
+    });
+    const onUnhandledRejection = vi.fn();
+    window.addEventListener('unhandledrejection', onUnhandledRejection);
+
+    shareViaNavigator({ title: 'Hello', url: 'https://example.com' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    window.removeEventListener('unhandledrejection', onUnhandledRejection);
+    expect(onUnhandledRejection).not.toHaveBeenCalled();
+  });
+});

--- a/Client.React/src/__tests__/useShareImage.test.tsx
+++ b/Client.React/src/__tests__/useShareImage.test.tsx
@@ -57,8 +57,11 @@ describe('useShareImage', () => {
     expect(onUnhandledRejection).not.toHaveBeenCalled();
   });
 
-  it('falls back to downloading the image when the browser cannot share files', async () => {
-    Object.defineProperty(navigator, 'canShare', { value: () => false, configurable: true });
+  it.each([
+    ['browser reports it cannot share files', () => false],
+    ['navigator.canShare is entirely unavailable (older browsers)', undefined],
+  ])('falls back to downloading the image when %s', async (_label, canShare) => {
+    Object.defineProperty(navigator, 'canShare', { value: canShare, configurable: true });
     Object.defineProperty(navigator, 'share', { value: undefined, configurable: true });
     const createObjectURL = vi.fn().mockReturnValue('blob:fake-url');
     const revokeObjectURL = vi.fn();
@@ -77,20 +80,6 @@ describe('useShareImage', () => {
     clickSpy.mockRestore();
   });
 
-  it('falls back to downloading when navigator.canShare is entirely unavailable (older browsers)', async () => {
-    Object.defineProperty(navigator, 'canShare', { value: undefined, configurable: true });
-    Object.defineProperty(navigator, 'share', { value: undefined, configurable: true });
-    Object.defineProperty(URL, 'createObjectURL', { value: vi.fn().mockReturnValue('blob:fake-url'), configurable: true });
-    Object.defineProperty(URL, 'revokeObjectURL', { value: vi.fn(), configurable: true });
-    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
-
-    const { result } = renderHook(() => useShareImage());
-    await result.current.shareImage(node, 'My Standings', 'standings.png');
-
-    expect(clickSpy).toHaveBeenCalled();
-    clickSpy.mockRestore();
-  });
-
   it('shows an error toast and does not throw when image generation fails', async () => {
     mockedToBlob.mockResolvedValue(null);
 
@@ -98,5 +87,13 @@ describe('useShareImage', () => {
     await result.current.shareImage(node, 'My Standings', 'standings.png');
 
     expect(toastPush).toHaveBeenCalledWith(expect.stringMatching(/failed/i), 'error');
+  });
+
+  it('shows an error toast and does not throw when the node is not mounted yet', async () => {
+    const { result } = renderHook(() => useShareImage());
+    await result.current.shareImage(null, 'My Standings', 'standings.png');
+
+    expect(toastPush).toHaveBeenCalledWith(expect.stringMatching(/nothing to share/i), 'error');
+    expect(mockedToBlob).not.toHaveBeenCalled();
   });
 });

--- a/Client.React/src/__tests__/useShareImage.test.tsx
+++ b/Client.React/src/__tests__/useShareImage.test.tsx
@@ -1,0 +1,102 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { useShareImage } from '../utils/useShareImage';
+
+const toastPush = vi.fn();
+vi.mock('../services/toast', () => ({ useToast: () => ({ push: toastPush }) }));
+
+const mockedToBlob = vi.fn();
+vi.mock('html-to-image', () => ({ toBlob: (...args: unknown[]) => mockedToBlob(...args) }));
+
+describe('useShareImage', () => {
+  const originalShare = navigator.share;
+  const originalCanShare = navigator.canShare;
+  const fakeBlob = new Blob(['fake-png-bytes'], { type: 'image/png' });
+  const node = document.createElement('div');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedToBlob.mockResolvedValue(fakeBlob);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'share', { value: originalShare, configurable: true });
+    Object.defineProperty(navigator, 'canShare', { value: originalCanShare, configurable: true });
+  });
+
+  it('shares the rendered node as a PNG file when the browser supports file sharing', async () => {
+    const shareMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'canShare', { value: () => true, configurable: true });
+    Object.defineProperty(navigator, 'share', { value: shareMock, configurable: true });
+
+    const { result } = renderHook(() => useShareImage());
+    await result.current.shareImage(node, 'My Standings', 'standings.png');
+
+    await waitFor(() => expect(shareMock).toHaveBeenCalled());
+    const call = shareMock.mock.calls[0][0];
+    expect(call.title).toBe('My Standings');
+    expect(call.files).toHaveLength(1);
+    expect(call.files[0].name).toBe('standings.png');
+    expect(call.files[0].type).toBe('image/png');
+  });
+
+  it('does not throw an unhandled rejection when the user cancels the native share sheet', async () => {
+    Object.defineProperty(navigator, 'canShare', { value: () => true, configurable: true });
+    Object.defineProperty(navigator, 'share', {
+      value: vi.fn().mockRejectedValue(new DOMException('Abort', 'AbortError')),
+      configurable: true,
+    });
+    const onUnhandledRejection = vi.fn();
+    window.addEventListener('unhandledrejection', onUnhandledRejection);
+
+    const { result } = renderHook(() => useShareImage());
+    await result.current.shareImage(node, 'My Standings', 'standings.png');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    window.removeEventListener('unhandledrejection', onUnhandledRejection);
+    expect(onUnhandledRejection).not.toHaveBeenCalled();
+  });
+
+  it('falls back to downloading the image when the browser cannot share files', async () => {
+    Object.defineProperty(navigator, 'canShare', { value: () => false, configurable: true });
+    Object.defineProperty(navigator, 'share', { value: undefined, configurable: true });
+    const createObjectURL = vi.fn().mockReturnValue('blob:fake-url');
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', { value: createObjectURL, configurable: true });
+    Object.defineProperty(URL, 'revokeObjectURL', { value: revokeObjectURL, configurable: true });
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useShareImage());
+    await result.current.shareImage(node, 'My Standings', 'standings.png');
+
+    expect(createObjectURL).toHaveBeenCalledWith(fakeBlob);
+    expect(clickSpy).toHaveBeenCalled();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake-url');
+    expect(toastPush).toHaveBeenCalledWith(expect.stringMatching(/downloaded/i), 'info');
+
+    clickSpy.mockRestore();
+  });
+
+  it('falls back to downloading when navigator.canShare is entirely unavailable (older browsers)', async () => {
+    Object.defineProperty(navigator, 'canShare', { value: undefined, configurable: true });
+    Object.defineProperty(navigator, 'share', { value: undefined, configurable: true });
+    Object.defineProperty(URL, 'createObjectURL', { value: vi.fn().mockReturnValue('blob:fake-url'), configurable: true });
+    Object.defineProperty(URL, 'revokeObjectURL', { value: vi.fn(), configurable: true });
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useShareImage());
+    await result.current.shareImage(node, 'My Standings', 'standings.png');
+
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
+
+  it('shows an error toast and does not throw when image generation fails', async () => {
+    mockedToBlob.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useShareImage());
+    await result.current.shareImage(node, 'My Standings', 'standings.png');
+
+    expect(toastPush).toHaveBeenCalledWith(expect.stringMatching(/failed/i), 'error');
+  });
+});

--- a/Client.React/src/__tests__/useShareImage.test.tsx
+++ b/Client.React/src/__tests__/useShareImage.test.tsx
@@ -74,14 +74,25 @@ describe('useShareImage', () => {
 
     expect(createObjectURL).toHaveBeenCalledWith(fakeBlob);
     expect(clickSpy).toHaveBeenCalled();
-    expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake-url');
     expect(toastPush).toHaveBeenCalledWith(expect.stringMatching(/downloaded/i), 'info');
+    // Revoke is deliberately deferred (see useShareImage.ts) so the browser has time to start
+    // reading the blob before the URL is invalidated.
+    await waitFor(() => expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake-url'), { timeout: 1500 });
 
     clickSpy.mockRestore();
   });
 
   it('shows an error toast and does not throw when image generation fails', async () => {
     mockedToBlob.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useShareImage());
+    await result.current.shareImage(node, 'My Standings', 'standings.png');
+
+    expect(toastPush).toHaveBeenCalledWith(expect.stringMatching(/failed/i), 'error');
+  });
+
+  it('shows an error toast and does not throw when toBlob rejects (e.g. a blocked font fetch)', async () => {
+    mockedToBlob.mockRejectedValue(new Error('network error'));
 
     const { result } = renderHook(() => useShareImage());
     await result.current.shareImage(node, 'My Standings', 'standings.png');

--- a/Client.React/src/components/ShareableStandingsCard.tsx
+++ b/Client.React/src/components/ShareableStandingsCard.tsx
@@ -13,8 +13,9 @@ interface ShareableStandingsCardProps {
 // the same way an Instagram story template doesn't follow the poster's OS theme.
 const ShareableStandingsCard = forwardRef<HTMLDivElement, ShareableStandingsCardProps>(
   ({ leagueName, userName, rank, total }, ref) => {
-    const totalColor = total > 0 ? '#10b981' : total < 0 ? '#ef4444' : '#ffffff';
-    const totalLabel = total > 0 ? `+${total}` : `${total}`;
+    const sign = Math.sign(total);
+    const totalColor = sign > 0 ? '#10b981' : sign < 0 ? '#ef4444' : '#ffffff';
+    const totalLabel = sign > 0 ? `+${total}` : `${total}`;
 
     return (
       <Box

--- a/Client.React/src/components/ShareableStandingsCard.tsx
+++ b/Client.React/src/components/ShareableStandingsCard.tsx
@@ -1,0 +1,51 @@
+import { forwardRef } from 'react';
+import { Box, Typography } from '@mui/material';
+
+interface ShareableStandingsCardProps {
+  leagueName: string;
+  userName: string;
+  rank: string;
+  total: number;
+}
+
+// Fixed brand look (not theme-reactive) — this gets exported as a static PNG shared outside
+// the app, so it should look the same regardless of the viewer's own light/dark preference,
+// the same way an Instagram story template doesn't follow the poster's OS theme.
+const ShareableStandingsCard = forwardRef<HTMLDivElement, ShareableStandingsCardProps>(
+  ({ leagueName, userName, rank, total }, ref) => {
+    const totalColor = total > 0 ? '#10b981' : total < 0 ? '#ef4444' : '#ffffff';
+    const totalLabel = total > 0 ? `+${total}` : `${total}`;
+
+    return (
+      <Box
+        ref={ref}
+        sx={{
+          width: 600,
+          height: 600,
+          background: 'linear-gradient(135deg, #1a2847 0%, #0f1729 100%)',
+          color: '#ffffff',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 2,
+          textAlign: 'center',
+          p: 4,
+        }}
+      >
+        <Typography sx={{ color: '#ff6b35', fontWeight: 700, letterSpacing: 3, fontSize: 20 }}>
+          IV LEAGUE
+        </Typography>
+        <Typography sx={{ fontSize: 26, opacity: 0.8 }}>{leagueName}</Typography>
+        <Typography sx={{ fontSize: 44, fontWeight: 800, mt: 2 }}>{userName}</Typography>
+        <Typography sx={{ fontSize: 22, opacity: 0.7 }}>{`#${rank}`}</Typography>
+        <Typography sx={{ fontSize: 72, fontWeight: 900, color: totalColor, mt: 2 }}>
+          {totalLabel}
+        </Typography>
+      </Box>
+    );
+  }
+);
+ShareableStandingsCard.displayName = 'ShareableStandingsCard';
+
+export default ShareableStandingsCard;

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -112,11 +112,17 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
       : {};
   };
 
-  const myRow = leaderboard.find((row) => row.userName === user?.name);
-  const leagueName = availableLeagues.find((l) => l.leagueId === currentLeague)?.leagueName ?? 'IV League';
+  const myRow = useMemo(
+    () => leaderboard.find((row) => row.userName === user?.name),
+    [leaderboard, user?.name]
+  );
+  const leagueName = useMemo(
+    () => availableLeagues.find((l) => l.leagueId === currentLeague)?.leagueName ?? 'IV League',
+    [availableLeagues, currentLeague]
+  );
 
   const handleShare = () => {
-    if (!myRow || !cardRef.current) {
+    if (!myRow) {
       share('IV League Standings', window.location.href);
       return;
     }

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -121,12 +121,24 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
     [availableLeagues, currentLeague]
   );
 
+  const [isPreparingShare, setIsPreparingShare] = useState(false);
+
+  useEffect(() => {
+    if (!isPreparingShare || !myRow) return;
+    void shareImage(cardRef.current, `${myRow.userName}'s IV League Standings`, 'iv-league-standings.png').finally(() =>
+      setIsPreparingShare(false)
+    );
+    // Only re-run when a share is actually kicked off — shareImage is a fresh function
+    // identity every render and must not retrigger a capture on its own.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPreparingShare]);
+
   const handleShare = () => {
     if (!myRow) {
       share('IV League Standings', window.location.href);
       return;
     }
-    void shareImage(cardRef.current, `${myRow.userName}'s IV League Standings`, 'iv-league-standings.png');
+    setIsPreparingShare(true);
   };
 
   if (loading) {
@@ -157,11 +169,15 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
           </Button>
         }
       />
-      {myRow && (
-        // Positioned in normal flow (0,0) inside a zero-size overflow:hidden wrapper, not at a
-        // large negative offset — WebKit's foreignObject-based canvas capture (what html-to-image
-        // uses) can render blank when the source node sits outside the viewport's coordinate
-        // space, which matters here since iOS Safari is this app's primary audience (CLAUDE.md).
+      {myRow && isPreparingShare && (
+        // Mounted only while actually capturing a share image — an always-mounted hidden card
+        // duplicates the user's name/rank text in the DOM, which broke a real Playwright demo
+        // test (getByText('alice') matched both the standings row and this card's own text)
+        // even though it's visually hidden. Positioned in normal flow (0,0) inside a zero-size
+        // overflow:hidden wrapper, not at a large negative offset — WebKit's foreignObject-based
+        // canvas capture (what html-to-image uses) can render blank when the source node sits
+        // outside the viewport's coordinate space, which matters here since iOS Safari is this
+        // app's primary audience (CLAUDE.md).
         <Box sx={{ position: 'absolute', top: 0, left: 0, width: 0, height: 0, overflow: 'hidden', pointerEvents: 'none' }} aria-hidden="true">
           <ShareableStandingsCard
             ref={cardRef}

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -106,15 +106,15 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
   };
 
   const rowClass = (row: LeaderboardDto) => {
-    if (!user?.name) return {};
-    return row.userName === user.name
+    if (!user?.userId) return {};
+    return row.userId === user.userId
       ? { backgroundColor: 'action.hover', fontWeight: 600 }
       : {};
   };
 
   const myRow = useMemo(
-    () => leaderboard.find((row) => row.userName === user?.name),
-    [leaderboard, user?.name]
+    () => leaderboard.find((row) => row.userId === user?.userId),
+    [leaderboard, user?.userId]
   );
   const leagueName = useMemo(
     () => availableLeagues.find((l) => l.leagueId === currentLeague)?.leagueName ?? 'IV League',
@@ -158,7 +158,11 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
         }
       />
       {myRow && (
-        <Box sx={{ position: 'fixed', top: -9999, left: -9999, pointerEvents: 'none' }} aria-hidden="true">
+        // Positioned in normal flow (0,0) inside a zero-size overflow:hidden wrapper, not at a
+        // large negative offset — WebKit's foreignObject-based canvas capture (what html-to-image
+        // uses) can render blank when the source node sits outside the viewport's coordinate
+        // space, which matters here since iOS Safari is this app's primary audience (CLAUDE.md).
+        <Box sx={{ position: 'absolute', top: 0, left: 0, width: 0, height: 0, overflow: 'hidden', pointerEvents: 'none' }} aria-hidden="true">
           <ShareableStandingsCard
             ref={cardRef}
             leagueName={leagueName}

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Navigate } from 'react-router-dom';
 import {
   alpha,
@@ -18,6 +18,7 @@ import {
 } from '@mui/material';
 import IosShareIcon from '@mui/icons-material/IosShare';
 import PageHeader from '../components/PageHeader';
+import ShareableStandingsCard from '../components/ShareableStandingsCard';
 import { useSession } from '../services/session';
 import { useAuth } from '../services/auth';
 import { getLeaderboard } from '../api/leaderboard';
@@ -25,6 +26,7 @@ import type { LeaderboardDto } from '../types/leaderboard';
 import type { SportAdapter } from '../services/sportAdapter';
 import { stickyColumnSx } from '../utils/tableStyles';
 import { useShareLink } from '../utils/useShareLink';
+import { useShareImage } from '../utils/useShareImage';
 
 interface LeaderboardPageProps {
   adapter: SportAdapter;
@@ -32,9 +34,11 @@ interface LeaderboardPageProps {
 
 export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
   const theme = useTheme();
-  const { currentLeague, leaguesLoaded } = useSession();
+  const { currentLeague, availableLeagues, leaguesLoaded } = useSession();
   const { user } = useAuth();
   const { share } = useShareLink();
+  const { shareImage } = useShareImage();
+  const cardRef = useRef<HTMLDivElement>(null);
   const [loading, setLoading] = useState(true);
   const [leaderboard, setLeaderboard] = useState<LeaderboardDto[]>([]);
 
@@ -108,6 +112,17 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
       : {};
   };
 
+  const myRow = leaderboard.find((row) => row.userName === user?.name);
+  const leagueName = availableLeagues.find((l) => l.leagueId === currentLeague)?.leagueName ?? 'IV League';
+
+  const handleShare = () => {
+    if (!myRow || !cardRef.current) {
+      share('IV League Standings', window.location.href);
+      return;
+    }
+    void shareImage(cardRef.current, `${myRow.userName}'s IV League Standings`, 'iv-league-standings.png');
+  };
+
   if (loading) {
     return (
       <Box>
@@ -130,12 +145,23 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
             size="small"
             variant="outlined"
             startIcon={<IosShareIcon />}
-            onClick={() => share('IV League Standings', window.location.href)}
+            onClick={handleShare}
           >
             Share
           </Button>
         }
       />
+      {myRow && (
+        <Box sx={{ position: 'fixed', top: -9999, left: -9999, pointerEvents: 'none' }} aria-hidden="true">
+          <ShareableStandingsCard
+            ref={cardRef}
+            leagueName={leagueName}
+            userName={myRow.userName}
+            rank={myRow.rank}
+            total={myRow.total}
+          />
+        </Box>
+      )}
       {leaderboard.length === 0 && (
         <Typography variant="body2" color="text.secondary" sx={{ mt: 4, textAlign: 'center' }}>
           No leaderboard data yet for this season.

--- a/Client.React/src/utils/nativeShare.ts
+++ b/Client.React/src/utils/nativeShare.ts
@@ -1,0 +1,7 @@
+/**
+ * Fires navigator.share and swallows the rejection. Cancelling the native share sheet rejects
+ * with AbortError — routine, not an error — shared by every hook that calls navigator.share.
+ */
+export function shareViaNavigator(data: ShareData): void {
+  navigator.share(data).catch(() => {});
+}

--- a/Client.React/src/utils/useShareImage.ts
+++ b/Client.React/src/utils/useShareImage.ts
@@ -1,0 +1,36 @@
+import { toBlob } from 'html-to-image';
+import { useToast } from '../services/toast';
+
+/**
+ * Renders a DOM node to a PNG and shares it as a file (native share sheet — iMessage,
+ * Instagram, etc. treat it like sharing a photo). Falls back to a direct download when the
+ * browser can't share files (e.g. desktop Safari).
+ */
+export function useShareImage() {
+  const toast = useToast();
+
+  const shareImage = async (node: HTMLElement, title: string, fileName: string) => {
+    const blob = await toBlob(node, { pixelRatio: 2 });
+    if (!blob) {
+      toast.push('Failed to generate image', 'error');
+      return;
+    }
+    const file = new File([blob], fileName, { type: 'image/png' });
+
+    if (navigator.canShare?.({ files: [file] })) {
+      // Cancelling the native share sheet rejects with AbortError — routine, not an error.
+      navigator.share({ files: [file], title }).catch(() => {});
+      return;
+    }
+
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    a.click();
+    URL.revokeObjectURL(url);
+    toast.push('Image downloaded — share it from your Photos/Downloads', 'info');
+  };
+
+  return { shareImage };
+}

--- a/Client.React/src/utils/useShareImage.ts
+++ b/Client.React/src/utils/useShareImage.ts
@@ -1,15 +1,20 @@
 import { toBlob } from 'html-to-image';
 import { useToast } from '../services/toast';
+import { shareViaNavigator } from './nativeShare';
 
 /**
  * Renders a DOM node to a PNG and shares it as a file (native share sheet — iMessage,
  * Instagram, etc. treat it like sharing a photo). Falls back to a direct download when the
- * browser can't share files (e.g. desktop Safari).
+ * browser can't share files (e.g. desktop Safari) or the node isn't mounted/painted yet.
  */
 export function useShareImage() {
   const toast = useToast();
 
-  const shareImage = async (node: HTMLElement, title: string, fileName: string) => {
+  const shareImage = async (node: HTMLElement | null, title: string, fileName: string) => {
+    if (!node) {
+      toast.push('Nothing to share yet', 'error');
+      return;
+    }
     const blob = await toBlob(node, { pixelRatio: 2 });
     if (!blob) {
       toast.push('Failed to generate image', 'error');
@@ -18,8 +23,7 @@ export function useShareImage() {
     const file = new File([blob], fileName, { type: 'image/png' });
 
     if (navigator.canShare?.({ files: [file] })) {
-      // Cancelling the native share sheet rejects with AbortError — routine, not an error.
-      navigator.share({ files: [file], title }).catch(() => {});
+      shareViaNavigator({ files: [file], title });
       return;
     }
 

--- a/Client.React/src/utils/useShareImage.ts
+++ b/Client.React/src/utils/useShareImage.ts
@@ -15,7 +15,12 @@ export function useShareImage() {
       toast.push('Nothing to share yet', 'error');
       return;
     }
-    const blob = await toBlob(node, { pixelRatio: 2 });
+    let blob: Blob | null;
+    try {
+      blob = await toBlob(node, { pixelRatio: 2 });
+    } catch {
+      blob = null;
+    }
     if (!blob) {
       toast.push('Failed to generate image', 'error');
       return;
@@ -32,7 +37,9 @@ export function useShareImage() {
     a.href = url;
     a.download = fileName;
     a.click();
-    URL.revokeObjectURL(url);
+    // Revoking immediately after click() can race with the browser actually starting to read
+    // the blob (observed in Firefox), silently truncating the download — defer the revoke.
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
     toast.push('Image downloaded — share it from your Photos/Downloads', 'info');
   };
 

--- a/Client.React/src/utils/useShareLink.ts
+++ b/Client.React/src/utils/useShareLink.ts
@@ -1,4 +1,5 @@
 import { useToast } from '../services/toast';
+import { shareViaNavigator } from './nativeShare';
 
 /**
  * Native-share-with-clipboard-fallback, shared by every "Share"/"Copy" button in the app.
@@ -17,9 +18,8 @@ export function useShareLink() {
   };
 
   const share = (title: string, url: string) => {
-    if (navigator.share) {
-      // Cancelling the native share sheet rejects with AbortError — routine, not an error.
-      navigator.share({ title, url }).catch(() => {});
+    if (typeof navigator.share === 'function') {
+      shareViaNavigator({ title, url });
     } else {
       void copy(url);
     }


### PR DESCRIPTION
## Summary
- Share Leaderboard standings as a branded PNG image (Web Share API with files, falling back to direct download) instead of just sharing a plain link
- Renders the current user's rank/total onto a fixed-look brand card (`ShareableStandingsCard`), captured client-side via `html-to-image`
- Hardening on top of the original feature (from `/simplify` + `/code-review`):
  - `toBlob()` rejection (e.g. a blocked font fetch) is now caught, not just a `null` result
  - Off-screen capture node moved into normal document flow (0-size, `overflow:hidden`, `top/left:0`) instead of a large negative offset, which can render blank on WebKit's `foreignObject`-based canvas capture (iOS Safari is this app's primary audience)
  - `URL.revokeObjectURL` is deferred until after the download starts, avoiding a race that can truncate the save in some browsers
  - The current user's row/share-card data is now matched by `userId` instead of display name — two league members sharing a name no longer collide

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test -- --run` — 399/399 passing
- [x] `npm run test:e2e -- --project=chromium` — 79/79 passing (leaderboard spec includes a new share-fallback test)
- [x] `dotnet test` — 632/632 passing (no backend changes)
- [x] `/simplify` — 4-angle review run; findings reviewed, none required a change (all were either behavior-changing tradeoffs or premature abstraction)
- [x] `/code-review` — run; the two real findings (userId matching, revoke race) fixed above; the WebKit-paint theory and desktop-Safari-download-attribute concern are noted below as unverified/lower-priority, not blocking

## Known follow-ups (not blocking this PR)
- Desktop Safari's handling of the `download` attribute on blob: URLs for the fallback path is untested live — if it silently opens a new tab instead of downloading, the toast text would be misleading. Low priority: this app's primary audience is mobile, where the native Share API path is used instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs