### PR TITLE
feat: existing users joining via a shareable link get the same pending-invite banner as Invite Player

### DIFF
--- a/Client.React/src/__tests__/JoinLeaguePage.test.tsx
+++ b/Client.React/src/__tests__/JoinLeaguePage.test.tsx
@@ -18,6 +18,7 @@ vi.mock('../services/auth', () => ({ useAuth: () => authState }));
 
 const sessionMock = {
   reloadLeagues: vi.fn().mockResolvedValue(undefined),
+  refreshPendingInvites: vi.fn().mockResolvedValue(undefined),
   availableLeagues: [] as { leagueId: number }[],
 };
 vi.mock('../services/session', () => ({ useSession: () => sessionMock }));
@@ -43,6 +44,7 @@ describe('JoinLeaguePage', () => {
   beforeEach(() => {
     navigateMock.mockReset();
     sessionMock.reloadLeagues.mockResolvedValue(undefined);
+    sessionMock.refreshPendingInvites.mockReset().mockResolvedValue(undefined);
     sessionMock.availableLeagues = [];
     authState.user = null;
   });
@@ -111,7 +113,11 @@ describe('JoinLeaguePage', () => {
     expect(screen.getByRole('button', { name: /go to dashboard/i })).toBeInTheDocument();
   });
 
-  it('calls joinViaLink and navigates to dashboard on success', async () => {
+  it('calls joinViaLink, refreshes pending invites (not leagues), and navigates to dashboard on success', async () => {
+    // frizat: joinViaLink now creates a pending membership invite rather than joining directly
+    // (see LeagueController.JoinViaLink) — the user isn't a league member yet after this call,
+    // so refreshing leagues would be a no-op; refreshing pending invites is what makes
+    // PendingInviteBanner show up immediately on the dashboard with Accept/Decline.
     vi.mocked(validateInviteLink).mockResolvedValue({
       token: 'tok123',
       leagueId: 1,
@@ -124,6 +130,10 @@ describe('JoinLeaguePage', () => {
     await waitFor(() => screen.getByRole('button', { name: /join/i }));
     await userEvent.click(screen.getByRole('button', { name: /join/i }));
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/dashboard'));
-    expect(sessionMock.reloadLeagues).toHaveBeenCalled();
+    expect(sessionMock.refreshPendingInvites).toHaveBeenCalled();
+    // frizat: /code-review caught that this test's title promised "not leagues" without
+    // actually asserting it — a regression re-adding reloadLeagues() to the success path
+    // would have passed silently.
+    expect(sessionMock.reloadLeagues).not.toHaveBeenCalled();
   });
 });

--- a/Client.React/src/pages/JoinLeaguePage.tsx
+++ b/Client.React/src/pages/JoinLeaguePage.tsx
@@ -15,7 +15,7 @@ export default function JoinLeaguePage() {
   const { token } = useParams<{ token: string }>();
   const navigate = useNavigate();
   const { user } = useAuth();
-  const { reloadLeagues, availableLeagues } = useSession();
+  const { reloadLeagues, availableLeagues, refreshPendingInvites } = useSession();
 
   const [loading, setLoading] = useState(true);
   const [joining, setJoining] = useState(false);
@@ -43,8 +43,11 @@ export default function JoinLeaguePage() {
     setJoining(true);
     setError(null);
     try {
+      // joinViaLink creates a pending membership invite rather than joining directly (see
+      // LeagueController.JoinViaLink) — refresh pending invites, not leagues, so
+      // PendingInviteBanner shows up immediately on the dashboard with Accept/Decline.
       await joinViaLink(token!);
-      await reloadLeagues();
+      await refreshPendingInvites();
       navigate('/dashboard');
     } catch (err) {
       const status = (err as { response?: { status?: number } }).response?.status;

--- a/Server.UnitTests/LeagueInviteLinkTests.cs
+++ b/Server.UnitTests/LeagueInviteLinkTests.cs
@@ -464,21 +464,29 @@ public class LeagueInviteLinkTests
     }
 
     [Fact]
-    public async Task JoinViaLink_ReturnsNoContent_WhenSuccessful()
+    public async Task JoinViaLink_CreatesPendingMembershipInvite_RatherThanJoiningDirectly()
     {
-        var link = new LeagueInviteLink { Token = "tok", LeagueId = 1, League = new LeagueInfo { Id = 1, LeagueName = "L" }, ExpiresAt = DateTimeOffset.UtcNow.AddHours(1) };
+        // frizat: an already-authenticated user clicking a share link used to be added to the
+        // league immediately, with no way to decline — that's inconsistent with the "Invite
+        // Player" flow, which creates a pending invite an existing user must explicitly accept
+        // or decline via PendingInviteBanner. Route link-joins through the same mechanism so
+        // both invite paths behave identically for an existing user; only a brand-new user's
+        // register-and-join-in-one-step path is unaffected by this change.
+        var link = new LeagueInviteLink { Token = "tok", LeagueId = 1, CreatedByUserId = OwnerId, League = new LeagueInfo { Id = 1, LeagueName = "L" }, ExpiresAt = DateTimeOffset.UtcNow.AddHours(1) };
         var linkService = Substitute.For<ILeagueInviteLinkService>();
         linkService.ValidateAsync("tok").Returns(link);
 
         var repo = Substitute.For<ILeagueRepository>();
         repo.UserExistsInLeagueAsync(MemberId, 1).Returns(false);
 
-        var controller = BuildController(BuildPrincipal(MemberId), repo: repo, linkService: linkService);
+        var membershipInviteService = Substitute.For<ILeagueMembershipInviteService>();
+
+        var controller = BuildController(BuildPrincipal(MemberId), repo: repo, linkService: linkService, membershipInviteService: membershipInviteService);
 
         var result = await controller.JoinViaLink("tok");
 
         Assert.IsType<NoContentResult>(result);
-        await repo.Received(1).AddLeagueUserMappingAsync(Arg.Is<LeagueUserMapping>(m =>
-            m.LeagueId == 1 && m.UserId == MemberId));
+        await membershipInviteService.Received(1).CreateOrReopenAsync(1, MemberId, OwnerId);
+        await repo.DidNotReceiveWithAnyArgs().AddLeagueUserMappingAsync(default!);
     }
 }

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -889,8 +889,13 @@ public class LeagueController(
         var link = await leagueInviteLinkService.ValidateAsync(token);
         if (link is null) return NotFound();
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
-        if (!await TryAddUserToLeagueAsync(userId, link.LeagueId))
+        if (await repo.UserExistsInLeagueAsync(userId, link.LeagueId))
             return Conflict("You are already a member of this league.");
+        // An already-authenticated user clicking a share link gets the same pending-invite +
+        // banner treatment as the "Invite Player" flow (see InviteToLeague above) — not an
+        // instant, undo-less join. Only a brand-new user's register-and-join-in-one-step path
+        // (AuthController.CreateUser's InviteLinkToken branch) still joins directly.
+        await membershipInviteService.CreateOrReopenAsync(link.LeagueId, userId, link.CreatedByUserId);
         return NoContent();
     }
 


### PR DESCRIPTION
## Summary
- An already-authenticated user clicking a league's share link joined instantly, with no way to decline — inconsistent with the "Invite Player" flow, which creates a pending invite the user must explicitly Accept/Decline via `PendingInviteBanner`
- `JoinViaLink` now routes an existing user's link-join through the same `membershipInviteService.CreateOrReopenAsync` mechanism `InviteToLeague` already uses, then redirects to `/dashboard` where the banner picks it up
- A brand-new (unauthenticated) user's register-and-join-in-one-step path is completely unchanged, as requested

## Test plan
- [x] TDD: failing tests written first (backend `JoinViaLink` behavior, frontend `JoinLeaguePage` refresh call), confirmed red then green
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm run test -- --run` — 407/407 passing
- [x] `npm run test:e2e -- --project=chromium` — 79/79 passing (including all 22 `inviteFlow.spec.ts` tests)
- [x] `dotnet test` — 635/635 passing
- [x] `/code-review` — 2 findings: a pre-existing TOCTOU race already present on the sibling `InviteToLeague` path (self-heals via `AcceptMembershipInvite`'s existing no-op-on-already-member handling, not introduced by this diff, left as-is) and a test-tightening nit (fixed — added an explicit assertion that `reloadLeagues` is NOT called on the new success path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs