### PR TITLE
fix: Matrix view pick badge — background color is the only win/loss signal now

### DIFF
--- a/Client.React/src/__tests__/UserPicksMatrix.test.tsx
+++ b/Client.React/src/__tests__/UserPicksMatrix.test.tsx
@@ -111,22 +111,50 @@ describe('UserPicksMatrix — Over/Under shown as a bold word, not a small icon'
     expect(container.querySelector('[data-testid="ArrowCircleDownIcon"]')).not.toBeInTheDocument();
   });
 
-  it('renders the OVER/UNDER label in a neutral color, not red, when the game has no result yet', () => {
-    // frizat: /code-review caught that the old icon's color logic (carried into the new text
-    // label) collapsed "no spread data yet" (result === null, a scheduled/in-progress game per
-    // ScoresPage's matrixSpreads) into the same branch as an actual loss — falsely showing a red
-    // "OVER" before the game was even decided. Matches the badge background's own 3-way branch.
-    const pendingPick: NflPickDto[] = [
+  // frizat: the badge already encoded win/loss three different ways at once — the tinted
+  // background, a colored OVER/UNDER label, and a corner check/cancel icon — which read as
+  // cluttered rather than clear (user feedback: "hard to see w/ the check box"). The
+  // background alone now carries the win/loss signal; text stays a single neutral ink color,
+  // same as the team abbreviation, in every case (win, loss, or no result yet).
+  it.each([
+    ['light', 'a winning pick', { team: 'KC', isWinner: true, isOverWinner: true, isUnderWinner: false, spread: -3, over: 45, under: 45 }],
+    ['light', 'a losing pick', { team: 'KC', isWinner: false, isOverWinner: false, isUnderWinner: true, spread: -3, over: 45, under: 45 }],
+    ['light', 'a pick with no result yet', undefined],
+    ['dark', 'a winning pick', { team: 'KC', isWinner: true, isOverWinner: true, isUnderWinner: false, spread: -3, over: 45, under: 45 }],
+    ['dark', 'a losing pick', { team: 'KC', isWinner: false, isOverWinner: false, isUnderWinner: true, spread: -3, over: 45, under: 45 }],
+    ['dark', 'a pick with no result yet', undefined],
+  ] as const)('renders the OVER/UNDER label in the same neutral ink as the team name in %s mode for %s', (mode, _label, spread) => {
+    // frizat: /code-review caught that this only ever rendered in light mode — a future
+    // dark-mode-only color override on just one of the two labels would've silently passed.
+    const pick: NflPickDto[] = [
       { id: 1, userId: 'u1', userName: 'alice', team: 'KC', pick: 'Over', season: 2025, nflWeek: 19, leagueId: 1, dateCreated: '' },
     ];
     render(
-      <ThemeProvider theme={createTheme()}>
-        <UserPicksMatrix users={['alice']} picks={pendingPick} spreads={{}} requiredPicks={1} />
+      <ThemeProvider theme={createTheme({ palette: { mode } })}>
+        <UserPicksMatrix users={['alice']} picks={pick} spreads={spread ? { KC: spread } : {}} requiredPicks={1} />
       </ThemeProvider>,
     );
-    const label = screen.getByText('OVER');
-    expect(label).not.toHaveStyle({ color: 'rgb(211, 47, 47)' }); // MUI error.main
-    expect(label).not.toHaveStyle({ color: 'rgb(46, 125, 50)' }); // MUI success.main
+    const teamLabel = screen.getByText('KC');
+    const ouLabel = screen.getByText('OVER');
+    expect(getComputedStyle(ouLabel).color).toBe(getComputedStyle(teamLabel).color);
+  });
+
+  it('does not render a win/loss check or cancel icon — the badge background alone carries that signal', () => {
+    const picks: NflPickDto[] = [
+      { id: 1, userId: 'u1', userName: 'alice', team: 'KC', pick: 'Over', season: 2025, nflWeek: 19, leagueId: 1, dateCreated: '' },
+    ];
+    const { container } = render(
+      <ThemeProvider theme={createTheme()}>
+        <UserPicksMatrix
+          users={['alice']}
+          picks={picks}
+          spreads={{ KC: { team: 'KC', isWinner: true, isOverWinner: true, isUnderWinner: false, spread: -3, over: 45, under: 45 } }}
+          requiredPicks={1}
+        />
+      </ThemeProvider>,
+    );
+    expect(container.querySelector('[data-testid="CheckCircleIcon"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-testid="CancelIcon"]')).not.toBeInTheDocument();
   });
 });
 

--- a/Client.React/src/components/UserPicksMatrix.tsx
+++ b/Client.React/src/components/UserPicksMatrix.tsx
@@ -8,8 +8,6 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import CancelIcon from '@mui/icons-material/Cancel';
 import type { NflPickDto, SpreadCalculationResponse } from '../types/picks';
 import { stickyColumnSx } from '../utils/tableStyles';
 
@@ -65,36 +63,15 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
         <Typography sx={{ fontSize: pick.team.length > 3 ? 16 : 22, fontWeight: 800, letterSpacing: '0.02em' }}>
           {pick.team}
         </Typography>
-        {/* frizat: a tiny corner arrow icon was easy to miss against the color-coded background
-            and the large team text above it — spell out OVER/UNDER instead, same bold treatment.
-            Match the badge background's 3-way branch (win/loss/no-result-yet) — result is null
-            for a scheduled/in-progress game (ScoresPage's matrixSpreads only populates an entry
-            once a game is final), which must read as neutral, not silently collapse into "loss". */}
+        {/* frizat: the badge used to signal win/loss three ways at once — the tinted background,
+            a colored OVER/UNDER label, and a corner check/cancel icon — reported as cluttered
+            and hard to read. The background alone now carries that signal; this label stays the
+            same neutral ink as the team name above it, in every case, with only weight/size
+            marking it as secondary information (which team > which bet type). */}
         {pick.pick !== 'Spread' && (
-          <Typography
-            sx={{
-              fontSize: 11,
-              fontWeight: 800,
-              letterSpacing: '0.03em',
-              color: result === true ? 'success.main' : result === false ? 'error.main' : 'text.secondary',
-            }}
-          >
+          <Typography sx={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.03em' }}>
             {pick.pick.toUpperCase()}
           </Typography>
-        )}
-        {result === true && (
-          <CheckCircleIcon
-            fontSize="small"
-            color="success"
-            sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'white', borderRadius: '50%' }}
-          />
-        )}
-        {result === false && (
-          <CancelIcon
-            fontSize="small"
-            color="error"
-            sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'white', borderRadius: '50%' }}
-          />
         )}
       </Paper>
     );


### PR DESCRIPTION
## Summary
User feedback: the Matrix view pick badge encoded win/loss three redundant ways at once — a tinted background, a colored OVER/UNDER label, and a corner check/cancel icon. Reported as cluttered and hard to read.

- Background color is now the only win/loss signal
- All text (team abbreviation and OVER/UNDER) stays one neutral ink color, with only size/weight distinguishing primary (team) from secondary (bet type) information

## Accessibility tradeoff (flagged by /code-review, resolved with user)
Color-only win/loss is a real WCAG 1.4.1 concern for red-green colorblindness vs. the previous shape-based icon cue. Surfaced to the user, who confirmed shipping as-is for now — not a priority at this time.

## Test plan
- [x] TDD: failing tests written first, confirmed red then green
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm run test -- --run` — 18/18 in this file, full suite green
- [x] `npm run test:e2e -- --project=chromium` — 79/79 passing
- [x] `dotnet test` — 635/635 passing (no backend changes)
- [x] `/code-review` — 2 findings: accessibility tradeoff (surfaced to user, resolved above) and a test-coverage gap (fixed — the neutral-color test now covers both light and dark mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs