### PR TITLE
fix: Scores Matrix view — spell out OVER/UNDER instead of a small corner arrow icon

### DIFF
--- a/Client.React/src/__tests__/UserPicksMatrix.test.tsx
+++ b/Client.React/src/__tests__/UserPicksMatrix.test.tsx
@@ -64,6 +64,72 @@ describe('UserPicksMatrix — text-only badges (no team logo)', () => {
   });
 });
 
+describe('UserPicksMatrix — Over/Under shown as a bold word, not a small icon', () => {
+  // frizat: a tiny corner arrow icon competing with the win/loss-colored badge background and
+  // the large team text was easy to miss — spell out OVER/UNDER instead, same size treatment
+  // as the team abbreviation label.
+  it('shows the word OVER for an Over pick', () => {
+    const overPick: NflPickDto[] = [
+      { id: 1, userId: 'u1', userName: 'alice', team: 'KC', pick: 'Over', season: 2025, nflWeek: 19, leagueId: 1, dateCreated: '' },
+    ];
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <UserPicksMatrix users={['alice']} picks={overPick} spreads={{}} requiredPicks={1} />
+      </ThemeProvider>,
+    );
+    expect(screen.getByText('OVER')).toBeInTheDocument();
+  });
+
+  it('shows the word UNDER for an Under pick', () => {
+    const underPick: NflPickDto[] = [
+      { id: 1, userId: 'u1', userName: 'alice', team: 'KC', pick: 'Under', season: 2025, nflWeek: 19, leagueId: 1, dateCreated: '' },
+    ];
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <UserPicksMatrix users={['alice']} picks={underPick} spreads={{}} requiredPicks={1} />
+      </ThemeProvider>,
+    );
+    expect(screen.getByText('UNDER')).toBeInTheDocument();
+  });
+
+  it('does not show an OVER/UNDER label for a Spread pick', () => {
+    renderMatrix('light');
+    expect(screen.queryByText('OVER')).not.toBeInTheDocument();
+    expect(screen.queryByText('UNDER')).not.toBeInTheDocument();
+  });
+
+  it('does not render an arrow icon anymore', () => {
+    const overPick: NflPickDto[] = [
+      { id: 1, userId: 'u1', userName: 'alice', team: 'KC', pick: 'Over', season: 2025, nflWeek: 19, leagueId: 1, dateCreated: '' },
+    ];
+    const { container } = render(
+      <ThemeProvider theme={createTheme()}>
+        <UserPicksMatrix users={['alice']} picks={overPick} spreads={{}} requiredPicks={1} />
+      </ThemeProvider>,
+    );
+    expect(container.querySelector('[data-testid="ArrowCircleUpIcon"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-testid="ArrowCircleDownIcon"]')).not.toBeInTheDocument();
+  });
+
+  it('renders the OVER/UNDER label in a neutral color, not red, when the game has no result yet', () => {
+    // frizat: /code-review caught that the old icon's color logic (carried into the new text
+    // label) collapsed "no spread data yet" (result === null, a scheduled/in-progress game per
+    // ScoresPage's matrixSpreads) into the same branch as an actual loss — falsely showing a red
+    // "OVER" before the game was even decided. Matches the badge background's own 3-way branch.
+    const pendingPick: NflPickDto[] = [
+      { id: 1, userId: 'u1', userName: 'alice', team: 'KC', pick: 'Over', season: 2025, nflWeek: 19, leagueId: 1, dateCreated: '' },
+    ];
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <UserPicksMatrix users={['alice']} picks={pendingPick} spreads={{}} requiredPicks={1} />
+      </ThemeProvider>,
+    );
+    const label = screen.getByText('OVER');
+    expect(label).not.toHaveStyle({ color: 'rgb(211, 47, 47)' }); // MUI error.main
+    expect(label).not.toHaveStyle({ color: 'rgb(46, 125, 50)' }); // MUI success.main
+  });
+});
+
 describe('UserPicksMatrix — Over/Under is an alternate pick type, not an additional pick', () => {
   // frizat: AddPicks' server-side validation caps total picks (any type) at requiredPicks — a
   // real user's Over/Under pick REPLACES one of their spread picks, it never adds a pick beyond

--- a/Client.React/src/components/UserPicksMatrix.tsx
+++ b/Client.React/src/components/UserPicksMatrix.tsx
@@ -8,8 +8,6 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
-import ArrowCircleUpIcon from '@mui/icons-material/ArrowCircleUp';
-import ArrowCircleDownIcon from '@mui/icons-material/ArrowCircleDown';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
 import type { NflPickDto, SpreadCalculationResponse } from '../types/picks';
@@ -60,20 +58,6 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
           flexShrink: 0,
         }}
       >
-        {pick.pick === 'Over' && (
-          <ArrowCircleUpIcon
-            fontSize="small"
-            sx={{ position: 'absolute', top: 4, left: 4, bgcolor: 'white', borderRadius: '50%' }}
-            color={result ? 'success' : 'error'}
-          />
-        )}
-        {pick.pick === 'Under' && (
-          <ArrowCircleDownIcon
-            fontSize="small"
-            sx={{ position: 'absolute', top: 4, left: 4, bgcolor: 'white', borderRadius: '50%' }}
-            color={result ? 'success' : 'error'}
-          />
-        )}
         {/* frizat: the helmet logo + 9px label was hard to read at a glance against the
             win/loss color-coded background — text-only, much larger, reads clearly instead.
             CFB abbreviations run up to 4 chars (UTSA, UNLV, WASH) vs NFL's 2-3 — shrink to fit
@@ -81,6 +65,23 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
         <Typography sx={{ fontSize: pick.team.length > 3 ? 16 : 22, fontWeight: 800, letterSpacing: '0.02em' }}>
           {pick.team}
         </Typography>
+        {/* frizat: a tiny corner arrow icon was easy to miss against the color-coded background
+            and the large team text above it — spell out OVER/UNDER instead, same bold treatment.
+            Match the badge background's 3-way branch (win/loss/no-result-yet) — result is null
+            for a scheduled/in-progress game (ScoresPage's matrixSpreads only populates an entry
+            once a game is final), which must read as neutral, not silently collapse into "loss". */}
+        {pick.pick !== 'Spread' && (
+          <Typography
+            sx={{
+              fontSize: 11,
+              fontWeight: 800,
+              letterSpacing: '0.03em',
+              color: result === true ? 'success.main' : result === false ? 'error.main' : 'text.secondary',
+            }}
+          >
+            {pick.pick.toUpperCase()}
+          </Typography>
+        )}
         {result === true && (
           <CheckCircleIcon
             fontSize="small"


### PR DESCRIPTION
## Summary
- Tiny arrow icon competed with the win/loss-colored badge background and large team text for attention — replaced with a bold OVER/UNDER word, same treatment as the team abbreviation shipped in #255
- `/code-review` caught a pre-existing bug carried over from the old icon's color logic: `result === null` (game not final yet) was collapsed into the same branch as an actual loss, showing red before the game was decided. Fixed to match the badge background's own true/false/neutral branch.

## Test plan
- [x] TDD: failing tests written first (OVER/UNDER text, no more icon, neutral color for pending games), confirmed red then green
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm run test -- --run` — 407/407 passing
- [x] `npm run test:e2e -- --project=chromium` — 79/79 passing
- [x] `dotnet test` — 635/635 passing (no backend changes)
- [x] `/code-review` — 1 finding, fixed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs