### PR TITLE
Promote dev to main — PRs #257-#263

### DIFF
--- a/Client.React/e2e/leaderboard.spec.ts
+++ b/Client.React/e2e/leaderboard.spec.ts
@@ -70,6 +70,31 @@ test.describe('Leaderboard page (authenticated)', () => {
     await expect(page.getByText('Standings')).not.toBeVisible();
   });
 
+  test('season selector defaults to the current season, and switching seasons re-fetches standings for that year', async ({ page }) => {
+    await gotoLeaderboard(page, sampleLeaderboard);
+    await expect(page.getByText('2024 Season')).toBeVisible({ timeout: 5000 }); // TEST_SEASON in e2e/helpers/routes.ts
+
+    // Registered after the default mock (from setupRoutes, via gotoLeaderboard/mockAuth) so it
+    // takes over for any leaderboard request from here on — proves the season change actually
+    // fires a new request for the newly-selected year, not just a client-side re-render.
+    const requestedSeasons: string[] = [];
+    await page.route(/\/api\/leaderboard\/\d+\/leaderboard\/\d+/, (route) => {
+      requestedSeasons.push(new URL(route.request().url()).pathname.split('/').pop()!);
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(sampleLeaderboard) });
+    });
+
+    // Other combobox-role selectors (e.g. Picks' week/season-type selector) can linger in the
+    // DOM after the client-side nav gotoLeaderboard does — target this one by its visible text.
+    await page.getByText('2024 Season').click();
+    await page.getByRole('option', { name: '2022 Season' }).click();
+
+    await expect(page.getByRole('combobox').filter({ hasText: '2022 Season' })).toBeVisible({ timeout: 5000 });
+    // Not asserting the exact call list — an incidental extra same-season refetch is possible
+    // depending on render timing and isn't what this test is about — just that switching to
+    // 2022 actually fires a real request for that year, not just a client-side re-render.
+    expect(requestedSeasons.at(-1)).toBe('2022');
+  });
+
   test('Share button renders the standings card and shares it (falls back to download when the browser cannot share files)', async ({ page }) => {
     // Force the download-fallback branch deterministically, rather than relying on whatever
     // Web Share API support this Chromium build happens to have.

--- a/Client.React/src/__tests__/JoinLeaguePage.test.tsx
+++ b/Client.React/src/__tests__/JoinLeaguePage.test.tsx
@@ -18,6 +18,7 @@ vi.mock('../services/auth', () => ({ useAuth: () => authState }));
 
 const sessionMock = {
   reloadLeagues: vi.fn().mockResolvedValue(undefined),
+  refreshPendingInvites: vi.fn().mockResolvedValue(undefined),
   availableLeagues: [] as { leagueId: number }[],
 };
 vi.mock('../services/session', () => ({ useSession: () => sessionMock }));
@@ -43,6 +44,7 @@ describe('JoinLeaguePage', () => {
   beforeEach(() => {
     navigateMock.mockReset();
     sessionMock.reloadLeagues.mockResolvedValue(undefined);
+    sessionMock.refreshPendingInvites.mockReset().mockResolvedValue(undefined);
     sessionMock.availableLeagues = [];
     authState.user = null;
   });
@@ -111,7 +113,11 @@ describe('JoinLeaguePage', () => {
     expect(screen.getByRole('button', { name: /go to dashboard/i })).toBeInTheDocument();
   });
 
-  it('calls joinViaLink and navigates to dashboard on success', async () => {
+  it('calls joinViaLink, refreshes pending invites (not leagues), and navigates to dashboard on success', async () => {
+    // frizat: joinViaLink now creates a pending membership invite rather than joining directly
+    // (see LeagueController.JoinViaLink) — the user isn't a league member yet after this call,
+    // so refreshing leagues would be a no-op; refreshing pending invites is what makes
+    // PendingInviteBanner show up immediately on the dashboard with Accept/Decline.
     vi.mocked(validateInviteLink).mockResolvedValue({
       token: 'tok123',
       leagueId: 1,
@@ -124,6 +130,10 @@ describe('JoinLeaguePage', () => {
     await waitFor(() => screen.getByRole('button', { name: /join/i }));
     await userEvent.click(screen.getByRole('button', { name: /join/i }));
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/dashboard'));
-    expect(sessionMock.reloadLeagues).toHaveBeenCalled();
+    expect(sessionMock.refreshPendingInvites).toHaveBeenCalled();
+    // frizat: /code-review caught that this test's title promised "not leagues" without
+    // actually asserting it — a regression re-adding reloadLeagues() to the success path
+    // would have passed silently.
+    expect(sessionMock.reloadLeagues).not.toHaveBeenCalled();
   });
 });

--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -185,9 +185,8 @@ describe('LeaguePortalPage (owner, non-admin)', () => {
     // on mobile Chrome. Root cause: value={juiceForm.juice} (a NUMBER) fed straight from
     // onChange={(e) => onJuiceFormChange('juice', Number(e.target.value))} — every keystroke
     // immediately re-coerces through Number() and feeds the result back as the controlled
-    // value, so clearing the field to retype, or typing a decimal point, gets silently
-    // overwritten back to a fully-parsed number (typing "1" then "." collapsed to "0" in live
-    // reproduction) before the next character lands. Live-verified against the local demo
+    // value, so clearing the field to retype gets silently overwritten back to a fully-parsed
+    // number (e.g. "0") before the next character lands. Live-verified against the local demo
     // stack before writing this test.
     renderPage();
     await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
@@ -200,8 +199,22 @@ describe('LeaguePortalPage (owner, non-admin)', () => {
     await userEvent.clear(field);
     expect(field).toHaveValue(null); // truly empty — not silently reset to 0
 
+    await userEvent.type(field, '175');
+    expect(field).toHaveValue(175);
+  });
+
+  // frizat: the backend's Juice DTO is `int` (Shared/Models/Data/Dtos/LeagueCreateDto.cs) —
+  // a decimal typed here used to display fine but 400 silently on save. Strip the decimal
+  // point as it's typed instead of catching the mismatch only after a failed save.
+  it('strips a typed decimal point in Tease Pts instead of accepting it, since the field is whole-number only', async () => {
+    renderPage();
+    await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+    const field = await screen.findByLabelText(/Tease Pts \(Regular Season\)/i);
+    await waitFor(() => expect(field).not.toBeDisabled());
+
+    await userEvent.clear(field);
     await userEvent.type(field, '17.5');
-    expect(field).toHaveValue(17.5); // decimal point survives the intermediate "17." state
+    expect(field).toHaveValue(175);
   });
 
   // frizat: "Juice Settings"/"Weekly Cost" read as gambling jargon to a general audience —

--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -180,6 +180,30 @@ describe('LeaguePortalPage (owner, non-admin)', () => {
     expect(screen.getByRole('button', { name: /save/i })).not.toBeDisabled();
   });
 
+  it('lets the owner clear and retype a Tease Pts value without it snapping back mid-edit', async () => {
+    // frizat: real user report — "can't type in #'s here" on desktop, "can't click up or down"
+    // on mobile Chrome. Root cause: value={juiceForm.juice} (a NUMBER) fed straight from
+    // onChange={(e) => onJuiceFormChange('juice', Number(e.target.value))} — every keystroke
+    // immediately re-coerces through Number() and feeds the result back as the controlled
+    // value, so clearing the field to retype, or typing a decimal point, gets silently
+    // overwritten back to a fully-parsed number (typing "1" then "." collapsed to "0" in live
+    // reproduction) before the next character lands. Live-verified against the local demo
+    // stack before writing this test.
+    renderPage();
+    await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+    // The default beforeEach only seeds juice data for CURRENT_SEASON - 1, so the current
+    // season's fields start at the form's zero-value default — irrelevant to this test, which
+    // only cares about the clear/retype behavior, not the starting number.
+    const field = await screen.findByLabelText(/Tease Pts \(Regular Season\)/i);
+    await waitFor(() => expect(field).not.toBeDisabled());
+
+    await userEvent.clear(field);
+    expect(field).toHaveValue(null); // truly empty — not silently reset to 0
+
+    await userEvent.type(field, '17.5');
+    expect(field).toHaveValue(17.5); // decimal point survives the intermediate "17." state
+  });
+
   // frizat: "Juice Settings"/"Weekly Cost" read as gambling jargon to a general audience —
   // renamed to plain language. Locking in the new copy so this doesn't silently regress.
   it('shows the Settings tab with plain-language labels (no gambling jargon)', async () => {

--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -486,6 +486,24 @@ describe('LeaguePortalPage — invite link and sent invitations', () => {
     expect(mockedGetLeagueInvitations).toHaveBeenCalledWith(1);
   });
 
+  it('explains the difference between Invite Player and Invite Link so owners pick the right one', async () => {
+    // frizat: a real incident — an owner generated a share link meaning "blast it to my whole
+    // group," a member clicked it, and the owner was confused about what would happen next.
+    // A short always-visible explanation next to the buttons is more likely to be read at the
+    // moment of confusion than a separate help page (mobile-first: no hover-only tooltip).
+    // /code-review caught that an earlier draft of this copy claimed the link joins existing
+    // members instantly — stale relative to LeagueController.JoinViaLink routing an existing
+    // user through the same pending-invite/Accept-Decline mechanism as Invite Player (see
+    // feat/invite-link-uses-membership-banner). The real distinguishing feature is targeting
+    // (one email vs. one shareable link for a whole group) — the accept/decline-vs-register
+    // rule is now identical on both paths, so the copy must say so, not the opposite.
+    renderPage();
+    await screen.findByText('frizat@example.com');
+
+    expect(screen.getByText(/invite player sends a request to one email.*existing members get a request to accept or decline.*new visitors register to join/i)).toBeInTheDocument();
+    expect(screen.getByText(/invite link.*same way.*one shareable link for your whole group/i)).toBeInTheDocument();
+  });
+
   it('shows the active invite link panel with copy and share buttons when a link exists', async () => {
     mockedGetCurrentInviteLink.mockResolvedValue(makeInviteLink());
     renderPage();

--- a/Client.React/src/__tests__/UserPicksMatrix.test.tsx
+++ b/Client.React/src/__tests__/UserPicksMatrix.test.tsx
@@ -111,22 +111,50 @@ describe('UserPicksMatrix — Over/Under shown as a bold word, not a small icon'
     expect(container.querySelector('[data-testid="ArrowCircleDownIcon"]')).not.toBeInTheDocument();
   });
 
-  it('renders the OVER/UNDER label in a neutral color, not red, when the game has no result yet', () => {
-    // frizat: /code-review caught that the old icon's color logic (carried into the new text
-    // label) collapsed "no spread data yet" (result === null, a scheduled/in-progress game per
-    // ScoresPage's matrixSpreads) into the same branch as an actual loss — falsely showing a red
-    // "OVER" before the game was even decided. Matches the badge background's own 3-way branch.
-    const pendingPick: NflPickDto[] = [
+  // frizat: the badge already encoded win/loss three different ways at once — the tinted
+  // background, a colored OVER/UNDER label, and a corner check/cancel icon — which read as
+  // cluttered rather than clear (user feedback: "hard to see w/ the check box"). The
+  // background alone now carries the win/loss signal; text stays a single neutral ink color,
+  // same as the team abbreviation, in every case (win, loss, or no result yet).
+  it.each([
+    ['light', 'a winning pick', { team: 'KC', isWinner: true, isOverWinner: true, isUnderWinner: false, spread: -3, over: 45, under: 45 }],
+    ['light', 'a losing pick', { team: 'KC', isWinner: false, isOverWinner: false, isUnderWinner: true, spread: -3, over: 45, under: 45 }],
+    ['light', 'a pick with no result yet', undefined],
+    ['dark', 'a winning pick', { team: 'KC', isWinner: true, isOverWinner: true, isUnderWinner: false, spread: -3, over: 45, under: 45 }],
+    ['dark', 'a losing pick', { team: 'KC', isWinner: false, isOverWinner: false, isUnderWinner: true, spread: -3, over: 45, under: 45 }],
+    ['dark', 'a pick with no result yet', undefined],
+  ] as const)('renders the OVER/UNDER label in the same neutral ink as the team name in %s mode for %s', (mode, _label, spread) => {
+    // frizat: /code-review caught that this only ever rendered in light mode — a future
+    // dark-mode-only color override on just one of the two labels would've silently passed.
+    const pick: NflPickDto[] = [
       { id: 1, userId: 'u1', userName: 'alice', team: 'KC', pick: 'Over', season: 2025, nflWeek: 19, leagueId: 1, dateCreated: '' },
     ];
     render(
-      <ThemeProvider theme={createTheme()}>
-        <UserPicksMatrix users={['alice']} picks={pendingPick} spreads={{}} requiredPicks={1} />
+      <ThemeProvider theme={createTheme({ palette: { mode } })}>
+        <UserPicksMatrix users={['alice']} picks={pick} spreads={spread ? { KC: spread } : {}} requiredPicks={1} />
       </ThemeProvider>,
     );
-    const label = screen.getByText('OVER');
-    expect(label).not.toHaveStyle({ color: 'rgb(211, 47, 47)' }); // MUI error.main
-    expect(label).not.toHaveStyle({ color: 'rgb(46, 125, 50)' }); // MUI success.main
+    const teamLabel = screen.getByText('KC');
+    const ouLabel = screen.getByText('OVER');
+    expect(getComputedStyle(ouLabel).color).toBe(getComputedStyle(teamLabel).color);
+  });
+
+  it('does not render a win/loss check or cancel icon — the badge background alone carries that signal', () => {
+    const picks: NflPickDto[] = [
+      { id: 1, userId: 'u1', userName: 'alice', team: 'KC', pick: 'Over', season: 2025, nflWeek: 19, leagueId: 1, dateCreated: '' },
+    ];
+    const { container } = render(
+      <ThemeProvider theme={createTheme()}>
+        <UserPicksMatrix
+          users={['alice']}
+          picks={picks}
+          spreads={{ KC: { team: 'KC', isWinner: true, isOverWinner: true, isUnderWinner: false, spread: -3, over: 45, under: 45 } }}
+          requiredPicks={1}
+        />
+      </ThemeProvider>,
+    );
+    expect(container.querySelector('[data-testid="CheckCircleIcon"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-testid="CancelIcon"]')).not.toBeInTheDocument();
   });
 });
 

--- a/Client.React/src/__tests__/UserPicksMatrix.test.tsx
+++ b/Client.React/src/__tests__/UserPicksMatrix.test.tsx
@@ -64,6 +64,72 @@ describe('UserPicksMatrix — text-only badges (no team logo)', () => {
   });
 });
 
+describe('UserPicksMatrix — Over/Under shown as a bold word, not a small icon', () => {
+  // frizat: a tiny corner arrow icon competing with the win/loss-colored badge background and
+  // the large team text was easy to miss — spell out OVER/UNDER instead, same size treatment
+  // as the team abbreviation label.
+  it('shows the word OVER for an Over pick', () => {
+    const overPick: NflPickDto[] = [
+      { id: 1, userId: 'u1', userName: 'alice', team: 'KC', pick: 'Over', season: 2025, nflWeek: 19, leagueId: 1, dateCreated: '' },
+    ];
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <UserPicksMatrix users={['alice']} picks={overPick} spreads={{}} requiredPicks={1} />
+      </ThemeProvider>,
+    );
+    expect(screen.getByText('OVER')).toBeInTheDocument();
+  });
+
+  it('shows the word UNDER for an Under pick', () => {
+    const underPick: NflPickDto[] = [
+      { id: 1, userId: 'u1', userName: 'alice', team: 'KC', pick: 'Under', season: 2025, nflWeek: 19, leagueId: 1, dateCreated: '' },
+    ];
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <UserPicksMatrix users={['alice']} picks={underPick} spreads={{}} requiredPicks={1} />
+      </ThemeProvider>,
+    );
+    expect(screen.getByText('UNDER')).toBeInTheDocument();
+  });
+
+  it('does not show an OVER/UNDER label for a Spread pick', () => {
+    renderMatrix('light');
+    expect(screen.queryByText('OVER')).not.toBeInTheDocument();
+    expect(screen.queryByText('UNDER')).not.toBeInTheDocument();
+  });
+
+  it('does not render an arrow icon anymore', () => {
+    const overPick: NflPickDto[] = [
+      { id: 1, userId: 'u1', userName: 'alice', team: 'KC', pick: 'Over', season: 2025, nflWeek: 19, leagueId: 1, dateCreated: '' },
+    ];
+    const { container } = render(
+      <ThemeProvider theme={createTheme()}>
+        <UserPicksMatrix users={['alice']} picks={overPick} spreads={{}} requiredPicks={1} />
+      </ThemeProvider>,
+    );
+    expect(container.querySelector('[data-testid="ArrowCircleUpIcon"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-testid="ArrowCircleDownIcon"]')).not.toBeInTheDocument();
+  });
+
+  it('renders the OVER/UNDER label in a neutral color, not red, when the game has no result yet', () => {
+    // frizat: /code-review caught that the old icon's color logic (carried into the new text
+    // label) collapsed "no spread data yet" (result === null, a scheduled/in-progress game per
+    // ScoresPage's matrixSpreads) into the same branch as an actual loss — falsely showing a red
+    // "OVER" before the game was even decided. Matches the badge background's own 3-way branch.
+    const pendingPick: NflPickDto[] = [
+      { id: 1, userId: 'u1', userName: 'alice', team: 'KC', pick: 'Over', season: 2025, nflWeek: 19, leagueId: 1, dateCreated: '' },
+    ];
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <UserPicksMatrix users={['alice']} picks={pendingPick} spreads={{}} requiredPicks={1} />
+      </ThemeProvider>,
+    );
+    const label = screen.getByText('OVER');
+    expect(label).not.toHaveStyle({ color: 'rgb(211, 47, 47)' }); // MUI error.main
+    expect(label).not.toHaveStyle({ color: 'rgb(46, 125, 50)' }); // MUI success.main
+  });
+});
+
 describe('UserPicksMatrix — Over/Under is an alternate pick type, not an additional pick', () => {
   // frizat: AddPicks' server-side validation caps total picks (any type) at requiredPicks — a
   // real user's Over/Under pick REPLACES one of their spread picks, it never adds a pick beyond

--- a/Client.React/src/__tests__/WeekYearSelector.test.tsx
+++ b/Client.React/src/__tests__/WeekYearSelector.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import WeekYearSelector from '../components/WeekYearSelector';
+import { createAppTheme } from '../app/theme';
 
 const defaultProps = {
   season: 2025,
@@ -42,6 +44,25 @@ describe('WeekYearSelector', () => {
     setup();
     expect(screen.getByRole('button', { name: /previous/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // /style-guide audit — container background/border must be theme-aware,
+  // not hardcoded light-mode literals (rgba(26, 40, 71, ...) is theme.ts's
+  // light-mode primary.main and renders near-invisible in dark mode)
+  // -----------------------------------------------------------------------
+
+  it('uses a dark-mode-appropriate border, not the hardcoded light literal', () => {
+    const darkTheme = createAppTheme('dark');
+    render(
+      <ThemeProvider theme={darkTheme}>
+        <WeekYearSelector {...defaultProps} />
+      </ThemeProvider>,
+    );
+    const container = screen.getByTestId('week-year-selector-container');
+    const style = getComputedStyle(container);
+    expect(style.borderColor).not.toBe('rgba(26, 40, 71, 0.1)');
+    expect(style.borderColor.replace(/\s/g, '')).toBe(darkTheme.palette.divider.replace(/\s/g, ''));
   });
 
   it('disables Previous button at minSeason week 1', () => {

--- a/Client.React/src/__tests__/leaderboard.test.tsx
+++ b/Client.React/src/__tests__/leaderboard.test.tsx
@@ -146,6 +146,107 @@ describe('LeaderboardPage', () => {
   });
 });
 
+describe('LeaderboardPage — season selector', () => {
+  beforeEach(() => {
+    sessionState.currentLeague = 1;
+    mockedGetLeaderboard.mockReset();
+    mockedGetLeaderboard.mockResolvedValue([
+      createLeaderboardEntry({ userId: '123', userName: 'TestUser', rank: '1', total: 5, weekResults: [] }),
+    ]);
+    vi.mocked(mockAdapter.currentSeasonYear).mockResolvedValue(2023);
+  });
+
+  it('defaults to the current season and loads it on mount', async () => {
+    renderPage();
+    await screen.findByRole('table');
+    expect(screen.getByText('2023 Season')).toBeInTheDocument();
+    expect(mockedGetLeaderboard).toHaveBeenCalledWith(1, 2023);
+  });
+
+  it('lets the viewer pick a previous season, like ESPN — re-fetches standings for that year', async () => {
+    renderPage();
+    await screen.findByRole('table');
+    mockedGetLeaderboard.mockClear();
+
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(screen.getByRole('option', { name: '2021 Season' }));
+
+    await waitFor(() => expect(mockedGetLeaderboard).toHaveBeenCalledWith(1, 2021));
+    expect(screen.getByText('2021 Season')).toBeInTheDocument();
+  });
+
+  it('offers every season from adapter.weekSelectorConfig.minSeason through the current season', async () => {
+    renderPage();
+    await screen.findByRole('table');
+
+    await userEvent.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('option', { name: '2023 Season' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: '2020 Season' })).toBeInTheDocument(); // mockAdapter.weekSelectorConfig.minSeason
+    expect(screen.queryByRole('option', { name: '2019 Season' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: '2024 Season' })).not.toBeInTheDocument();
+  });
+
+  it('disables the season selector while a season change is loading, preventing overlapping requests', async () => {
+    // frizat: /code-review flagged that rapidly re-selecting seasons had no race guard — a
+    // slower earlier request resolving after a later one could leave the table showing the
+    // wrong season's data. Rather than layering a manual staleness-check on top, disable the
+    // control while a fetch is in flight so a second request can never be fired before the
+    // first resolves — simpler, and standard behavior for a data-driven selector mid-fetch.
+    let resolveFetch!: (value: ReturnType<typeof createLeaderboardEntry>[]) => void;
+    mockedGetLeaderboard.mockImplementationOnce(() => Promise.resolve([
+      createLeaderboardEntry({ userId: '123', userName: 'TestUser', rank: '1', total: 5, weekResults: [] }),
+    ]));
+
+    renderPage();
+    await screen.findByRole('table');
+
+    mockedGetLeaderboard.mockImplementationOnce(() => new Promise((res) => { resolveFetch = res; }));
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(screen.getByRole('option', { name: '2021 Season' }));
+
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-disabled', 'true');
+
+    resolveFetch([createLeaderboardEntry({ userId: '456', userName: 'PastYearUser', rank: '1', total: 2, weekResults: [] })]);
+    await screen.findByText('PastYearUser');
+    expect(screen.getByRole('combobox')).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('shows the full loading state (not stale data) when the current league changes, not just the season', async () => {
+    // frizat: /code-review caught that the "only show a light refresh, not a full spinner, after
+    // the first load" optimization was keyed on ANY fetch ever completing, not on the currently
+    // selected league — switching leagues via AppLayout's league-selector chip while sitting on
+    // this page (a real, reachable flow, unrelated to this page's own season selector) left the
+    // PREVIOUS league's standings rendered, unlabeled as stale, while the new league's data
+    // loaded, with no guard against an out-of-order response overwriting the right one.
+    mockedGetLeaderboard.mockResolvedValueOnce([
+      createLeaderboardEntry({ userId: '123', userName: 'LeagueOneUser', rank: '1', total: 5, weekResults: [] }),
+    ]);
+    const { rerender } = renderPage();
+    await screen.findByText('LeagueOneUser');
+
+    let resolveLeagueTwo!: (value: ReturnType<typeof createLeaderboardEntry>[]) => void;
+    mockedGetLeaderboard.mockImplementationOnce(() => new Promise((res) => { resolveLeagueTwo = res; }));
+
+    sessionState.currentLeague = 2;
+    rerender(
+      <ThemeProvider theme={createAppTheme('light')}>
+        <MemoryRouter initialEntries={['/leaderboard']}>
+          <Routes>
+            <Route path="/leaderboard" element={<LeaderboardPage adapter={mockAdapter} />} />
+            <Route path="/leaguepicker" element={<div>League Picker</div>} />
+          </Routes>
+        </MemoryRouter>
+      </ThemeProvider>,
+    );
+
+    // The old league's data must not still be on screen while the new league loads.
+    await waitFor(() => expect(screen.queryByText('LeagueOneUser')).not.toBeInTheDocument());
+
+    resolveLeagueTwo([createLeaderboardEntry({ userId: '789', userName: 'LeagueTwoUser', rank: '1', total: 9, weekResults: [] })]);
+    await screen.findByText('LeagueTwoUser');
+  });
+});
+
 describe('LeaderboardPage — week-cell colors', () => {
   beforeEach(() => {
     sessionState.currentLeague = 1;

--- a/Client.React/src/__tests__/picks.test.tsx
+++ b/Client.React/src/__tests__/picks.test.tsx
@@ -189,6 +189,20 @@ describe('PicksPage', () => {
     });
   });
 
+  // frizat: /style-guide audit — Submit and Clear were both contained/equal-size, reading as
+  // two equal-strength CTAs when Submit is the primary action and Clear is a rare, lesser one.
+  // Clear also used color="warning" as a small filled button — the exact configuration the
+  // style guide documents as unreadable in both modes for pick-state buttons.
+  it('demotes Clear to an outlined button so Submit reads as the primary action', async () => {
+    await setupDefaults();
+    await renderPage();
+    const submit = screen.getByRole('button', { name: /submit pick/i });
+    const clear = screen.getByRole('button', { name: /clear selected picks/i });
+    expect(submit.className).toMatch(/MuiButton-contained/);
+    expect(clear.className).toMatch(/MuiButton-outlined/);
+    expect(clear.className).not.toMatch(/warning/i);
+  });
+
   it('pick button toggles to picked and back', async () => {
     await setupDefaults();
     await renderPage();

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ScoresPage from '../pages/ScoresPage';
@@ -202,6 +202,65 @@ describe('ScoresPage', () => {
     await renderPage();
     expect(screen.getAllByTestId('ArrowCircleUpIcon').length).toBeGreaterThan(0);
     expect(screen.getAllByTestId('ArrowCircleDownIcon').length).toBeGreaterThan(0);
+  });
+
+  // frizat: /style-guide audit — each pick-result row encoded win/loss three redundant ways at
+  // once: this shield icon (shape AND color both changed), the IconButton's own color, and the
+  // Badge's color. Drop the standalone shield icon; the badge/icon-button pair alone is the
+  // signal now (same "background/color is the only signal" resolution as the Matrix view).
+  it('does not render a redundant win/loss shield icon — the pick badge/button color alone carries it', async () => {
+    const picks = [createPick({ team: 'BUF', userName: 'OtherUser', userId: '456' })];
+    await setupDefaults({ picks, gameStarted: true });
+    await renderPage();
+    expect(screen.queryByTestId('GppGoodIcon')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('GppBadIcon')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('GppMaybeIcon')).not.toBeInTheDocument();
+  });
+
+  // frizat: same redundancy on the O/U row — the up/down arrows were colored success/error on
+  // top of the Badge/IconButton pairs on either side already showing the identical win/loss
+  // state. Arrows now stay a fixed neutral color; the badges are the one signal.
+  it('keeps the Over/Under arrows a neutral color regardless of win/loss — the badges already carry that signal', async () => {
+    // BUF 24, MIA 10 → total 34 < O/U 47.5 → Under wins (see makeScores comment above)
+    await setupDefaults({ week: 1, postSeason: true, gameStarted: true });
+    await renderPage();
+    const upArrow = screen.getAllByTestId('ArrowCircleUpIcon')[0];
+    const downArrow = screen.getAllByTestId('ArrowCircleDownIcon')[0];
+    expect(upArrow).not.toHaveStyle({ color: 'rgb(211, 47, 47)' }); // MUI error.main
+    expect(upArrow).not.toHaveStyle({ color: 'rgb(46, 125, 50)' }); // MUI success.main
+    expect(downArrow).not.toHaveStyle({ color: 'rgb(211, 47, 47)' });
+    expect(downArrow).not.toHaveStyle({ color: 'rgb(46, 125, 50)' });
+  });
+
+  // frizat: /style-guide audit — "Show As Matrix" defaulted to unstyled contained (reads as
+  // primary navy, near-inert next to body text) while "Show Only My Picks" used contained
+  // secondary (the brand orange reserved for real CTAs like Share) — two equal-weight view
+  // filters shouldn't have one wearing the brand accent. Both are the same neutral treatment now.
+  it('gives the Matrix and My-Picks view toggles matching weight, neither wearing the brand-CTA color', async () => {
+    const picks = [createPick({ team: 'BUF' })];
+    await setupDefaults({ picks, gameStarted: true });
+    await renderPage();
+
+    const matrixButton = screen.getByRole('button', { name: /show as matrix/i });
+    const myPicksButton = screen.getByRole('button', { name: /show only my picks/i });
+    expect(matrixButton.className).toMatch(/MuiButton-outlinedInfo/);
+    expect(myPicksButton.className).toMatch(/MuiButton-outlinedInfo/);
+    expect(matrixButton.className).not.toMatch(/Secondary/);
+    expect(myPicksButton.className).not.toMatch(/Secondary/);
+  });
+
+  // /code-review caught that the removed shield icon was the ONLY win/loss signal for a team
+  // nobody in the league picked — the badge/icon-button pair used pickCount === 0 to both hide
+  // the count bubble AND disable the button, and MUI's disabled state flattens `color` to gray
+  // regardless of the success/error prop. Disabled must now track "not decided yet" only, so the
+  // outcome color still shows even with zero picks.
+  it('keeps the pick icon enabled and colored by outcome even when nobody in the league picked that side', async () => {
+    await setupDefaults({ picks: [], gameStarted: true });
+    const { getByTestId } = await renderPage();
+    const badge = getByTestId('badge-BUF-spread');
+    const button = within(badge).getByRole('button');
+    expect(button).not.toBeDisabled();
+    expect(button.className).toMatch(/colorSuccess/);
   });
 
   it('spread badge is info when current user has a pick', async () => {

--- a/Client.React/src/__tests__/seasonRange.test.ts
+++ b/Client.React/src/__tests__/seasonRange.test.ts
@@ -1,0 +1,11 @@
+import { buildDescendingSeasonRange } from '../utils/seasonRange';
+
+describe('buildDescendingSeasonRange', () => {
+  it('returns years from maxSeason down to minSeason, most recent first', () => {
+    expect(buildDescendingSeasonRange(2020, 2023)).toEqual([2023, 2022, 2021, 2020]);
+  });
+
+  it('returns a single-element array when minSeason equals maxSeason', () => {
+    expect(buildDescendingSeasonRange(2023, 2023)).toEqual([2023]);
+  });
+});

--- a/Client.React/src/__tests__/useNumericField.test.tsx
+++ b/Client.React/src/__tests__/useNumericField.test.tsx
@@ -1,0 +1,76 @@
+import { act, renderHook } from '@testing-library/react';
+import { useNumericField } from '../utils/useNumericField';
+
+describe('useNumericField', () => {
+  it('reflects the initial value as a string', () => {
+    const { result } = renderHook(() => useNumericField(13, () => {}));
+    expect(result.current.value).toBe('13');
+  });
+
+  it('preserves an incomplete intermediate value without pushing it upward', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useNumericField(1, onChange));
+
+    act(() => result.current.onChange({ target: { value: '-' } } as React.ChangeEvent<HTMLInputElement>));
+
+    expect(result.current.value).toBe('-');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('pushes the parsed number upward once the value is valid', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useNumericField(1, onChange));
+
+    act(() => result.current.onChange({ target: { value: '1.5' } } as React.ChangeEvent<HTMLInputElement>));
+
+    expect(result.current.value).toBe('1.5');
+    expect(onChange).toHaveBeenCalledWith(1.5);
+  });
+
+  it('snaps back to the last valid value on blur after an incomplete edit', () => {
+    const { result } = renderHook(() => useNumericField(7, () => {}));
+
+    act(() => result.current.onChange({ target: { value: '' } } as React.ChangeEvent<HTMLInputElement>));
+    expect(result.current.value).toBe('');
+
+    act(() => result.current.onBlur());
+    expect(result.current.value).toBe('7');
+  });
+
+  it('does not clobber a mid-edit decimal when backspacing produces the same committed number', () => {
+    // /code-review finding: 17.5 -> backspace to "17." parses to 17, which matches the
+    // previously-committed 17.5's new value of 17 once rounded down — the resync effect
+    // must not stomp "17." back to "17" just because the committed number didn't change
+    // in a way distinguishable from an external update.
+    const onChange = vi.fn();
+    const { result, rerender } = renderHook(({ value }) => useNumericField(value, onChange), {
+      initialProps: { value: 17.5 },
+    });
+
+    act(() => result.current.onChange({ target: { value: '17.' } } as React.ChangeEvent<HTMLInputElement>));
+    expect(onChange).toHaveBeenCalledWith(17);
+
+    rerender({ value: 17 });
+    expect(result.current.value).toBe('17.');
+  });
+
+  it('does not push Infinity upward for overflowing/scientific-notation input', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useNumericField(1, onChange));
+
+    act(() => result.current.onChange({ target: { value: '1e400' } } as React.ChangeEvent<HTMLInputElement>));
+
+    expect(result.current.value).toBe('1e400');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('resyncs the displayed value when the parent value prop changes', () => {
+    const { result, rerender } = renderHook(({ value }) => useNumericField(value, () => {}), {
+      initialProps: { value: 5 },
+    });
+    expect(result.current.value).toBe('5');
+
+    rerender({ value: 20 });
+    expect(result.current.value).toBe('20');
+  });
+});

--- a/Client.React/src/__tests__/useNumericField.test.tsx
+++ b/Client.React/src/__tests__/useNumericField.test.tsx
@@ -73,4 +73,40 @@ describe('useNumericField', () => {
     rerender({ value: 20 });
     expect(result.current.value).toBe('20');
   });
+
+  describe('integerOnly', () => {
+    // The backend's Juice/Cost DTOs are all `int` — a decimal typed into these fields
+    // previously displayed fine but 400'd silently on save. Stripping the decimal point
+    // as it's typed keeps the field's own contract (whole numbers) instead of catching
+    // the mismatch only after a failed save.
+    it('strips a typed decimal point instead of accepting it', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() => useNumericField(1, onChange, { integerOnly: true }));
+
+      act(() => result.current.onChange({ target: { value: '1.' } } as React.ChangeEvent<HTMLInputElement>));
+      expect(result.current.value).toBe('1');
+
+      act(() => result.current.onChange({ target: { value: '1.5' } } as React.ChangeEvent<HTMLInputElement>));
+      expect(result.current.value).toBe('15');
+      expect(onChange).toHaveBeenLastCalledWith(15);
+    });
+
+    it('still allows a bare "-" as a mid-edit state without pushing a value upward', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() => useNumericField(3, onChange, { integerOnly: true }));
+
+      act(() => result.current.onChange({ target: { value: '-' } } as React.ChangeEvent<HTMLInputElement>));
+      expect(result.current.value).toBe('-');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('does not strip the decimal point when integerOnly is not set', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() => useNumericField(1, onChange));
+
+      act(() => result.current.onChange({ target: { value: '1.5' } } as React.ChangeEvent<HTMLInputElement>));
+      expect(result.current.value).toBe('1.5');
+      expect(onChange).toHaveBeenCalledWith(1.5);
+    });
+  });
 });

--- a/Client.React/src/components/UserPicksMatrix.tsx
+++ b/Client.React/src/components/UserPicksMatrix.tsx
@@ -8,8 +8,6 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
-import ArrowCircleUpIcon from '@mui/icons-material/ArrowCircleUp';
-import ArrowCircleDownIcon from '@mui/icons-material/ArrowCircleDown';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
 import type { NflPickDto, SpreadCalculationResponse } from '../types/picks';
@@ -60,20 +58,6 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
           flexShrink: 0,
         }}
       >
-        {pick.pick === 'Over' && (
-          <ArrowCircleUpIcon
-            fontSize="small"
-            sx={{ position: 'absolute', top: 4, left: 4, bgcolor: 'white', borderRadius: '50%' }}
-            color={result ? 'success' : 'error'}
-          />
-        )}
-        {pick.pick === 'Under' && (
-          <ArrowCircleDownIcon
-            fontSize="small"
-            sx={{ position: 'absolute', top: 4, left: 4, bgcolor: 'white', borderRadius: '50%' }}
-            color={result ? 'success' : 'error'}
-          />
-        )}
         {/* frizat: the helmet logo + 9px label was hard to read at a glance against the
             win/loss color-coded background — text-only, much larger, reads clearly instead.
             CFB abbreviations run up to 4 chars (UTSA, UNLV, WASH) vs NFL's 2-3 — shrink to fit
@@ -81,6 +65,23 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
         <Typography sx={{ fontSize: pick.team.length > 3 ? 16 : 22, fontWeight: 800, letterSpacing: '0.02em' }}>
           {pick.team}
         </Typography>
+        {/* frizat: a tiny corner arrow icon was easy to miss against the color-coded background
+            and the large team text above it — spell out OVER/UNDER instead, same bold treatment.
+            Match the badge background's 3-way branch (win/loss/no-result-yet) — result is null
+            for a scheduled/in-progress game (ScoresPage's matrixSpreads only populates an entry
+            once a game is final), which must read as neutral, not silently collapse into "loss". */}
+        {pick.pick !== 'Spread' && (
+          <Typography
+            sx={{
+              fontSize: 11,
+              fontWeight: 800,
+              letterSpacing: '0.03em',
+              color: result === true ? 'success.main' : result === false ? 'error.main' : 'text.secondary',
+            }}
+          >
+            {pick.pick.toUpperCase()}
+          </Typography>
+        )}
         {result === true && (
           <CheckCircleIcon
             fontSize="small"

--- a/Client.React/src/components/UserPicksMatrix.tsx
+++ b/Client.React/src/components/UserPicksMatrix.tsx
@@ -8,8 +8,6 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import CancelIcon from '@mui/icons-material/Cancel';
 import type { NflPickDto, SpreadCalculationResponse } from '../types/picks';
 import { stickyColumnSx } from '../utils/tableStyles';
 
@@ -65,36 +63,15 @@ export default function UserPicksMatrix({ users, picks, spreads, requiredPicks }
         <Typography sx={{ fontSize: pick.team.length > 3 ? 16 : 22, fontWeight: 800, letterSpacing: '0.02em' }}>
           {pick.team}
         </Typography>
-        {/* frizat: a tiny corner arrow icon was easy to miss against the color-coded background
-            and the large team text above it — spell out OVER/UNDER instead, same bold treatment.
-            Match the badge background's 3-way branch (win/loss/no-result-yet) — result is null
-            for a scheduled/in-progress game (ScoresPage's matrixSpreads only populates an entry
-            once a game is final), which must read as neutral, not silently collapse into "loss". */}
+        {/* frizat: the badge used to signal win/loss three ways at once — the tinted background,
+            a colored OVER/UNDER label, and a corner check/cancel icon — reported as cluttered
+            and hard to read. The background alone now carries that signal; this label stays the
+            same neutral ink as the team name above it, in every case, with only weight/size
+            marking it as secondary information (which team > which bet type). */}
         {pick.pick !== 'Spread' && (
-          <Typography
-            sx={{
-              fontSize: 11,
-              fontWeight: 800,
-              letterSpacing: '0.03em',
-              color: result === true ? 'success.main' : result === false ? 'error.main' : 'text.secondary',
-            }}
-          >
+          <Typography sx={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.03em' }}>
             {pick.pick.toUpperCase()}
           </Typography>
-        )}
-        {result === true && (
-          <CheckCircleIcon
-            fontSize="small"
-            color="success"
-            sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'white', borderRadius: '50%' }}
-          />
-        )}
-        {result === false && (
-          <CancelIcon
-            fontSize="small"
-            color="error"
-            sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'white', borderRadius: '50%' }}
-          />
         )}
       </Paper>
     );

--- a/Client.React/src/components/WeekYearSelector.tsx
+++ b/Client.React/src/components/WeekYearSelector.tsx
@@ -3,6 +3,7 @@ import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { useEffect, useMemo } from 'react';
 import { getWeekName } from '../utils/gameHelpers';
+import { buildDescendingSeasonRange } from '../utils/seasonRange';
 
 interface WeekYearSelectorProps {
   season: number;
@@ -93,7 +94,7 @@ export default function WeekYearSelector({
   };
 
   const seasonOptions = useMemo(
-    () => Array.from({ length: maxSeason - minSeason + 1 }, (_, i) => minSeason + i).reverse(),
+    () => buildDescendingSeasonRange(minSeason, maxSeason),
     [minSeason, maxSeason]
   );
 

--- a/Client.React/src/components/WeekYearSelector.tsx
+++ b/Client.React/src/components/WeekYearSelector.tsx
@@ -100,15 +100,17 @@ export default function WeekYearSelector({
 
   return (
     <Box
+      data-testid="week-year-selector-container"
       sx={{
         display: 'flex',
         flexDirection: 'column',
         gap: 1.5,
         p: { xs: 1, sm: 2 },
         mb: 3,
-        backgroundColor: 'rgba(26, 40, 71, 0.04)',
+        bgcolor: 'action.hover',
         borderRadius: 2,
-        border: '1px solid rgba(26, 40, 71, 0.1)',
+        border: '1px solid',
+        borderColor: 'divider',
       }}
     >
       {/* Selects row — frizat: flexWrap alone made mobile layout depend on content width: a short

--- a/Client.React/src/pages/JoinLeaguePage.tsx
+++ b/Client.React/src/pages/JoinLeaguePage.tsx
@@ -15,7 +15,7 @@ export default function JoinLeaguePage() {
   const { token } = useParams<{ token: string }>();
   const navigate = useNavigate();
   const { user } = useAuth();
-  const { reloadLeagues, availableLeagues } = useSession();
+  const { reloadLeagues, availableLeagues, refreshPendingInvites } = useSession();
 
   const [loading, setLoading] = useState(true);
   const [joining, setJoining] = useState(false);
@@ -43,8 +43,11 @@ export default function JoinLeaguePage() {
     setJoining(true);
     setError(null);
     try {
+      // joinViaLink creates a pending membership invite rather than joining directly (see
+      // LeagueController.JoinViaLink) — refresh pending invites, not leagues, so
+      // PendingInviteBanner shows up immediately on the dashboard with Accept/Decline.
       await joinViaLink(token!);
-      await reloadLeagues();
+      await refreshPendingInvites();
       navigate('/dashboard');
     } catch (err) {
       const status = (err as { response?: { status?: number } }).response?.status;

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { buildDescendingSeasonRange } from '../utils/seasonRange';
 import { Navigate } from 'react-router-dom';
 import {
   alpha,
@@ -8,6 +9,8 @@ import {
   CardContent,
   CircularProgress,
   Grid,
+  MenuItem,
+  Select,
   Table,
   TableBody,
   TableCell,
@@ -41,19 +44,51 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
   const cardRef = useRef<HTMLDivElement>(null);
   const [loading, setLoading] = useState(true);
   const [leaderboard, setLeaderboard] = useState<LeaderboardDto[]>([]);
+  const [season, setSeason] = useState<number | null>(null);
+  // Remember the real current-season ceiling separately from `season` (which the selector
+  // below can move to a past year) — otherwise re-deriving the selector's upper bound from
+  // whatever season is currently being VIEWED would shrink the range after picking a past
+  // year, trapping the viewer in history (same bug class PicksPage's season selector hit).
+  const [maxSeason, setMaxSeason] = useState<number | null>(null);
+
+  // Only the very first fetch FOR THE CURRENTLY SELECTED LEAGUE shows the full-page spinner — a
+  // season switch within the same league keeps the page on screen and just disables the
+  // selector for the moment a fetch is in flight. Scoping this per-league (not a single global
+  // "ever loaded" flag) matters because AppLayout's league-selector chip can change
+  // `currentLeague` while already sitting on this page: without resetting the flag here, that
+  // switch would silently keep the PREVIOUS league's standings on screen (unlabeled as stale)
+  // while the new league's data loaded, with no guard against an out-of-order response
+  // overwriting the right one (/code-review caught this as a real, reachable regression).
+  const hasLoadedOnce = useRef(false);
+  const [refreshing, setRefreshing] = useState(false);
 
   useEffect(() => {
-    const run = async () => {
-      setLoading(true);
-      if (!leaguesLoaded || !currentLeague) { setLoading(false); return; }
-      const seasonYear = await adapter.currentSeasonYear();
+    if (!leaguesLoaded || !currentLeague) { setLoading(false); return; }
+    hasLoadedOnce.current = false;
+    void adapter.currentSeasonYear().then((seasonYear) => {
       if (!seasonYear) { setLoading(false); return; }
-      const data = await getLeaderboard(currentLeague, seasonYear);
+      setSeason(seasonYear);
+      setMaxSeason(seasonYear);
+    });
+  }, [currentLeague, leaguesLoaded, adapter]);
+
+  useEffect(() => {
+    if (!currentLeague || season == null) return;
+    const run = async () => {
+      if (hasLoadedOnce.current) setRefreshing(true); else setLoading(true);
+      const data = await getLeaderboard(currentLeague, season);
       setLeaderboard(data ?? []);
+      hasLoadedOnce.current = true;
       setLoading(false);
+      setRefreshing(false);
     };
     void run();
-  }, [currentLeague, leaguesLoaded, adapter]);
+  }, [currentLeague, season]);
+
+  const seasonOptions = useMemo(() => {
+    if (maxSeason == null) return [];
+    return buildDescendingSeasonRange(adapter.weekSelectorConfig.minSeason, maxSeason);
+  }, [maxSeason, adapter.weekSelectorConfig.minSeason]);
 
   const maxWeek = useMemo(() => {
     if (leaderboard.length === 0) return 0;
@@ -169,6 +204,24 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
           </Button>
         }
       />
+      {season != null && seasonOptions.length > 0 && (
+        // frizat: /code-review flagged that cramming this into PageHeader's title+action row
+        // (already carrying the "Leaderboard" h4 + Share button) risked overflow on the app's
+        // ~390px mobile primary viewport — its own row has no competing width to fight for.
+        <Box sx={{ mb: 2 }}>
+          <Select
+            size="small"
+            value={season}
+            disabled={refreshing}
+            onChange={(e) => setSeason(Number(e.target.value))}
+            sx={{ width: { xs: '100%', sm: 'auto' } }}
+          >
+            {seasonOptions.map((year) => (
+              <MenuItem key={year} value={year}>{year} Season</MenuItem>
+            ))}
+          </Select>
+        </Box>
+      )}
       {myRow && isPreparingShare && (
         // Mounted only while actually capturing a share image — an always-mounted hidden card
         // duplicates the user's name/rank text in the DOM, which broke a real Playwright demo

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -767,6 +767,22 @@ function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInv
         )}
       </Stack>
 
+      {/* frizat: real incident — an owner generated a share link meaning "blast it to my whole
+          group," a member clicked it, and the owner was confused about what would happen next.
+          Always-visible text, not a hover tooltip, since this is mobile-first and the confusion
+          happens exactly when someone is about to click one of these buttons. Both mechanisms
+          apply the identical accept/decline-vs-register rule (LeagueController.JoinViaLink
+          routes an existing user through the same membershipInviteService.CreateOrReopenAsync
+          as InviteToLeague) — the real difference is targeting: one email vs. one shareable
+          link for a whole group. Don't say the link joins existing members instantly; it
+          doesn't (only a brand-new visitor registering through either path does). */}
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5, maxWidth: 640 }}>
+        Invite Player sends a request to one email — existing members get a request to accept or decline, new visitors register to join.
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3, maxWidth: 640 }}>
+        Invite Link works the same way, but gives you one shareable link for your whole group instead of one email at a time.
+      </Typography>
+
       {inviteLink && (
         <Box sx={{ mb: 3, p: 2, border: 1, borderColor: linkExpired ? 'warning.main' : 'divider', borderRadius: 1, maxWidth: 520 }}>
           <Stack spacing={1}>

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -40,6 +40,7 @@ import { useToast } from '../services/toast';
 import { isAdmin } from '../utils/auth';
 import { extractApiErrorMessage } from '../utils/apiError';
 import { useShareLink } from '../utils/useShareLink';
+import { useNumericField } from '../utils/useNumericField';
 import {
   getLeagueUserMappings,
   getLeagueJuice,
@@ -948,6 +949,11 @@ function JuiceTab({
   availableSeasons, selectedSeason, onSeasonChange, juiceForm, onJuiceFormChange,
   hasMappingForSeason, locked, onSave, onRollForward, saving, rollingForward,
 }: JuiceTabProps) {
+  const juiceField = useNumericField(juiceForm.juice, (n) => onJuiceFormChange('juice', n));
+  const juiceDivisionalField = useNumericField(juiceForm.juiceDivisional, (n) => onJuiceFormChange('juiceDivisional', n));
+  const juiceConferenceField = useNumericField(juiceForm.juiceConference, (n) => onJuiceFormChange('juiceConference', n));
+  const weeklyCostField = useNumericField(juiceForm.weeklyCost, (n) => onJuiceFormChange('weeklyCost', n));
+
   return (
     <Box>
       <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 3 }}>
@@ -982,32 +988,28 @@ function JuiceTab({
           type="number"
           size="small"
           disabled={locked}
-          value={juiceForm.juice}
-          onChange={(e) => onJuiceFormChange('juice', Number(e.target.value))}
+          {...juiceField}
         />
         <TextField
           label="Tease Pts (Divisional)"
           type="number"
           size="small"
           disabled={locked}
-          value={juiceForm.juiceDivisional}
-          onChange={(e) => onJuiceFormChange('juiceDivisional', Number(e.target.value))}
+          {...juiceDivisionalField}
         />
         <TextField
           label="Tease Pts (Conference)"
           type="number"
           size="small"
           disabled={locked}
-          value={juiceForm.juiceConference}
-          onChange={(e) => onJuiceFormChange('juiceConference', Number(e.target.value))}
+          {...juiceConferenceField}
         />
         <TextField
           label="Cost Per Week ($)"
           type="number"
           size="small"
           disabled={locked}
-          value={juiceForm.weeklyCost}
-          onChange={(e) => onJuiceFormChange('weeklyCost', Number(e.target.value))}
+          {...weeklyCostField}
         />
         <Button variant="contained" onClick={onSave} disabled={saving || locked} sx={{ alignSelf: 'flex-start' }}>
           {saving ? <CircularProgress size={18} /> : 'Save'}

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -965,10 +965,13 @@ function JuiceTab({
   availableSeasons, selectedSeason, onSeasonChange, juiceForm, onJuiceFormChange,
   hasMappingForSeason, locked, onSave, onRollForward, saving, rollingForward,
 }: JuiceTabProps) {
-  const juiceField = useNumericField(juiceForm.juice, (n) => onJuiceFormChange('juice', n));
-  const juiceDivisionalField = useNumericField(juiceForm.juiceDivisional, (n) => onJuiceFormChange('juiceDivisional', n));
-  const juiceConferenceField = useNumericField(juiceForm.juiceConference, (n) => onJuiceFormChange('juiceConference', n));
-  const weeklyCostField = useNumericField(juiceForm.weeklyCost, (n) => onJuiceFormChange('weeklyCost', n));
+  // All 4 fields are backend `int` DTOs (Shared/Models/Data/Dtos/LeagueCreateDto.cs) — teaser
+  // points and weekly cost are always whole numbers in this domain, so integerOnly strips a
+  // typed decimal point instead of letting it through to a save that 400s.
+  const juiceField = useNumericField(juiceForm.juice, (n) => onJuiceFormChange('juice', n), { integerOnly: true });
+  const juiceDivisionalField = useNumericField(juiceForm.juiceDivisional, (n) => onJuiceFormChange('juiceDivisional', n), { integerOnly: true });
+  const juiceConferenceField = useNumericField(juiceForm.juiceConference, (n) => onJuiceFormChange('juiceConference', n), { integerOnly: true });
+  const weeklyCostField = useNumericField(juiceForm.weeklyCost, (n) => onJuiceFormChange('weeklyCost', n), { integerOnly: true });
 
   return (
     <Box>
@@ -1004,6 +1007,7 @@ function JuiceTab({
           type="number"
           size="small"
           disabled={locked}
+          slotProps={{ htmlInput: { inputMode: 'numeric' } }}
           {...juiceField}
         />
         <TextField
@@ -1011,6 +1015,7 @@ function JuiceTab({
           type="number"
           size="small"
           disabled={locked}
+          slotProps={{ htmlInput: { inputMode: 'numeric' } }}
           {...juiceDivisionalField}
         />
         <TextField
@@ -1018,6 +1023,7 @@ function JuiceTab({
           type="number"
           size="small"
           disabled={locked}
+          slotProps={{ htmlInput: { inputMode: 'numeric' } }}
           {...juiceConferenceField}
         />
         <TextField
@@ -1025,6 +1031,7 @@ function JuiceTab({
           type="number"
           size="small"
           disabled={locked}
+          slotProps={{ htmlInput: { inputMode: 'numeric' } }}
           {...weeklyCostField}
         />
         <Button variant="contained" onClick={onSave} disabled={saving || locked} sx={{ alignSelf: 'flex-start' }}>

--- a/Client.React/src/pages/PicksPage.tsx
+++ b/Client.React/src/pages/PicksPage.tsx
@@ -226,7 +226,11 @@ export default function PicksPage({ adapter }: PicksPageProps) {
               <Button variant="contained" color="success" disabled={storingPicks || userPicks.size === 0} onClick={handleSubmit}>
                 {storingPicks ? 'Submitting…' : 'Submit Pick(s)'}
               </Button>
-              <Button variant="contained" color="warning" disabled={userPicks.size === 0} onClick={handleClear}>
+              {/* frizat: /style-guide audit — both buttons were equal-weight contained, and
+                  Clear used color="warning" as a small filled button, the exact configuration
+                  the style guide documents as unreadable in both modes for pick-state buttons.
+                  Outlined demotes Clear to secondary, matching its rare, lower-stakes role. */}
+              <Button variant="outlined" disabled={userPicks.size === 0} onClick={handleClear}>
                 Clear Selected Picks
               </Button>
             </Stack>

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -4,9 +4,6 @@ import {
   IconButton, Paper, Stack, Typography,
 } from '@mui/material';
 import PersonIcon from '@mui/icons-material/Person';
-import GppGoodIcon from '@mui/icons-material/GppGood';
-import GppBadIcon from '@mui/icons-material/GppBad';
-import GppMaybeIcon from '@mui/icons-material/GppMaybe';
 import ArrowCircleUpIcon from '@mui/icons-material/ArrowCircleUp';
 import ArrowCircleDownIcon from '@mui/icons-material/ArrowCircleDown';
 import IosShareIcon from '@mui/icons-material/IosShare';
@@ -41,12 +38,6 @@ function teamWins(game: GameView, team: string, pickType: 'Spread' | 'Over' | 'U
   }
   if (game.overWins == null) return null;
   return pickType === 'Over' ? game.overWins : !game.overWins;
-}
-
-function coverIcon(game: GameView, team: string, pickType: 'Spread' | 'Over' | 'Under') {
-  const wins = teamWins(game, team, pickType);
-  if (wins == null) return <GppMaybeIcon color="disabled" />;
-  return wins ? <GppGoodIcon color="success" /> : <GppBadIcon color="error" />;
 }
 
 function badgeColor(game: GameView, team: string, pickType: 'Spread' | 'Over' | 'Under'): 'success' | 'error' | 'info' | 'default' {
@@ -272,13 +263,17 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
       <Grid container spacing={2}>
         {/* Controls row */}
         <Grid size={12} sx={{ display: 'flex', justifyContent: 'flex-end', gap: 2 }}>
+          {/* frizat: /style-guide audit — these are neutral view filters, not brand CTAs, but
+              one defaulted to unstyled contained (reads as inert navy) and the other used
+              contained secondary (the brand orange reserved for real CTAs like Share). Same
+              matching, neutral treatment for both now. */}
           {data?.allPicks.length && data.allPicks.length > 0 && (
-            <Button variant="contained" onClick={() => setShowMatrixView(p => !p)}>
+            <Button variant="outlined" color="info" onClick={() => setShowMatrixView(p => !p)}>
               {showMatrixView ? 'Show Standard View' : 'Show As Matrix'}
             </Button>
           )}
           {!showMatrixView && (
-            <Button variant="contained" color="secondary" onClick={() => setShowOnlyMyPicks(p => !p)}>
+            <Button variant="outlined" color="info" onClick={() => setShowOnlyMyPicks(p => !p)}>
               {showOnlyMyPicks ? 'Show All Games' : 'Show Only My Picks'}
             </Button>
           )}
@@ -341,7 +336,6 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
 
                     {/* Away team pick row */}
                     <Stack direction="row" alignItems="center" sx={{ mt: 2, gap: 1.5, px: 1 }}>
-                      {coverIcon(game, game.awayTeam, 'Spread')}
                       <Typography sx={{ minWidth: 40, fontWeight: 600 }}>{game.awayTeam}</Typography>
                       <Box sx={{ flexGrow: 1 }} />
                       <Typography variant="subtitle1" className="spread-value" sx={{ minWidth: 56, textAlign: 'right' }}>{game.awaySpread != null ? spreadLabel(game.awaySpread) : ''}</Typography>
@@ -353,9 +347,16 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
                         badgeContent={pickCountForTeam(game.id, game.awayTeam, 'Spread')}
                         invisible={(!isFinal && !isLive) || pickCountForTeam(game.id, game.awayTeam, 'Spread') === 0}
                       >
+                        {/* frizat: /code-review caught that gating `disabled` on pickCount === 0 (in
+                            addition to not-decided-yet) flattens this icon's color to MUI's disabled
+                            gray via the `disabled` prop, which erases the win/loss signal for a team
+                            literally nobody in the league picked — the one case the removed shield
+                            icon used to cover on its own, independent of picks. Disabled now tracks
+                            only "not decided yet"; `invisible` above still hides the pick-count bubble
+                            when nobody picked, but the button itself stays colored by outcome. */}
                         <IconButton
                           color={(isFinal || isLive) ? (hc === false ? 'success' : hc === true ? 'error' : 'inherit') : 'inherit'}
-                          disabled={(!isFinal && !isLive) || pickCountForTeam(game.id, game.awayTeam, 'Spread') === 0}
+                          disabled={!isFinal && !isLive}
                           onClick={() => showDialog(game, game.awayTeam, 'Spread')}
                           size="small"
                         >
@@ -366,7 +367,6 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
 
                     {/* Home team pick row */}
                     <Stack direction="row" alignItems="center" sx={{ mt: 1.5, gap: 1.5, px: 1 }}>
-                      {coverIcon(game, game.homeTeam, 'Spread')}
                       <Typography sx={{ minWidth: 40, fontWeight: 600 }}>{game.homeTeam}</Typography>
                       <Box sx={{ flexGrow: 1 }} />
                       <Typography variant="subtitle1" className="spread-value" sx={{ minWidth: 56, textAlign: 'right' }}>{game.homeSpread != null ? spreadLabel(game.homeSpread) : ''}</Typography>
@@ -380,7 +380,7 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
                       >
                         <IconButton
                           color={(isFinal || isLive) ? (hc === true ? 'success' : hc === false ? 'error' : 'inherit') : 'inherit'}
-                          disabled={(!isFinal && !isLive) || pickCountForTeam(game.id, game.homeTeam, 'Spread') === 0}
+                          disabled={!isFinal && !isLive}
                           onClick={() => showDialog(game, game.homeTeam, 'Spread')}
                           size="small"
                         >
@@ -397,20 +397,24 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
                           invisible={(!isFinal && !isLive) || pickCountForTeam(game.id, game.homeTeam, 'Over') === 0}>
                           <IconButton size="small"
                             color={(isFinal || isLive) ? (ov ? 'success' : ov === false ? 'error' : 'inherit') : 'inherit'}
-                            disabled={(!isFinal && !isLive) || pickCountForTeam(game.id, game.homeTeam, 'Over') === 0}
+                            disabled={!isFinal && !isLive}
                             onClick={() => showDialog(game, game.homeTeam, 'Over')}>
                             <PersonIcon />
                           </IconButton>
                         </Badge>
-                        <ArrowCircleUpIcon sx={{ color: (isFinal || isLive) ? (ov ? 'success.main' : 'error.main') : 'text.secondary', flexShrink: 0 }} />
+                        {/* frizat: /style-guide audit — these were color-coded success/error on top of the
+                            Badge/IconButton pairs on either side already showing the identical win/loss
+                            state (same redundant-signal issue as the shield icon this page dropped
+                            elsewhere). The arrows are just Over/Under labels now; the badges are the signal. */}
+                        <ArrowCircleUpIcon sx={{ color: 'text.secondary', flexShrink: 0 }} />
                         <Typography variant="subtitle1" sx={{ minWidth: 36, textAlign: 'center' }}>{game.overUnder}</Typography>
-                        <ArrowCircleDownIcon sx={{ color: (isFinal || isLive) ? (!ov ? 'success.main' : 'error.main') : 'text.secondary', flexShrink: 0 }} />
+                        <ArrowCircleDownIcon sx={{ color: 'text.secondary', flexShrink: 0 }} />
                         <Badge data-testid={`badge-${game.homeTeam}-under`} color={didUserPick(game.id, game.homeTeam, 'Under') ? 'info' : badgeColor(game, game.homeTeam, 'Under')} overlap="circular"
                           badgeContent={pickCountForTeam(game.id, game.homeTeam, 'Under')}
                           invisible={(!isFinal && !isLive) || pickCountForTeam(game.id, game.homeTeam, 'Under') === 0}>
                           <IconButton size="small"
                             color={(isFinal || isLive) ? (!ov ? 'success' : ov === true ? 'error' : 'inherit') : 'inherit'}
-                            disabled={(!isFinal && !isLive) || pickCountForTeam(game.id, game.homeTeam, 'Under') === 0}
+                            disabled={!isFinal && !isLive}
                             onClick={() => showDialog(game, game.homeTeam, 'Under')}>
                             <PersonIcon />
                           </IconButton>

--- a/Client.React/src/utils/seasonRange.ts
+++ b/Client.React/src/utils/seasonRange.ts
@@ -1,0 +1,6 @@
+/** Descending list of season years from maxSeason down to minSeason, inclusive — the "most
+ * recent first" order every season dropdown in this app (WeekYearSelector, LeaderboardPage)
+ * presents to the user. */
+export function buildDescendingSeasonRange(minSeason: number, maxSeason: number): number[] {
+  return Array.from({ length: maxSeason - minSeason + 1 }, (_, i) => maxSeason - i);
+}

--- a/Client.React/src/utils/useNumericField.ts
+++ b/Client.React/src/utils/useNumericField.ts
@@ -1,10 +1,18 @@
 import { useEffect, useRef, useState, type ChangeEvent } from 'react';
 
+interface UseNumericFieldOptions {
+  // Strips a typed decimal point instead of accepting it — for fields whose backend DTO is
+  // an `int` (e.g. Juice/Cost settings), where a decimal value would otherwise display fine
+  // but 400 silently on save.
+  integerOnly?: boolean;
+}
+
 // Buffers a numeric <TextField>'s displayed value as a raw string so mid-edit states
 // (empty, "-", "17.") aren't stomped back to a parsed number on every keystroke. Only
 // pushes a value upward once it actually parses to a finite number; resyncs from `value`
 // on a genuinely external change (not one this hook itself just committed) and on blur.
-export function useNumericField(value: number, onChange: (n: number) => void) {
+export function useNumericField(value: number, onChange: (n: number) => void, options?: UseNumericFieldOptions) {
+  const integerOnly = options?.integerOnly ?? false;
   const [raw, setRaw] = useState(String(value));
   const lastCommitted = useRef(value);
   useEffect(() => {
@@ -18,10 +26,11 @@ export function useNumericField(value: number, onChange: (n: number) => void) {
   return {
     value: raw,
     onChange: (e: ChangeEvent<HTMLInputElement>) => {
-      const str = e.target.value;
+      const typed = e.target.value;
+      const str = integerOnly ? (typed.startsWith('-') ? '-' : '') + typed.replace(/\D/g, '') : typed;
       setRaw(str);
       const parsed = Number(str);
-      if (str.trim() !== '' && Number.isFinite(parsed)) {
+      if (str.trim() !== '' && str !== '-' && Number.isFinite(parsed)) {
         lastCommitted.current = parsed;
         onChange(parsed);
       }

--- a/Client.React/src/utils/useNumericField.ts
+++ b/Client.React/src/utils/useNumericField.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef, useState, type ChangeEvent } from 'react';
+
+// Buffers a numeric <TextField>'s displayed value as a raw string so mid-edit states
+// (empty, "-", "17.") aren't stomped back to a parsed number on every keystroke. Only
+// pushes a value upward once it actually parses to a finite number; resyncs from `value`
+// on a genuinely external change (not one this hook itself just committed) and on blur.
+export function useNumericField(value: number, onChange: (n: number) => void) {
+  const [raw, setRaw] = useState(String(value));
+  const lastCommitted = useRef(value);
+  useEffect(() => {
+    // Skip if `value` only changed because our own onChange call just pushed it —
+    // otherwise a mid-edit string that already parses to the new value (e.g. "17."
+    // while committing 17) gets its trailing characters stomped on the very next render.
+    if (value === lastCommitted.current) return;
+    lastCommitted.current = value;
+    setRaw(String(value));
+  }, [value]);
+  return {
+    value: raw,
+    onChange: (e: ChangeEvent<HTMLInputElement>) => {
+      const str = e.target.value;
+      setRaw(str);
+      const parsed = Number(str);
+      if (str.trim() !== '' && Number.isFinite(parsed)) {
+        lastCommitted.current = parsed;
+        onChange(parsed);
+      }
+    },
+    // Leaving the field empty or mid-typed ("-", "17.") snaps back to the last valid number
+    // once the user clicks away, rather than silently saving a value that doesn't match what's
+    // displayed.
+    onBlur: () => setRaw(String(value)),
+  };
+}

--- a/Server.UnitTests/LeagueInviteLinkTests.cs
+++ b/Server.UnitTests/LeagueInviteLinkTests.cs
@@ -464,21 +464,29 @@ public class LeagueInviteLinkTests
     }
 
     [Fact]
-    public async Task JoinViaLink_ReturnsNoContent_WhenSuccessful()
+    public async Task JoinViaLink_CreatesPendingMembershipInvite_RatherThanJoiningDirectly()
     {
-        var link = new LeagueInviteLink { Token = "tok", LeagueId = 1, League = new LeagueInfo { Id = 1, LeagueName = "L" }, ExpiresAt = DateTimeOffset.UtcNow.AddHours(1) };
+        // frizat: an already-authenticated user clicking a share link used to be added to the
+        // league immediately, with no way to decline — that's inconsistent with the "Invite
+        // Player" flow, which creates a pending invite an existing user must explicitly accept
+        // or decline via PendingInviteBanner. Route link-joins through the same mechanism so
+        // both invite paths behave identically for an existing user; only a brand-new user's
+        // register-and-join-in-one-step path is unaffected by this change.
+        var link = new LeagueInviteLink { Token = "tok", LeagueId = 1, CreatedByUserId = OwnerId, League = new LeagueInfo { Id = 1, LeagueName = "L" }, ExpiresAt = DateTimeOffset.UtcNow.AddHours(1) };
         var linkService = Substitute.For<ILeagueInviteLinkService>();
         linkService.ValidateAsync("tok").Returns(link);
 
         var repo = Substitute.For<ILeagueRepository>();
         repo.UserExistsInLeagueAsync(MemberId, 1).Returns(false);
 
-        var controller = BuildController(BuildPrincipal(MemberId), repo: repo, linkService: linkService);
+        var membershipInviteService = Substitute.For<ILeagueMembershipInviteService>();
+
+        var controller = BuildController(BuildPrincipal(MemberId), repo: repo, linkService: linkService, membershipInviteService: membershipInviteService);
 
         var result = await controller.JoinViaLink("tok");
 
         Assert.IsType<NoContentResult>(result);
-        await repo.Received(1).AddLeagueUserMappingAsync(Arg.Is<LeagueUserMapping>(m =>
-            m.LeagueId == 1 && m.UserId == MemberId));
+        await membershipInviteService.Received(1).CreateOrReopenAsync(1, MemberId, OwnerId);
+        await repo.DidNotReceiveWithAnyArgs().AddLeagueUserMappingAsync(default!);
     }
 }

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -889,8 +889,13 @@ public class LeagueController(
         var link = await leagueInviteLinkService.ValidateAsync(token);
         if (link is null) return NotFound();
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
-        if (!await TryAddUserToLeagueAsync(userId, link.LeagueId))
+        if (await repo.UserExistsInLeagueAsync(userId, link.LeagueId))
             return Conflict("You are already a member of this league.");
+        // An already-authenticated user clicking a share link gets the same pending-invite +
+        // banner treatment as the "Invite Player" flow (see InviteToLeague above) — not an
+        // instant, undo-less join. Only a brand-new user's register-and-join-in-one-step path
+        // (AuthController.CreateUser's InviteLinkToken branch) still joins directly.
+        await membershipInviteService.CreateOrReopenAsync(link.LeagueId, userId, link.CreatedByUserId);
         return NoContent();
     }
 


### PR DESCRIPTION
## Summary
Promotes 7 PRs merged to `dev` since the last cutover (#256):

- #257 — fix: Scores Matrix view — spell out OVER/UNDER instead of a small corner arrow icon
- #258 — feat: existing users joining via a shareable link get the same pending-invite banner as Invite Player
- #259 — feat: Leaderboard season selector — view standings from previous years, like ESPN
- #260 — fix: Matrix view pick badge — background color is the only win/loss signal now
- #261 — docs: explain Invite Player vs Invite Link on the League Portal
- #262 — fix: juice settings number input race + frontend-design audit cleanup
- #263 — fix: enforce whole numbers on Juice/Cost settings fields

## Test plan
- [x] Each PR passed its own CI (backend/frontend build & test, demo e2e, demo replay e2e, Docker parity, secret scan) before merging to `dev`
- [x] #262 and #263 were additionally live-verified on `dev.ivleague.xyz` after deploy (Scores page redesign, Juice settings number-input fix, integer-only enforcement)
- [x] Railway dev + Vercel preview both deployed cleanly for every merge commit in this range

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs