### PR TITLE
docs: explain Invite Player vs Invite Link on the League Portal

### DIFF
--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -486,6 +486,24 @@ describe('LeaguePortalPage — invite link and sent invitations', () => {
     expect(mockedGetLeagueInvitations).toHaveBeenCalledWith(1);
   });
 
+  it('explains the difference between Invite Player and Invite Link so owners pick the right one', async () => {
+    // frizat: a real incident — an owner generated a share link meaning "blast it to my whole
+    // group," a member clicked it, and the owner was confused about what would happen next.
+    // A short always-visible explanation next to the buttons is more likely to be read at the
+    // moment of confusion than a separate help page (mobile-first: no hover-only tooltip).
+    // /code-review caught that an earlier draft of this copy claimed the link joins existing
+    // members instantly — stale relative to LeagueController.JoinViaLink routing an existing
+    // user through the same pending-invite/Accept-Decline mechanism as Invite Player (see
+    // feat/invite-link-uses-membership-banner). The real distinguishing feature is targeting
+    // (one email vs. one shareable link for a whole group) — the accept/decline-vs-register
+    // rule is now identical on both paths, so the copy must say so, not the opposite.
+    renderPage();
+    await screen.findByText('frizat@example.com');
+
+    expect(screen.getByText(/invite player sends a request to one email.*existing members get a request to accept or decline.*new visitors register to join/i)).toBeInTheDocument();
+    expect(screen.getByText(/invite link.*same way.*one shareable link for your whole group/i)).toBeInTheDocument();
+  });
+
   it('shows the active invite link panel with copy and share buttons when a link exists', async () => {
     mockedGetCurrentInviteLink.mockResolvedValue(makeInviteLink());
     renderPage();

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -767,6 +767,22 @@ function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInv
         )}
       </Stack>
 
+      {/* frizat: real incident — an owner generated a share link meaning "blast it to my whole
+          group," a member clicked it, and the owner was confused about what would happen next.
+          Always-visible text, not a hover tooltip, since this is mobile-first and the confusion
+          happens exactly when someone is about to click one of these buttons. Both mechanisms
+          apply the identical accept/decline-vs-register rule (LeagueController.JoinViaLink
+          routes an existing user through the same membershipInviteService.CreateOrReopenAsync
+          as InviteToLeague) — the real difference is targeting: one email vs. one shareable
+          link for a whole group. Don't say the link joins existing members instantly; it
+          doesn't (only a brand-new visitor registering through either path does). */}
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5, maxWidth: 640 }}>
+        Invite Player sends a request to one email — existing members get a request to accept or decline, new visitors register to join.
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3, maxWidth: 640 }}>
+        Invite Link works the same way, but gives you one shareable link for your whole group instead of one email at a time.
+      </Typography>
+
       {inviteLink && (
         <Box sx={{ mb: 3, p: 2, border: 1, borderColor: linkExpired ? 'warning.main' : 'divider', borderRadius: 1, maxWidth: 520 }}>
           <Stack spacing={1}>


### PR DESCRIPTION
## Summary
Real incident this session: an owner generated a share link meaning "blast it to my whole group," a member clicked it, and the owner was confused about what would happen next.

Adds short, always-visible copy next to the Invite Player / Invite Link buttons — not a hover tooltip, since this is mobile-first and the confusion happens exactly when someone is about to click one of these.

## Correction mid-flight
`/code-review` caught that an earlier draft of this copy was factually wrong: it claimed the link joins existing members instantly. Since #258 (`feat/invite-link-uses-membership-banner`), `LeagueController.JoinViaLink` routes an existing user through the same pending-invite/Accept-Decline mechanism as Invite Player — only a brand-new visitor registering through either path joins immediately. The real distinguishing feature is targeting (one email vs. one shareable link for a whole group), not instant-vs-pending. Fixed before merge.

## Test plan
- [x] TDD: test written first, confirmed red then green
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm run test -- --run` — 421/421 passing
- [x] `npm run test:e2e -- --project=chromium` — 80/80 passing
- [x] `dotnet test` — 635/635 passing (no backend changes)
- [x] `/code-review` — 2 findings, both fixed (see above)
- [x] Manually verified live on the local demo stack — copy renders correctly in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs