### PR TITLE
fix: enforce whole numbers on Juice/Cost settings fields

### DIFF
--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -185,9 +185,8 @@ describe('LeaguePortalPage (owner, non-admin)', () => {
     // on mobile Chrome. Root cause: value={juiceForm.juice} (a NUMBER) fed straight from
     // onChange={(e) => onJuiceFormChange('juice', Number(e.target.value))} — every keystroke
     // immediately re-coerces through Number() and feeds the result back as the controlled
-    // value, so clearing the field to retype, or typing a decimal point, gets silently
-    // overwritten back to a fully-parsed number (typing "1" then "." collapsed to "0" in live
-    // reproduction) before the next character lands. Live-verified against the local demo
+    // value, so clearing the field to retype gets silently overwritten back to a fully-parsed
+    // number (e.g. "0") before the next character lands. Live-verified against the local demo
     // stack before writing this test.
     renderPage();
     await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
@@ -200,8 +199,22 @@ describe('LeaguePortalPage (owner, non-admin)', () => {
     await userEvent.clear(field);
     expect(field).toHaveValue(null); // truly empty — not silently reset to 0
 
+    await userEvent.type(field, '175');
+    expect(field).toHaveValue(175);
+  });
+
+  // frizat: the backend's Juice DTO is `int` (Shared/Models/Data/Dtos/LeagueCreateDto.cs) —
+  // a decimal typed here used to display fine but 400 silently on save. Strip the decimal
+  // point as it's typed instead of catching the mismatch only after a failed save.
+  it('strips a typed decimal point in Tease Pts instead of accepting it, since the field is whole-number only', async () => {
+    renderPage();
+    await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+    const field = await screen.findByLabelText(/Tease Pts \(Regular Season\)/i);
+    await waitFor(() => expect(field).not.toBeDisabled());
+
+    await userEvent.clear(field);
     await userEvent.type(field, '17.5');
-    expect(field).toHaveValue(17.5); // decimal point survives the intermediate "17." state
+    expect(field).toHaveValue(175);
   });
 
   // frizat: "Juice Settings"/"Weekly Cost" read as gambling jargon to a general audience —

--- a/Client.React/src/__tests__/useNumericField.test.tsx
+++ b/Client.React/src/__tests__/useNumericField.test.tsx
@@ -73,4 +73,40 @@ describe('useNumericField', () => {
     rerender({ value: 20 });
     expect(result.current.value).toBe('20');
   });
+
+  describe('integerOnly', () => {
+    // The backend's Juice/Cost DTOs are all `int` — a decimal typed into these fields
+    // previously displayed fine but 400'd silently on save. Stripping the decimal point
+    // as it's typed keeps the field's own contract (whole numbers) instead of catching
+    // the mismatch only after a failed save.
+    it('strips a typed decimal point instead of accepting it', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() => useNumericField(1, onChange, { integerOnly: true }));
+
+      act(() => result.current.onChange({ target: { value: '1.' } } as React.ChangeEvent<HTMLInputElement>));
+      expect(result.current.value).toBe('1');
+
+      act(() => result.current.onChange({ target: { value: '1.5' } } as React.ChangeEvent<HTMLInputElement>));
+      expect(result.current.value).toBe('15');
+      expect(onChange).toHaveBeenLastCalledWith(15);
+    });
+
+    it('still allows a bare "-" as a mid-edit state without pushing a value upward', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() => useNumericField(3, onChange, { integerOnly: true }));
+
+      act(() => result.current.onChange({ target: { value: '-' } } as React.ChangeEvent<HTMLInputElement>));
+      expect(result.current.value).toBe('-');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('does not strip the decimal point when integerOnly is not set', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() => useNumericField(1, onChange));
+
+      act(() => result.current.onChange({ target: { value: '1.5' } } as React.ChangeEvent<HTMLInputElement>));
+      expect(result.current.value).toBe('1.5');
+      expect(onChange).toHaveBeenCalledWith(1.5);
+    });
+  });
 });

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -965,10 +965,13 @@ function JuiceTab({
   availableSeasons, selectedSeason, onSeasonChange, juiceForm, onJuiceFormChange,
   hasMappingForSeason, locked, onSave, onRollForward, saving, rollingForward,
 }: JuiceTabProps) {
-  const juiceField = useNumericField(juiceForm.juice, (n) => onJuiceFormChange('juice', n));
-  const juiceDivisionalField = useNumericField(juiceForm.juiceDivisional, (n) => onJuiceFormChange('juiceDivisional', n));
-  const juiceConferenceField = useNumericField(juiceForm.juiceConference, (n) => onJuiceFormChange('juiceConference', n));
-  const weeklyCostField = useNumericField(juiceForm.weeklyCost, (n) => onJuiceFormChange('weeklyCost', n));
+  // All 4 fields are backend `int` DTOs (Shared/Models/Data/Dtos/LeagueCreateDto.cs) — teaser
+  // points and weekly cost are always whole numbers in this domain, so integerOnly strips a
+  // typed decimal point instead of letting it through to a save that 400s.
+  const juiceField = useNumericField(juiceForm.juice, (n) => onJuiceFormChange('juice', n), { integerOnly: true });
+  const juiceDivisionalField = useNumericField(juiceForm.juiceDivisional, (n) => onJuiceFormChange('juiceDivisional', n), { integerOnly: true });
+  const juiceConferenceField = useNumericField(juiceForm.juiceConference, (n) => onJuiceFormChange('juiceConference', n), { integerOnly: true });
+  const weeklyCostField = useNumericField(juiceForm.weeklyCost, (n) => onJuiceFormChange('weeklyCost', n), { integerOnly: true });
 
   return (
     <Box>
@@ -1004,6 +1007,7 @@ function JuiceTab({
           type="number"
           size="small"
           disabled={locked}
+          slotProps={{ htmlInput: { inputMode: 'numeric' } }}
           {...juiceField}
         />
         <TextField
@@ -1011,6 +1015,7 @@ function JuiceTab({
           type="number"
           size="small"
           disabled={locked}
+          slotProps={{ htmlInput: { inputMode: 'numeric' } }}
           {...juiceDivisionalField}
         />
         <TextField
@@ -1018,6 +1023,7 @@ function JuiceTab({
           type="number"
           size="small"
           disabled={locked}
+          slotProps={{ htmlInput: { inputMode: 'numeric' } }}
           {...juiceConferenceField}
         />
         <TextField
@@ -1025,6 +1031,7 @@ function JuiceTab({
           type="number"
           size="small"
           disabled={locked}
+          slotProps={{ htmlInput: { inputMode: 'numeric' } }}
           {...weeklyCostField}
         />
         <Button variant="contained" onClick={onSave} disabled={saving || locked} sx={{ alignSelf: 'flex-start' }}>

--- a/Client.React/src/utils/useNumericField.ts
+++ b/Client.React/src/utils/useNumericField.ts
@@ -1,10 +1,18 @@
 import { useEffect, useRef, useState, type ChangeEvent } from 'react';
 
+interface UseNumericFieldOptions {
+  // Strips a typed decimal point instead of accepting it — for fields whose backend DTO is
+  // an `int` (e.g. Juice/Cost settings), where a decimal value would otherwise display fine
+  // but 400 silently on save.
+  integerOnly?: boolean;
+}
+
 // Buffers a numeric <TextField>'s displayed value as a raw string so mid-edit states
 // (empty, "-", "17.") aren't stomped back to a parsed number on every keystroke. Only
 // pushes a value upward once it actually parses to a finite number; resyncs from `value`
 // on a genuinely external change (not one this hook itself just committed) and on blur.
-export function useNumericField(value: number, onChange: (n: number) => void) {
+export function useNumericField(value: number, onChange: (n: number) => void, options?: UseNumericFieldOptions) {
+  const integerOnly = options?.integerOnly ?? false;
   const [raw, setRaw] = useState(String(value));
   const lastCommitted = useRef(value);
   useEffect(() => {
@@ -18,10 +26,11 @@ export function useNumericField(value: number, onChange: (n: number) => void) {
   return {
     value: raw,
     onChange: (e: ChangeEvent<HTMLInputElement>) => {
-      const str = e.target.value;
+      const typed = e.target.value;
+      const str = integerOnly ? (typed.startsWith('-') ? '-' : '') + typed.replace(/\D/g, '') : typed;
       setRaw(str);
       const parsed = Number(str);
-      if (str.trim() !== '' && Number.isFinite(parsed)) {
+      if (str.trim() !== '' && str !== '-' && Number.isFinite(parsed)) {
         lastCommitted.current = parsed;
         onChange(parsed);
       }


### PR DESCRIPTION
## Summary
- Follow-up to #262. Live QA on `dev.ivleague.xyz` after that PR surfaced that the backend's `LeagueJuiceUpdateDto` (`Juice`, `JuiceDivisional`, `JuiceConference`, `WeeklyCost`) is all `int` — typing a decimal into any of these 4 fields displayed fine but 400'd on save (with a generic "Failed to save juice settings" error toast, not a silent failure, but with no indication *why* it failed).
- Since teaser points and weekly cost are always whole numbers in this domain, `useNumericField` (`src/utils/useNumericField.ts`) gets a new `integerOnly` option that strips a typed decimal point as it's entered, instead of only catching the mismatch after a failed save.
- Also adds `inputMode="numeric"` to the 4 TextFields for a better mobile numeric keypad — more directly addresses the "can't type on mobile Chrome" half of the original bug report than the base race-condition fix alone did.

## Test plan
- [x] `npm run test -- --run` — 48 files / 439 tests passed
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:e2e -- --project=chromium` — 80 passed
- [x] `/simplify` — one readability nit applied (regex simplified); no blocking findings
- [x] Live-verified on `dev.ivleague.xyz` before this fix: cleared/retyped a decimal in Cost Per Week, confirmed the value now displays correctly but the save 400s — this PR closes that gap
- [x] Updated the pre-existing decimal-preservation test in `LeaguePortalPage.test.tsx` to match the new whole-number-only behavior (it previously asserted the now-intentionally-wrong expectation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs