### PR TITLE
feat: Leaderboard season selector — view standings from previous years, like ESPN

### DIFF
--- a/Client.React/e2e/leaderboard.spec.ts
+++ b/Client.React/e2e/leaderboard.spec.ts
@@ -70,6 +70,31 @@ test.describe('Leaderboard page (authenticated)', () => {
     await expect(page.getByText('Standings')).not.toBeVisible();
   });
 
+  test('season selector defaults to the current season, and switching seasons re-fetches standings for that year', async ({ page }) => {
+    await gotoLeaderboard(page, sampleLeaderboard);
+    await expect(page.getByText('2024 Season')).toBeVisible({ timeout: 5000 }); // TEST_SEASON in e2e/helpers/routes.ts
+
+    // Registered after the default mock (from setupRoutes, via gotoLeaderboard/mockAuth) so it
+    // takes over for any leaderboard request from here on — proves the season change actually
+    // fires a new request for the newly-selected year, not just a client-side re-render.
+    const requestedSeasons: string[] = [];
+    await page.route(/\/api\/leaderboard\/\d+\/leaderboard\/\d+/, (route) => {
+      requestedSeasons.push(new URL(route.request().url()).pathname.split('/').pop()!);
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(sampleLeaderboard) });
+    });
+
+    // Other combobox-role selectors (e.g. Picks' week/season-type selector) can linger in the
+    // DOM after the client-side nav gotoLeaderboard does — target this one by its visible text.
+    await page.getByText('2024 Season').click();
+    await page.getByRole('option', { name: '2022 Season' }).click();
+
+    await expect(page.getByRole('combobox').filter({ hasText: '2022 Season' })).toBeVisible({ timeout: 5000 });
+    // Not asserting the exact call list — an incidental extra same-season refetch is possible
+    // depending on render timing and isn't what this test is about — just that switching to
+    // 2022 actually fires a real request for that year, not just a client-side re-render.
+    expect(requestedSeasons.at(-1)).toBe('2022');
+  });
+
   test('Share button renders the standings card and shares it (falls back to download when the browser cannot share files)', async ({ page }) => {
     // Force the download-fallback branch deterministically, rather than relying on whatever
     // Web Share API support this Chromium build happens to have.

--- a/Client.React/src/__tests__/leaderboard.test.tsx
+++ b/Client.React/src/__tests__/leaderboard.test.tsx
@@ -146,6 +146,107 @@ describe('LeaderboardPage', () => {
   });
 });
 
+describe('LeaderboardPage — season selector', () => {
+  beforeEach(() => {
+    sessionState.currentLeague = 1;
+    mockedGetLeaderboard.mockReset();
+    mockedGetLeaderboard.mockResolvedValue([
+      createLeaderboardEntry({ userId: '123', userName: 'TestUser', rank: '1', total: 5, weekResults: [] }),
+    ]);
+    vi.mocked(mockAdapter.currentSeasonYear).mockResolvedValue(2023);
+  });
+
+  it('defaults to the current season and loads it on mount', async () => {
+    renderPage();
+    await screen.findByRole('table');
+    expect(screen.getByText('2023 Season')).toBeInTheDocument();
+    expect(mockedGetLeaderboard).toHaveBeenCalledWith(1, 2023);
+  });
+
+  it('lets the viewer pick a previous season, like ESPN — re-fetches standings for that year', async () => {
+    renderPage();
+    await screen.findByRole('table');
+    mockedGetLeaderboard.mockClear();
+
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(screen.getByRole('option', { name: '2021 Season' }));
+
+    await waitFor(() => expect(mockedGetLeaderboard).toHaveBeenCalledWith(1, 2021));
+    expect(screen.getByText('2021 Season')).toBeInTheDocument();
+  });
+
+  it('offers every season from adapter.weekSelectorConfig.minSeason through the current season', async () => {
+    renderPage();
+    await screen.findByRole('table');
+
+    await userEvent.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('option', { name: '2023 Season' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: '2020 Season' })).toBeInTheDocument(); // mockAdapter.weekSelectorConfig.minSeason
+    expect(screen.queryByRole('option', { name: '2019 Season' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: '2024 Season' })).not.toBeInTheDocument();
+  });
+
+  it('disables the season selector while a season change is loading, preventing overlapping requests', async () => {
+    // frizat: /code-review flagged that rapidly re-selecting seasons had no race guard — a
+    // slower earlier request resolving after a later one could leave the table showing the
+    // wrong season's data. Rather than layering a manual staleness-check on top, disable the
+    // control while a fetch is in flight so a second request can never be fired before the
+    // first resolves — simpler, and standard behavior for a data-driven selector mid-fetch.
+    let resolveFetch!: (value: ReturnType<typeof createLeaderboardEntry>[]) => void;
+    mockedGetLeaderboard.mockImplementationOnce(() => Promise.resolve([
+      createLeaderboardEntry({ userId: '123', userName: 'TestUser', rank: '1', total: 5, weekResults: [] }),
+    ]));
+
+    renderPage();
+    await screen.findByRole('table');
+
+    mockedGetLeaderboard.mockImplementationOnce(() => new Promise((res) => { resolveFetch = res; }));
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(screen.getByRole('option', { name: '2021 Season' }));
+
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-disabled', 'true');
+
+    resolveFetch([createLeaderboardEntry({ userId: '456', userName: 'PastYearUser', rank: '1', total: 2, weekResults: [] })]);
+    await screen.findByText('PastYearUser');
+    expect(screen.getByRole('combobox')).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('shows the full loading state (not stale data) when the current league changes, not just the season', async () => {
+    // frizat: /code-review caught that the "only show a light refresh, not a full spinner, after
+    // the first load" optimization was keyed on ANY fetch ever completing, not on the currently
+    // selected league — switching leagues via AppLayout's league-selector chip while sitting on
+    // this page (a real, reachable flow, unrelated to this page's own season selector) left the
+    // PREVIOUS league's standings rendered, unlabeled as stale, while the new league's data
+    // loaded, with no guard against an out-of-order response overwriting the right one.
+    mockedGetLeaderboard.mockResolvedValueOnce([
+      createLeaderboardEntry({ userId: '123', userName: 'LeagueOneUser', rank: '1', total: 5, weekResults: [] }),
+    ]);
+    const { rerender } = renderPage();
+    await screen.findByText('LeagueOneUser');
+
+    let resolveLeagueTwo!: (value: ReturnType<typeof createLeaderboardEntry>[]) => void;
+    mockedGetLeaderboard.mockImplementationOnce(() => new Promise((res) => { resolveLeagueTwo = res; }));
+
+    sessionState.currentLeague = 2;
+    rerender(
+      <ThemeProvider theme={createAppTheme('light')}>
+        <MemoryRouter initialEntries={['/leaderboard']}>
+          <Routes>
+            <Route path="/leaderboard" element={<LeaderboardPage adapter={mockAdapter} />} />
+            <Route path="/leaguepicker" element={<div>League Picker</div>} />
+          </Routes>
+        </MemoryRouter>
+      </ThemeProvider>,
+    );
+
+    // The old league's data must not still be on screen while the new league loads.
+    await waitFor(() => expect(screen.queryByText('LeagueOneUser')).not.toBeInTheDocument());
+
+    resolveLeagueTwo([createLeaderboardEntry({ userId: '789', userName: 'LeagueTwoUser', rank: '1', total: 9, weekResults: [] })]);
+    await screen.findByText('LeagueTwoUser');
+  });
+});
+
 describe('LeaderboardPage — week-cell colors', () => {
   beforeEach(() => {
     sessionState.currentLeague = 1;

--- a/Client.React/src/__tests__/seasonRange.test.ts
+++ b/Client.React/src/__tests__/seasonRange.test.ts
@@ -1,0 +1,11 @@
+import { buildDescendingSeasonRange } from '../utils/seasonRange';
+
+describe('buildDescendingSeasonRange', () => {
+  it('returns years from maxSeason down to minSeason, most recent first', () => {
+    expect(buildDescendingSeasonRange(2020, 2023)).toEqual([2023, 2022, 2021, 2020]);
+  });
+
+  it('returns a single-element array when minSeason equals maxSeason', () => {
+    expect(buildDescendingSeasonRange(2023, 2023)).toEqual([2023]);
+  });
+});

--- a/Client.React/src/components/WeekYearSelector.tsx
+++ b/Client.React/src/components/WeekYearSelector.tsx
@@ -3,6 +3,7 @@ import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { useEffect, useMemo } from 'react';
 import { getWeekName } from '../utils/gameHelpers';
+import { buildDescendingSeasonRange } from '../utils/seasonRange';
 
 interface WeekYearSelectorProps {
   season: number;
@@ -93,7 +94,7 @@ export default function WeekYearSelector({
   };
 
   const seasonOptions = useMemo(
-    () => Array.from({ length: maxSeason - minSeason + 1 }, (_, i) => minSeason + i).reverse(),
+    () => buildDescendingSeasonRange(minSeason, maxSeason),
     [minSeason, maxSeason]
   );
 

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { buildDescendingSeasonRange } from '../utils/seasonRange';
 import { Navigate } from 'react-router-dom';
 import {
   alpha,
@@ -8,6 +9,8 @@ import {
   CardContent,
   CircularProgress,
   Grid,
+  MenuItem,
+  Select,
   Table,
   TableBody,
   TableCell,
@@ -41,19 +44,51 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
   const cardRef = useRef<HTMLDivElement>(null);
   const [loading, setLoading] = useState(true);
   const [leaderboard, setLeaderboard] = useState<LeaderboardDto[]>([]);
+  const [season, setSeason] = useState<number | null>(null);
+  // Remember the real current-season ceiling separately from `season` (which the selector
+  // below can move to a past year) — otherwise re-deriving the selector's upper bound from
+  // whatever season is currently being VIEWED would shrink the range after picking a past
+  // year, trapping the viewer in history (same bug class PicksPage's season selector hit).
+  const [maxSeason, setMaxSeason] = useState<number | null>(null);
+
+  // Only the very first fetch FOR THE CURRENTLY SELECTED LEAGUE shows the full-page spinner — a
+  // season switch within the same league keeps the page on screen and just disables the
+  // selector for the moment a fetch is in flight. Scoping this per-league (not a single global
+  // "ever loaded" flag) matters because AppLayout's league-selector chip can change
+  // `currentLeague` while already sitting on this page: without resetting the flag here, that
+  // switch would silently keep the PREVIOUS league's standings on screen (unlabeled as stale)
+  // while the new league's data loaded, with no guard against an out-of-order response
+  // overwriting the right one (/code-review caught this as a real, reachable regression).
+  const hasLoadedOnce = useRef(false);
+  const [refreshing, setRefreshing] = useState(false);
 
   useEffect(() => {
-    const run = async () => {
-      setLoading(true);
-      if (!leaguesLoaded || !currentLeague) { setLoading(false); return; }
-      const seasonYear = await adapter.currentSeasonYear();
+    if (!leaguesLoaded || !currentLeague) { setLoading(false); return; }
+    hasLoadedOnce.current = false;
+    void adapter.currentSeasonYear().then((seasonYear) => {
       if (!seasonYear) { setLoading(false); return; }
-      const data = await getLeaderboard(currentLeague, seasonYear);
+      setSeason(seasonYear);
+      setMaxSeason(seasonYear);
+    });
+  }, [currentLeague, leaguesLoaded, adapter]);
+
+  useEffect(() => {
+    if (!currentLeague || season == null) return;
+    const run = async () => {
+      if (hasLoadedOnce.current) setRefreshing(true); else setLoading(true);
+      const data = await getLeaderboard(currentLeague, season);
       setLeaderboard(data ?? []);
+      hasLoadedOnce.current = true;
       setLoading(false);
+      setRefreshing(false);
     };
     void run();
-  }, [currentLeague, leaguesLoaded, adapter]);
+  }, [currentLeague, season]);
+
+  const seasonOptions = useMemo(() => {
+    if (maxSeason == null) return [];
+    return buildDescendingSeasonRange(adapter.weekSelectorConfig.minSeason, maxSeason);
+  }, [maxSeason, adapter.weekSelectorConfig.minSeason]);
 
   const maxWeek = useMemo(() => {
     if (leaderboard.length === 0) return 0;
@@ -169,6 +204,24 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
           </Button>
         }
       />
+      {season != null && seasonOptions.length > 0 && (
+        // frizat: /code-review flagged that cramming this into PageHeader's title+action row
+        // (already carrying the "Leaderboard" h4 + Share button) risked overflow on the app's
+        // ~390px mobile primary viewport — its own row has no competing width to fight for.
+        <Box sx={{ mb: 2 }}>
+          <Select
+            size="small"
+            value={season}
+            disabled={refreshing}
+            onChange={(e) => setSeason(Number(e.target.value))}
+            sx={{ width: { xs: '100%', sm: 'auto' } }}
+          >
+            {seasonOptions.map((year) => (
+              <MenuItem key={year} value={year}>{year} Season</MenuItem>
+            ))}
+          </Select>
+        </Box>
+      )}
       {myRow && isPreparingShare && (
         // Mounted only while actually capturing a share image — an always-mounted hidden card
         // duplicates the user's name/rank text in the DOM, which broke a real Playwright demo

--- a/Client.React/src/utils/seasonRange.ts
+++ b/Client.React/src/utils/seasonRange.ts
@@ -1,0 +1,6 @@
+/** Descending list of season years from maxSeason down to minSeason, inclusive — the "most
+ * recent first" order every season dropdown in this app (WeekYearSelector, LeaderboardPage)
+ * presents to the user. */
+export function buildDescendingSeasonRange(minSeason: number, maxSeason: number): number[] {
+  return Array.from({ length: maxSeason - minSeason + 1 }, (_, i) => maxSeason - i);
+}


### PR DESCRIPTION
## Summary
- Leaderboard page only ever showed the current season — backend's `GetLeaderboard` already accepted an arbitrary `seasonYear`, so this was purely a frontend gap
- Adds a year dropdown (bounded by `adapter.weekSelectorConfig.minSeason` through the current season), ESPN-style
- Extracted `buildDescendingSeasonRange` as a shared utility (was duplicated inline in `WeekYearSelector`)

## Fixes from /code-review (two passes)
- Selector moved to its own row instead of `PageHeader`'s title+action row, which risked overflow on the app's ~390px mobile primary viewport
- Season switches disable the selector while a fetch is in flight instead of a manual stale-response race guard
- Added missing mock-based Playwright coverage
- A real regression caught in the second pass: the "light refresh after first load" optimization was keyed on any fetch ever completing, not the currently selected league — switching leagues via AppLayout's league-selector chip while on this page left the previous league's stale standings on screen with no staleness guard. Fixed by resetting the loaded-flag whenever `currentLeague` changes.

## Test plan
- [x] TDD throughout — failing tests written first for the selector, the disable-during-fetch behavior, and the league-switch regression; confirmed red then green each time
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm run test -- --run` — 417/417 passing
- [x] `npm run test:e2e -- --project=chromium` — 80/80 passing
- [x] `dotnet test` — 635/635 passing (no backend changes)
- [x] `/code-review` — run twice; all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs