### PR TITLE
fix: juice settings number input race + frontend-design audit cleanup

### DIFF
--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -180,6 +180,30 @@ describe('LeaguePortalPage (owner, non-admin)', () => {
     expect(screen.getByRole('button', { name: /save/i })).not.toBeDisabled();
   });
 
+  it('lets the owner clear and retype a Tease Pts value without it snapping back mid-edit', async () => {
+    // frizat: real user report — "can't type in #'s here" on desktop, "can't click up or down"
+    // on mobile Chrome. Root cause: value={juiceForm.juice} (a NUMBER) fed straight from
+    // onChange={(e) => onJuiceFormChange('juice', Number(e.target.value))} — every keystroke
+    // immediately re-coerces through Number() and feeds the result back as the controlled
+    // value, so clearing the field to retype, or typing a decimal point, gets silently
+    // overwritten back to a fully-parsed number (typing "1" then "." collapsed to "0" in live
+    // reproduction) before the next character lands. Live-verified against the local demo
+    // stack before writing this test.
+    renderPage();
+    await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+    // The default beforeEach only seeds juice data for CURRENT_SEASON - 1, so the current
+    // season's fields start at the form's zero-value default — irrelevant to this test, which
+    // only cares about the clear/retype behavior, not the starting number.
+    const field = await screen.findByLabelText(/Tease Pts \(Regular Season\)/i);
+    await waitFor(() => expect(field).not.toBeDisabled());
+
+    await userEvent.clear(field);
+    expect(field).toHaveValue(null); // truly empty — not silently reset to 0
+
+    await userEvent.type(field, '17.5');
+    expect(field).toHaveValue(17.5); // decimal point survives the intermediate "17." state
+  });
+
   // frizat: "Juice Settings"/"Weekly Cost" read as gambling jargon to a general audience —
   // renamed to plain language. Locking in the new copy so this doesn't silently regress.
   it('shows the Settings tab with plain-language labels (no gambling jargon)', async () => {

--- a/Client.React/src/__tests__/WeekYearSelector.test.tsx
+++ b/Client.React/src/__tests__/WeekYearSelector.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import WeekYearSelector from '../components/WeekYearSelector';
+import { createAppTheme } from '../app/theme';
 
 const defaultProps = {
   season: 2025,
@@ -42,6 +44,25 @@ describe('WeekYearSelector', () => {
     setup();
     expect(screen.getByRole('button', { name: /previous/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // /style-guide audit — container background/border must be theme-aware,
+  // not hardcoded light-mode literals (rgba(26, 40, 71, ...) is theme.ts's
+  // light-mode primary.main and renders near-invisible in dark mode)
+  // -----------------------------------------------------------------------
+
+  it('uses a dark-mode-appropriate border, not the hardcoded light literal', () => {
+    const darkTheme = createAppTheme('dark');
+    render(
+      <ThemeProvider theme={darkTheme}>
+        <WeekYearSelector {...defaultProps} />
+      </ThemeProvider>,
+    );
+    const container = screen.getByTestId('week-year-selector-container');
+    const style = getComputedStyle(container);
+    expect(style.borderColor).not.toBe('rgba(26, 40, 71, 0.1)');
+    expect(style.borderColor.replace(/\s/g, '')).toBe(darkTheme.palette.divider.replace(/\s/g, ''));
   });
 
   it('disables Previous button at minSeason week 1', () => {

--- a/Client.React/src/__tests__/picks.test.tsx
+++ b/Client.React/src/__tests__/picks.test.tsx
@@ -189,6 +189,20 @@ describe('PicksPage', () => {
     });
   });
 
+  // frizat: /style-guide audit — Submit and Clear were both contained/equal-size, reading as
+  // two equal-strength CTAs when Submit is the primary action and Clear is a rare, lesser one.
+  // Clear also used color="warning" as a small filled button — the exact configuration the
+  // style guide documents as unreadable in both modes for pick-state buttons.
+  it('demotes Clear to an outlined button so Submit reads as the primary action', async () => {
+    await setupDefaults();
+    await renderPage();
+    const submit = screen.getByRole('button', { name: /submit pick/i });
+    const clear = screen.getByRole('button', { name: /clear selected picks/i });
+    expect(submit.className).toMatch(/MuiButton-contained/);
+    expect(clear.className).toMatch(/MuiButton-outlined/);
+    expect(clear.className).not.toMatch(/warning/i);
+  });
+
   it('pick button toggles to picked and back', async () => {
     await setupDefaults();
     await renderPage();

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ScoresPage from '../pages/ScoresPage';
@@ -202,6 +202,65 @@ describe('ScoresPage', () => {
     await renderPage();
     expect(screen.getAllByTestId('ArrowCircleUpIcon').length).toBeGreaterThan(0);
     expect(screen.getAllByTestId('ArrowCircleDownIcon').length).toBeGreaterThan(0);
+  });
+
+  // frizat: /style-guide audit — each pick-result row encoded win/loss three redundant ways at
+  // once: this shield icon (shape AND color both changed), the IconButton's own color, and the
+  // Badge's color. Drop the standalone shield icon; the badge/icon-button pair alone is the
+  // signal now (same "background/color is the only signal" resolution as the Matrix view).
+  it('does not render a redundant win/loss shield icon — the pick badge/button color alone carries it', async () => {
+    const picks = [createPick({ team: 'BUF', userName: 'OtherUser', userId: '456' })];
+    await setupDefaults({ picks, gameStarted: true });
+    await renderPage();
+    expect(screen.queryByTestId('GppGoodIcon')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('GppBadIcon')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('GppMaybeIcon')).not.toBeInTheDocument();
+  });
+
+  // frizat: same redundancy on the O/U row — the up/down arrows were colored success/error on
+  // top of the Badge/IconButton pairs on either side already showing the identical win/loss
+  // state. Arrows now stay a fixed neutral color; the badges are the one signal.
+  it('keeps the Over/Under arrows a neutral color regardless of win/loss — the badges already carry that signal', async () => {
+    // BUF 24, MIA 10 → total 34 < O/U 47.5 → Under wins (see makeScores comment above)
+    await setupDefaults({ week: 1, postSeason: true, gameStarted: true });
+    await renderPage();
+    const upArrow = screen.getAllByTestId('ArrowCircleUpIcon')[0];
+    const downArrow = screen.getAllByTestId('ArrowCircleDownIcon')[0];
+    expect(upArrow).not.toHaveStyle({ color: 'rgb(211, 47, 47)' }); // MUI error.main
+    expect(upArrow).not.toHaveStyle({ color: 'rgb(46, 125, 50)' }); // MUI success.main
+    expect(downArrow).not.toHaveStyle({ color: 'rgb(211, 47, 47)' });
+    expect(downArrow).not.toHaveStyle({ color: 'rgb(46, 125, 50)' });
+  });
+
+  // frizat: /style-guide audit — "Show As Matrix" defaulted to unstyled contained (reads as
+  // primary navy, near-inert next to body text) while "Show Only My Picks" used contained
+  // secondary (the brand orange reserved for real CTAs like Share) — two equal-weight view
+  // filters shouldn't have one wearing the brand accent. Both are the same neutral treatment now.
+  it('gives the Matrix and My-Picks view toggles matching weight, neither wearing the brand-CTA color', async () => {
+    const picks = [createPick({ team: 'BUF' })];
+    await setupDefaults({ picks, gameStarted: true });
+    await renderPage();
+
+    const matrixButton = screen.getByRole('button', { name: /show as matrix/i });
+    const myPicksButton = screen.getByRole('button', { name: /show only my picks/i });
+    expect(matrixButton.className).toMatch(/MuiButton-outlinedInfo/);
+    expect(myPicksButton.className).toMatch(/MuiButton-outlinedInfo/);
+    expect(matrixButton.className).not.toMatch(/Secondary/);
+    expect(myPicksButton.className).not.toMatch(/Secondary/);
+  });
+
+  // /code-review caught that the removed shield icon was the ONLY win/loss signal for a team
+  // nobody in the league picked — the badge/icon-button pair used pickCount === 0 to both hide
+  // the count bubble AND disable the button, and MUI's disabled state flattens `color` to gray
+  // regardless of the success/error prop. Disabled must now track "not decided yet" only, so the
+  // outcome color still shows even with zero picks.
+  it('keeps the pick icon enabled and colored by outcome even when nobody in the league picked that side', async () => {
+    await setupDefaults({ picks: [], gameStarted: true });
+    const { getByTestId } = await renderPage();
+    const badge = getByTestId('badge-BUF-spread');
+    const button = within(badge).getByRole('button');
+    expect(button).not.toBeDisabled();
+    expect(button.className).toMatch(/colorSuccess/);
   });
 
   it('spread badge is info when current user has a pick', async () => {

--- a/Client.React/src/__tests__/useNumericField.test.tsx
+++ b/Client.React/src/__tests__/useNumericField.test.tsx
@@ -1,0 +1,76 @@
+import { act, renderHook } from '@testing-library/react';
+import { useNumericField } from '../utils/useNumericField';
+
+describe('useNumericField', () => {
+  it('reflects the initial value as a string', () => {
+    const { result } = renderHook(() => useNumericField(13, () => {}));
+    expect(result.current.value).toBe('13');
+  });
+
+  it('preserves an incomplete intermediate value without pushing it upward', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useNumericField(1, onChange));
+
+    act(() => result.current.onChange({ target: { value: '-' } } as React.ChangeEvent<HTMLInputElement>));
+
+    expect(result.current.value).toBe('-');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('pushes the parsed number upward once the value is valid', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useNumericField(1, onChange));
+
+    act(() => result.current.onChange({ target: { value: '1.5' } } as React.ChangeEvent<HTMLInputElement>));
+
+    expect(result.current.value).toBe('1.5');
+    expect(onChange).toHaveBeenCalledWith(1.5);
+  });
+
+  it('snaps back to the last valid value on blur after an incomplete edit', () => {
+    const { result } = renderHook(() => useNumericField(7, () => {}));
+
+    act(() => result.current.onChange({ target: { value: '' } } as React.ChangeEvent<HTMLInputElement>));
+    expect(result.current.value).toBe('');
+
+    act(() => result.current.onBlur());
+    expect(result.current.value).toBe('7');
+  });
+
+  it('does not clobber a mid-edit decimal when backspacing produces the same committed number', () => {
+    // /code-review finding: 17.5 -> backspace to "17." parses to 17, which matches the
+    // previously-committed 17.5's new value of 17 once rounded down — the resync effect
+    // must not stomp "17." back to "17" just because the committed number didn't change
+    // in a way distinguishable from an external update.
+    const onChange = vi.fn();
+    const { result, rerender } = renderHook(({ value }) => useNumericField(value, onChange), {
+      initialProps: { value: 17.5 },
+    });
+
+    act(() => result.current.onChange({ target: { value: '17.' } } as React.ChangeEvent<HTMLInputElement>));
+    expect(onChange).toHaveBeenCalledWith(17);
+
+    rerender({ value: 17 });
+    expect(result.current.value).toBe('17.');
+  });
+
+  it('does not push Infinity upward for overflowing/scientific-notation input', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useNumericField(1, onChange));
+
+    act(() => result.current.onChange({ target: { value: '1e400' } } as React.ChangeEvent<HTMLInputElement>));
+
+    expect(result.current.value).toBe('1e400');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('resyncs the displayed value when the parent value prop changes', () => {
+    const { result, rerender } = renderHook(({ value }) => useNumericField(value, () => {}), {
+      initialProps: { value: 5 },
+    });
+    expect(result.current.value).toBe('5');
+
+    rerender({ value: 20 });
+    expect(result.current.value).toBe('20');
+  });
+});

--- a/Client.React/src/components/WeekYearSelector.tsx
+++ b/Client.React/src/components/WeekYearSelector.tsx
@@ -100,15 +100,17 @@ export default function WeekYearSelector({
 
   return (
     <Box
+      data-testid="week-year-selector-container"
       sx={{
         display: 'flex',
         flexDirection: 'column',
         gap: 1.5,
         p: { xs: 1, sm: 2 },
         mb: 3,
-        backgroundColor: 'rgba(26, 40, 71, 0.04)',
+        bgcolor: 'action.hover',
         borderRadius: 2,
-        border: '1px solid rgba(26, 40, 71, 0.1)',
+        border: '1px solid',
+        borderColor: 'divider',
       }}
     >
       {/* Selects row — frizat: flexWrap alone made mobile layout depend on content width: a short

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -40,6 +40,7 @@ import { useToast } from '../services/toast';
 import { isAdmin } from '../utils/auth';
 import { extractApiErrorMessage } from '../utils/apiError';
 import { useShareLink } from '../utils/useShareLink';
+import { useNumericField } from '../utils/useNumericField';
 import {
   getLeagueUserMappings,
   getLeagueJuice,
@@ -948,6 +949,11 @@ function JuiceTab({
   availableSeasons, selectedSeason, onSeasonChange, juiceForm, onJuiceFormChange,
   hasMappingForSeason, locked, onSave, onRollForward, saving, rollingForward,
 }: JuiceTabProps) {
+  const juiceField = useNumericField(juiceForm.juice, (n) => onJuiceFormChange('juice', n));
+  const juiceDivisionalField = useNumericField(juiceForm.juiceDivisional, (n) => onJuiceFormChange('juiceDivisional', n));
+  const juiceConferenceField = useNumericField(juiceForm.juiceConference, (n) => onJuiceFormChange('juiceConference', n));
+  const weeklyCostField = useNumericField(juiceForm.weeklyCost, (n) => onJuiceFormChange('weeklyCost', n));
+
   return (
     <Box>
       <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 3 }}>
@@ -982,32 +988,28 @@ function JuiceTab({
           type="number"
           size="small"
           disabled={locked}
-          value={juiceForm.juice}
-          onChange={(e) => onJuiceFormChange('juice', Number(e.target.value))}
+          {...juiceField}
         />
         <TextField
           label="Tease Pts (Divisional)"
           type="number"
           size="small"
           disabled={locked}
-          value={juiceForm.juiceDivisional}
-          onChange={(e) => onJuiceFormChange('juiceDivisional', Number(e.target.value))}
+          {...juiceDivisionalField}
         />
         <TextField
           label="Tease Pts (Conference)"
           type="number"
           size="small"
           disabled={locked}
-          value={juiceForm.juiceConference}
-          onChange={(e) => onJuiceFormChange('juiceConference', Number(e.target.value))}
+          {...juiceConferenceField}
         />
         <TextField
           label="Cost Per Week ($)"
           type="number"
           size="small"
           disabled={locked}
-          value={juiceForm.weeklyCost}
-          onChange={(e) => onJuiceFormChange('weeklyCost', Number(e.target.value))}
+          {...weeklyCostField}
         />
         <Button variant="contained" onClick={onSave} disabled={saving || locked} sx={{ alignSelf: 'flex-start' }}>
           {saving ? <CircularProgress size={18} /> : 'Save'}

--- a/Client.React/src/pages/PicksPage.tsx
+++ b/Client.React/src/pages/PicksPage.tsx
@@ -226,7 +226,11 @@ export default function PicksPage({ adapter }: PicksPageProps) {
               <Button variant="contained" color="success" disabled={storingPicks || userPicks.size === 0} onClick={handleSubmit}>
                 {storingPicks ? 'Submitting…' : 'Submit Pick(s)'}
               </Button>
-              <Button variant="contained" color="warning" disabled={userPicks.size === 0} onClick={handleClear}>
+              {/* frizat: /style-guide audit — both buttons were equal-weight contained, and
+                  Clear used color="warning" as a small filled button, the exact configuration
+                  the style guide documents as unreadable in both modes for pick-state buttons.
+                  Outlined demotes Clear to secondary, matching its rare, lower-stakes role. */}
+              <Button variant="outlined" disabled={userPicks.size === 0} onClick={handleClear}>
                 Clear Selected Picks
               </Button>
             </Stack>

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -4,9 +4,6 @@ import {
   IconButton, Paper, Stack, Typography,
 } from '@mui/material';
 import PersonIcon from '@mui/icons-material/Person';
-import GppGoodIcon from '@mui/icons-material/GppGood';
-import GppBadIcon from '@mui/icons-material/GppBad';
-import GppMaybeIcon from '@mui/icons-material/GppMaybe';
 import ArrowCircleUpIcon from '@mui/icons-material/ArrowCircleUp';
 import ArrowCircleDownIcon from '@mui/icons-material/ArrowCircleDown';
 import IosShareIcon from '@mui/icons-material/IosShare';
@@ -41,12 +38,6 @@ function teamWins(game: GameView, team: string, pickType: 'Spread' | 'Over' | 'U
   }
   if (game.overWins == null) return null;
   return pickType === 'Over' ? game.overWins : !game.overWins;
-}
-
-function coverIcon(game: GameView, team: string, pickType: 'Spread' | 'Over' | 'Under') {
-  const wins = teamWins(game, team, pickType);
-  if (wins == null) return <GppMaybeIcon color="disabled" />;
-  return wins ? <GppGoodIcon color="success" /> : <GppBadIcon color="error" />;
 }
 
 function badgeColor(game: GameView, team: string, pickType: 'Spread' | 'Over' | 'Under'): 'success' | 'error' | 'info' | 'default' {
@@ -272,13 +263,17 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
       <Grid container spacing={2}>
         {/* Controls row */}
         <Grid size={12} sx={{ display: 'flex', justifyContent: 'flex-end', gap: 2 }}>
+          {/* frizat: /style-guide audit — these are neutral view filters, not brand CTAs, but
+              one defaulted to unstyled contained (reads as inert navy) and the other used
+              contained secondary (the brand orange reserved for real CTAs like Share). Same
+              matching, neutral treatment for both now. */}
           {data?.allPicks.length && data.allPicks.length > 0 && (
-            <Button variant="contained" onClick={() => setShowMatrixView(p => !p)}>
+            <Button variant="outlined" color="info" onClick={() => setShowMatrixView(p => !p)}>
               {showMatrixView ? 'Show Standard View' : 'Show As Matrix'}
             </Button>
           )}
           {!showMatrixView && (
-            <Button variant="contained" color="secondary" onClick={() => setShowOnlyMyPicks(p => !p)}>
+            <Button variant="outlined" color="info" onClick={() => setShowOnlyMyPicks(p => !p)}>
               {showOnlyMyPicks ? 'Show All Games' : 'Show Only My Picks'}
             </Button>
           )}
@@ -341,7 +336,6 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
 
                     {/* Away team pick row */}
                     <Stack direction="row" alignItems="center" sx={{ mt: 2, gap: 1.5, px: 1 }}>
-                      {coverIcon(game, game.awayTeam, 'Spread')}
                       <Typography sx={{ minWidth: 40, fontWeight: 600 }}>{game.awayTeam}</Typography>
                       <Box sx={{ flexGrow: 1 }} />
                       <Typography variant="subtitle1" className="spread-value" sx={{ minWidth: 56, textAlign: 'right' }}>{game.awaySpread != null ? spreadLabel(game.awaySpread) : ''}</Typography>
@@ -353,9 +347,16 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
                         badgeContent={pickCountForTeam(game.id, game.awayTeam, 'Spread')}
                         invisible={(!isFinal && !isLive) || pickCountForTeam(game.id, game.awayTeam, 'Spread') === 0}
                       >
+                        {/* frizat: /code-review caught that gating `disabled` on pickCount === 0 (in
+                            addition to not-decided-yet) flattens this icon's color to MUI's disabled
+                            gray via the `disabled` prop, which erases the win/loss signal for a team
+                            literally nobody in the league picked — the one case the removed shield
+                            icon used to cover on its own, independent of picks. Disabled now tracks
+                            only "not decided yet"; `invisible` above still hides the pick-count bubble
+                            when nobody picked, but the button itself stays colored by outcome. */}
                         <IconButton
                           color={(isFinal || isLive) ? (hc === false ? 'success' : hc === true ? 'error' : 'inherit') : 'inherit'}
-                          disabled={(!isFinal && !isLive) || pickCountForTeam(game.id, game.awayTeam, 'Spread') === 0}
+                          disabled={!isFinal && !isLive}
                           onClick={() => showDialog(game, game.awayTeam, 'Spread')}
                           size="small"
                         >
@@ -366,7 +367,6 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
 
                     {/* Home team pick row */}
                     <Stack direction="row" alignItems="center" sx={{ mt: 1.5, gap: 1.5, px: 1 }}>
-                      {coverIcon(game, game.homeTeam, 'Spread')}
                       <Typography sx={{ minWidth: 40, fontWeight: 600 }}>{game.homeTeam}</Typography>
                       <Box sx={{ flexGrow: 1 }} />
                       <Typography variant="subtitle1" className="spread-value" sx={{ minWidth: 56, textAlign: 'right' }}>{game.homeSpread != null ? spreadLabel(game.homeSpread) : ''}</Typography>
@@ -380,7 +380,7 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
                       >
                         <IconButton
                           color={(isFinal || isLive) ? (hc === true ? 'success' : hc === false ? 'error' : 'inherit') : 'inherit'}
-                          disabled={(!isFinal && !isLive) || pickCountForTeam(game.id, game.homeTeam, 'Spread') === 0}
+                          disabled={!isFinal && !isLive}
                           onClick={() => showDialog(game, game.homeTeam, 'Spread')}
                           size="small"
                         >
@@ -397,20 +397,24 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
                           invisible={(!isFinal && !isLive) || pickCountForTeam(game.id, game.homeTeam, 'Over') === 0}>
                           <IconButton size="small"
                             color={(isFinal || isLive) ? (ov ? 'success' : ov === false ? 'error' : 'inherit') : 'inherit'}
-                            disabled={(!isFinal && !isLive) || pickCountForTeam(game.id, game.homeTeam, 'Over') === 0}
+                            disabled={!isFinal && !isLive}
                             onClick={() => showDialog(game, game.homeTeam, 'Over')}>
                             <PersonIcon />
                           </IconButton>
                         </Badge>
-                        <ArrowCircleUpIcon sx={{ color: (isFinal || isLive) ? (ov ? 'success.main' : 'error.main') : 'text.secondary', flexShrink: 0 }} />
+                        {/* frizat: /style-guide audit — these were color-coded success/error on top of the
+                            Badge/IconButton pairs on either side already showing the identical win/loss
+                            state (same redundant-signal issue as the shield icon this page dropped
+                            elsewhere). The arrows are just Over/Under labels now; the badges are the signal. */}
+                        <ArrowCircleUpIcon sx={{ color: 'text.secondary', flexShrink: 0 }} />
                         <Typography variant="subtitle1" sx={{ minWidth: 36, textAlign: 'center' }}>{game.overUnder}</Typography>
-                        <ArrowCircleDownIcon sx={{ color: (isFinal || isLive) ? (!ov ? 'success.main' : 'error.main') : 'text.secondary', flexShrink: 0 }} />
+                        <ArrowCircleDownIcon sx={{ color: 'text.secondary', flexShrink: 0 }} />
                         <Badge data-testid={`badge-${game.homeTeam}-under`} color={didUserPick(game.id, game.homeTeam, 'Under') ? 'info' : badgeColor(game, game.homeTeam, 'Under')} overlap="circular"
                           badgeContent={pickCountForTeam(game.id, game.homeTeam, 'Under')}
                           invisible={(!isFinal && !isLive) || pickCountForTeam(game.id, game.homeTeam, 'Under') === 0}>
                           <IconButton size="small"
                             color={(isFinal || isLive) ? (!ov ? 'success' : ov === true ? 'error' : 'inherit') : 'inherit'}
-                            disabled={(!isFinal && !isLive) || pickCountForTeam(game.id, game.homeTeam, 'Under') === 0}
+                            disabled={!isFinal && !isLive}
                             onClick={() => showDialog(game, game.homeTeam, 'Under')}>
                             <PersonIcon />
                           </IconButton>

--- a/Client.React/src/utils/useNumericField.ts
+++ b/Client.React/src/utils/useNumericField.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef, useState, type ChangeEvent } from 'react';
+
+// Buffers a numeric <TextField>'s displayed value as a raw string so mid-edit states
+// (empty, "-", "17.") aren't stomped back to a parsed number on every keystroke. Only
+// pushes a value upward once it actually parses to a finite number; resyncs from `value`
+// on a genuinely external change (not one this hook itself just committed) and on blur.
+export function useNumericField(value: number, onChange: (n: number) => void) {
+  const [raw, setRaw] = useState(String(value));
+  const lastCommitted = useRef(value);
+  useEffect(() => {
+    // Skip if `value` only changed because our own onChange call just pushed it —
+    // otherwise a mid-edit string that already parses to the new value (e.g. "17."
+    // while committing 17) gets its trailing characters stomped on the very next render.
+    if (value === lastCommitted.current) return;
+    lastCommitted.current = value;
+    setRaw(String(value));
+  }, [value]);
+  return {
+    value: raw,
+    onChange: (e: ChangeEvent<HTMLInputElement>) => {
+      const str = e.target.value;
+      setRaw(str);
+      const parsed = Number(str);
+      if (str.trim() !== '' && Number.isFinite(parsed)) {
+        lastCommitted.current = parsed;
+        onChange(parsed);
+      }
+    },
+    // Leaving the field empty or mid-typed ("-", "17.") snaps back to the last valid number
+    // once the user clicks away, rather than silently saving a value that doesn't match what's
+    // displayed.
+    onBlur: () => setRaw(String(value)),
+  };
+}


### PR DESCRIPTION
## Summary
- Fixes a controlled-input race in the League Portal's Juice/Cost settings (Tease Pts Regular/Divisional/Conference, Cost Per Week): typing a decimal, clearing the field, or backspacing into a decimal got silently stomped back to a parsed number mid-edit. Reported live as "can't type in #'s" / "can't click up or down on mobile" on `/league/manage`, reproduced in-browser against the demo stack before fixing. `useNumericField` (`src/utils/useNumericField.ts`) buffers the field's raw display string separately from the last-committed number.
- Bundles 4 findings from a `/style-guide` frontend-design audit (subagent review) requested in the same work session:
  - `ScoresPage`: drop the redundant win/loss shield icon — the pick badge/icon-button color already carries that signal; neutral O/U arrow color for the same reason; matching outlined/info weight for the Matrix/My-Picks view toggles (previously one was unstyled contained, the other wore the brand-CTA orange)
  - `PicksPage`: demote Clear to outlined so Submit reads as the primary action
  - `WeekYearSelector`: replace hardcoded `rgba(26, 40, 71, ...)` literals (light-mode-only, near-invisible in dark mode) with theme-aware `sx` tokens (`bgcolor: 'action.hover'`, `borderColor: 'divider'`)
- A 5th audit finding (GameCard's locked-pick checkmark) was evaluated and **deliberately skipped** — an existing comment there explains the checkmark is intentional, since opacity-only dimming isn't a clear enough signal on its own for a locked pick.
- `/simplify` + `/code-review` were run on the full diff; both surfaced real findings that were fixed before this PR, including: a resync-effect bug in `useNumericField` that could still clobber a mid-edit decimal on backspace, a missing `Number.isFinite` guard (`Infinity` could slip through), and a `ScoresPage` regression where MUI's `disabled` state was flattening the win/loss icon color to gray for any team nobody in the league picked (the case the removed shield icon used to cover independently of picks).

## Test plan
- [x] `dotnet test` — 635 passed (backend unaffected, sanity check)
- [x] `npm run test -- --run` — 48 files / 435 tests passed
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:e2e -- --project=chromium` — 80 passed
- [x] Live-reproduced the original number-input bug against the local demo stack before fixing, then confirmed the fix in-browser
- [x] `/simplify` (4 parallel review agents: reuse, simplification, efficiency, altitude) — findings applied
- [x] `/code-review` — findings applied (see summary above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs