### PR TITLE
fix: address 5 follow-up findings from the season-window code-review pass

### DIFF
--- a/Client.React/src/__tests__/leaderboard.test.tsx
+++ b/Client.React/src/__tests__/leaderboard.test.tsx
@@ -245,6 +245,51 @@ describe('LeaderboardPage — season selector', () => {
     resolveLeagueTwo([createLeaderboardEntry({ userId: '789', userName: 'LeagueTwoUser', rank: '1', total: 9, weekResults: [] })]);
     await screen.findByText('LeagueTwoUser');
   });
+
+  // /code-review: the season selector's own race is prevented by disabling it mid-fetch (see the
+  // test above), but AppLayout's separate league-switcher chip lives outside this page — nothing
+  // stops a user from switching league A -> B -> A again while earlier fetches are still in
+  // flight, and the fetch effect had no staleness guard: whichever response happened to resolve
+  // last was applied, regardless of whether it matched the currently-selected league.
+  it('ignores a stale response from an abandoned league switch, even if it resolves after a newer one', async () => {
+    mockedGetLeaderboard.mockResolvedValueOnce([
+      createLeaderboardEntry({ userId: '1', userName: 'LeagueOneUser', rank: '1', total: 1, weekResults: [] }),
+    ]);
+    const { rerender } = renderPage();
+    await screen.findByText('LeagueOneUser');
+
+    const rerenderWithLeague = (leagueId: number) => {
+      sessionState.currentLeague = leagueId;
+      rerender(
+        <ThemeProvider theme={createAppTheme('light')}>
+          <MemoryRouter initialEntries={['/leaderboard']}>
+            <Routes>
+              <Route path="/leaderboard" element={<LeaderboardPage adapter={mockAdapter} />} />
+              <Route path="/leaguepicker" element={<div>League Picker</div>} />
+            </Routes>
+          </MemoryRouter>
+        </ThemeProvider>,
+      );
+    };
+
+    let resolveLeagueTwo!: (value: ReturnType<typeof createLeaderboardEntry>[]) => void;
+    mockedGetLeaderboard.mockImplementationOnce(() => new Promise((res) => { resolveLeagueTwo = res; }));
+    rerenderWithLeague(2); // switch to league 2 — fetch starts, left pending
+
+    let resolveLeagueThree!: (value: ReturnType<typeof createLeaderboardEntry>[]) => void;
+    mockedGetLeaderboard.mockImplementationOnce(() => new Promise((res) => { resolveLeagueThree = res; }));
+    rerenderWithLeague(3); // switch again before league 2's fetch ever resolved
+
+    resolveLeagueThree([createLeaderboardEntry({ userId: '3', userName: 'LeagueThreeUser', rank: '1', total: 3, weekResults: [] })]);
+    await screen.findByText('LeagueThreeUser');
+
+    // The abandoned league-2 request finally resolves — its data must NOT overwrite league 3's,
+    // which is what's actually selected now.
+    resolveLeagueTwo([createLeaderboardEntry({ userId: '2', userName: 'LeagueTwoUser', rank: '1', total: 2, weekResults: [] })]);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByText('LeagueTwoUser')).not.toBeInTheDocument();
+    expect(screen.getByText('LeagueThreeUser')).toBeInTheDocument();
+  });
 });
 
 describe('LeaderboardPage — week-cell colors', () => {

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -74,15 +74,24 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
 
   useEffect(() => {
     if (!currentLeague || season == null) return;
+    // /code-review: the season selector's own race is prevented elsewhere by disabling it
+    // mid-fetch, but AppLayout's separate league-switcher chip can change `currentLeague` while
+    // this effect's previous run is still in flight — nothing stops league A -> B -> A happening
+    // before any of those fetches resolve. `ignore` is this run's own flag, closed over fresh on
+    // every dependency change; a response is only applied if this exact run is still the latest
+    // one when it resolves.
+    let ignore = false;
     const run = async () => {
       if (hasLoadedOnce.current) setRefreshing(true); else setLoading(true);
       const data = await getLeaderboard(currentLeague, season);
+      if (ignore) return;
       setLeaderboard(data ?? []);
       hasLoadedOnce.current = true;
       setLoading(false);
       setRefreshing(false);
     };
     void run();
+    return () => { ignore = true; };
   }, [currentLeague, season]);
 
   const seasonOptions = useMemo(() => {

--- a/Server.UnitTests/InvitationServiceTests.cs
+++ b/Server.UnitTests/InvitationServiceTests.cs
@@ -1,7 +1,10 @@
 using FourPlayWebApp.Server.Data;
 using FourPlayWebApp.Server.Services;
 using FourPlayWebApp.Server.Models;
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Models.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 using Xunit;
@@ -193,6 +196,55 @@ namespace FourPlayWebApp.Server.UnitTests
             var (service, _) = BuildService(nameof(DeleteInvitationAsync_NonExistentId_DoesNotThrow));
 
             await service.DeleteInvitationAsync(999999);
+        }
+
+        // /code-review: CreateInvitationAsync's upsert has the identical TOCTOU race
+        // LeagueMembershipInviteService.CreateOrReopenAsync guards against (see its own comment
+        // and CreateOrReopenAsync_ConcurrentCallsForSameNewPair_BothSucceed_ExactlyOneRowCreated)
+        // — two concurrent requests inviting the same not-yet-invited (Email, LeagueId) pair can
+        // both read `existing == null` before either writes, and the loser's SaveChangesAsync
+        // throws an unhandled DbUpdateException on the unique-index violation instead of the
+        // caller getting a clean result. The InMemory provider used by BuildService above doesn't
+        // enforce unique indexes, so this needs a real constraint-enforcing provider (SQLite,
+        // mirroring LeagueMembershipInviteServiceTests' setup) to actually reproduce.
+        private static ApplicationDbContext OpenSqliteDb(string dbName) =>
+            new(new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseSqlite($"Data Source={dbName};Mode=Memory;Cache=Shared")
+                .Options);
+
+        private static IDbContextFactory<ApplicationDbContext> BuildSqliteFactory(string dbName)
+        {
+            var factory = Substitute.For<IDbContextFactory<ApplicationDbContext>>();
+            factory.CreateDbContextAsync().Returns(_ => Task.FromResult(OpenSqliteDb(dbName)));
+            return factory;
+        }
+
+        [Fact]
+        public async Task CreateInvitationAsync_ConcurrentCallsForSameNewPair_BothSucceed_ExactlyOneRowCreated()
+        {
+            var dbName = nameof(CreateInvitationAsync_ConcurrentCallsForSameNewPair_BothSucceed_ExactlyOneRowCreated);
+            await using var keepAlive = new SqliteConnection($"Data Source={dbName};Mode=Memory;Cache=Shared");
+            await keepAlive.OpenAsync();
+            await using (var init = OpenSqliteDb(dbName)) { await init.Database.EnsureCreatedAsync(); }
+            await using (var seed = OpenSqliteDb(dbName)) {
+                seed.Users.Add(new ApplicationUser {
+                    Id = "owner", UserName = "owner", NormalizedUserName = "OWNER", Email = "owner@example.com",
+                    SecurityStamp = Guid.NewGuid().ToString(), ConcurrencyStamp = Guid.NewGuid().ToString(),
+                });
+                seed.LeagueInfo.Add(new LeagueInfo { Id = 1, LeagueName = "Test", OwnerUserId = "owner" });
+                await seed.SaveChangesAsync();
+            }
+            var factory = BuildSqliteFactory(dbName);
+            var emailSender = Substitute.For<IEmailSender>();
+            var serviceA = new InvitationService(factory, emailSender);
+            var serviceB = new InvitationService(factory, emailSender);
+
+            await Task.WhenAll(
+                serviceA.CreateInvitationAsync("race@example.com", "owner", leagueId: 1),
+                serviceB.CreateInvitationAsync("race@example.com", "owner", leagueId: 1));
+
+            await using var verify = OpenSqliteDb(dbName);
+            Assert.Equal(1, await verify.Invitations.CountAsync(i => i.Email == "race@example.com" && i.LeagueId == 1));
         }
     }
 }

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -352,6 +352,55 @@ public class LeagueOwnershipTests
         await repo.DidNotReceive().GetLeagueMemberCountAsync(1, Arg.Any<int>(), Arg.Any<LeagueType>());
     }
 
+    // /code-review: GetLeagueCost/UpdateLeagueJuice/RollForwardJuice/RemoveLeagueMember all called
+    // GetLeagueInfoAsync(leagueId) unguarded — its real (non-mocked) implementation uses
+    // FirstAsync(), which throws InvalidOperationException for a missing league, same as
+    // DeleteLeague's existing guard above. Without a try/catch, a bad/deleted leagueId 500s
+    // instead of a clean 404, inconsistent with every other endpoint in this controller.
+    [Fact]
+    public async Task GetLeagueCost_ReturnsNotFound_WhenLeagueDoesNotExist()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(999).Returns(Task.FromException<LeagueInfo>(new InvalidOperationException("Sequence contains no elements")));
+
+        var result = await ctrl.GetLeagueCost(999);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdateLeagueJuice_ReturnsNotFound_WhenLeagueDoesNotExist()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(999).Returns(Task.FromException<LeagueInfo>(new InvalidOperationException("Sequence contains no elements")));
+
+        var result = await ctrl.UpdateLeagueJuice(999, 2025, new LeagueJuiceUpdateDto(13, 10, 6, 5));
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task RollForwardJuice_ReturnsNotFound_WhenLeagueDoesNotExist()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(999).Returns(Task.FromException<LeagueInfo>(new InvalidOperationException("Sequence contains no elements")));
+
+        var result = await ctrl.RollForwardJuice(999, 2026);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task RemoveLeagueMember_ReturnsNotFound_WhenLeagueDoesNotExist()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(999).Returns(Task.FromException<LeagueInfo>(new InvalidOperationException("Sequence contains no elements")));
+
+        var result = await ctrl.RemoveLeagueMember(999, "victim-003");
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
     // ── GetAllLeaguesCost (admin platform-wide cost dashboard, frizat-fug) ──────
 
     [Fact]

--- a/Server.UnitTests/LeagueRepositoryTests.cs
+++ b/Server.UnitTests/LeagueRepositoryTests.cs
@@ -244,6 +244,34 @@ public class LeagueRepositoryTests
         Assert.Equal(0, count);
     }
 
+    // /code-review: GetSeasonDateRangeAsync's CFB branch computed the season end as
+    // WeekEndDate.ToDateTime(TimeOnly.MinValue) — midnight at the *start* of the last calendar
+    // day, not end-of-day. A member joining later that same day (a real day, still within the
+    // season by any reasonable reading of WeekEndDate) was incorrectly excluded, inconsistent
+    // with CfbCurrentSlateService's TimeOnly.MaxValue convention for the same "end of this date"
+    // concept elsewhere in the codebase.
+    [Fact]
+    public async Task GetLeagueMemberCountAsync_SeasonAware_Cfb_CountsMemberWhoJoinedLaterOnTheSeasonsLastCalendarDay()
+    {
+        var factory = new DbContextFactoryStub(nameof(GetLeagueMemberCountAsync_SeasonAware_Cfb_CountsMemberWhoJoinedLaterOnTheSeasonsLastCalendarDay));
+        var seedDb = factory.CreateDbContext();
+        seedDb.CfbSeasonWeekConfigs.Add(new CfbSeasonWeekConfig {
+            Season = 2024, EspnWeekNumber = 1, IvLeagueWeekNumber = 1,
+            WeekStartDate = new DateOnly(2024, 8, 20), WeekEndDate = new DateOnly(2025, 1, 15),
+        });
+        // Joined at 6pm UTC on the season's last calendar day — still that day, still in-season.
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping {
+            LeagueId = 1, UserId = "joined-late-on-last-day",
+            DateCreated = new DateTimeOffset(2025, 1, 15, 18, 0, 0, TimeSpan.Zero),
+        });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        var count = await repo.GetLeagueMemberCountAsync(1, 2024, LeagueType.Cfb);
+
+        Assert.Equal(1, count);
+    }
+
     [Fact]
     public async Task GetLeagueMemberCountAsync_SeasonAware_ExcludesMemberWhoJoinedAfterTheSeasonEnded()
     {

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -738,12 +738,10 @@ public class LeagueController(
     [HttpGet("{leagueId:int}/cost")]
     [ProducesResponseType(typeof(LeagueCostDto), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetLeagueCost(int leagueId, int? season = null) {
-        var league = await repo.GetLeagueInfoAsync(leagueId);
-        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != userId)
-            return Forbid();
+        var (league, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         var count = season.HasValue
-            ? await repo.GetLeagueMemberCountAsync(leagueId, season.Value, league.LeagueType)
+            ? await repo.GetLeagueMemberCountAsync(leagueId, season.Value, league!.LeagueType)
             : await repo.GetLeagueMemberCountAsync(leagueId);
         return Ok(new LeagueCostDto(count, ComputeLeagueCost(count)));
     }
@@ -777,10 +775,8 @@ public class LeagueController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> UpdateLeagueJuice(int leagueId, int season, [FromBody] LeagueJuiceUpdateDto dto) {
-        var league = await repo.GetLeagueInfoAsync(leagueId);
-        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != userId)
-            return Forbid();
+        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         var existing = await repo.GetLeagueJuiceMappingAsync(leagueId, season);
         if (existing is null) return NotFound($"No juice mapping for league {leagueId} season {season}.");
         existing.Juice = dto.Juice;
@@ -796,10 +792,8 @@ public class LeagueController(
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> RollForwardJuice(int leagueId, int toSeason) {
-        var league = await repo.GetLeagueInfoAsync(leagueId);
-        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != userId)
-            return Forbid();
+        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         if (await repo.GetLeagueJuiceMappingAsync(leagueId, toSeason) is not null)
             return BadRequest($"Juice mapping for season {toSeason} already exists.");
         var priorMapping = (await repo.GetLeagueJuiceMappingAsync(leagueId))
@@ -823,10 +817,8 @@ public class LeagueController(
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> RemoveLeagueMember(int leagueId, string userId) {
-        var league = await repo.GetLeagueInfoAsync(leagueId);
-        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
-            return Forbid();
+        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         await repo.RemoveLeagueUserMappingAsync(leagueId, userId);
         return NoContent();
     }
@@ -839,18 +831,8 @@ public class LeagueController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> DeleteLeague(int leagueId) {
-        LeagueInfo league;
-        try {
-            league = await repo.GetLeagueInfoAsync(leagueId);
-        } catch (InvalidOperationException) {
-            // GetLeagueInfoAsync's real implementation throws (FirstAsync) rather than returning
-            // null for a missing league — realistic here specifically: a double-submitted delete
-            // (slow network, already-deleted league) should 404, not 500.
-            return NotFound();
-        }
-        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
-            return Forbid();
+        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         await repo.DeleteLeagueAsync(leagueId);
         return NoContent();
     }
@@ -861,14 +843,11 @@ public class LeagueController(
     [ProducesResponseType(typeof(LeagueInviteLinkDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<LeagueInviteLinkDto>> GenerateInviteLink(int leagueId) {
-        LeagueInfo league;
-        try { league = await repo.GetLeagueInfoAsync(leagueId); }
-        catch (InvalidOperationException) { return NotFound(); }
+        var (league, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
-            return Forbid();
         var link = await leagueInviteLinkService.GenerateAsync(leagueId, callerId);
-        return Ok(new LeagueInviteLinkDto(link.Token, link.LeagueId, league.LeagueName, link.ExpiresAt));
+        return Ok(new LeagueInviteLinkDto(link.Token, link.LeagueId, league!.LeagueName, link.ExpiresAt));
     }
 
     [HttpGet("join/{token}")]
@@ -924,27 +903,19 @@ public class LeagueController(
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<LeagueInviteLinkDto>> GetCurrentInviteLink(int leagueId) {
-        LeagueInfo league;
-        try { league = await repo.GetLeagueInfoAsync(leagueId); }
-        catch (InvalidOperationException) { return NotFound(); }
-        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
-            return Forbid();
+        var (league, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         var link = await leagueInviteLinkService.GetCurrentAsync(leagueId);
         if (link is null) return NotFound();
-        return Ok(new LeagueInviteLinkDto(link.Token, link.LeagueId, league.LeagueName, link.ExpiresAt));
+        return Ok(new LeagueInviteLinkDto(link.Token, link.LeagueId, league!.LeagueName, link.ExpiresAt));
     }
 
     [HttpDelete("{leagueId:int}/invite-link")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> RevokeInviteLink(int leagueId) {
-        LeagueInfo league;
-        try { league = await repo.GetLeagueInfoAsync(leagueId); }
-        catch (InvalidOperationException) { return NotFound(); }
-        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
-            return Forbid();
+        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         await leagueInviteLinkService.RevokeAsync(leagueId);
         return NoContent();
     }
@@ -953,12 +924,8 @@ public class LeagueController(
     [ProducesResponseType(typeof(IReadOnlyList<InvitationDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<IReadOnlyList<InvitationDto>>> GetLeagueInvitations(int leagueId) {
-        LeagueInfo league;
-        try { league = await repo.GetLeagueInfoAsync(leagueId); }
-        catch (InvalidOperationException) { return NotFound(); }
-        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
-            return Forbid();
+        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         var invitations = await invitationService.GetInvitationsByLeagueAsync(leagueId);
         return Ok(invitations.ToDtoList());
     }
@@ -967,12 +934,8 @@ public class LeagueController(
     [ProducesResponseType(typeof(IReadOnlyList<MembershipInviteStatusDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<IReadOnlyList<MembershipInviteStatusDto>>> GetLeagueMembershipInvites(int leagueId) {
-        LeagueInfo league;
-        try { league = await repo.GetLeagueInfoAsync(leagueId); }
-        catch (InvalidOperationException) { return NotFound(); }
-        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
-            return Forbid();
+        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         var invites = await membershipInviteService.GetByLeagueAsync(leagueId);
         return Ok(invites.ToStatusDtoList());
     }
@@ -983,12 +946,9 @@ public class LeagueController(
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> InviteToLeague(int leagueId, [FromBody] LeagueInviteDto dto) {
-        LeagueInfo league;
-        try { league = await repo.GetLeagueInfoAsync(leagueId); }
-        catch (InvalidOperationException) { return NotFound(); }
+        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
-            return Forbid();
 
         // Someone who already has an account (owns a league or belongs to one) must be
         // addable to a NEW league directly — routing them through CreateInvitationAsync would
@@ -1044,6 +1004,25 @@ public class LeagueController(
 
         await membershipInviteService.MarkDeclinedAsync(id);
         return NoContent();
+    }
+
+    /// <summary>
+    /// Shared preamble for the 10+ endpoints that load a league by id and require the caller to
+    /// own it (or be an admin): 404 if the league doesn't exist (GetLeagueInfoAsync's real
+    /// implementation uses FirstAsync(), which throws InvalidOperationException rather than
+    /// returning null), 403 if the caller is neither the owner nor an admin.
+    /// </summary>
+    private async Task<(LeagueInfo? league, ActionResult? error)> LoadOwnedLeagueAsync(int leagueId) {
+        LeagueInfo league;
+        try {
+            league = await repo.GetLeagueInfoAsync(leagueId);
+        } catch (InvalidOperationException) {
+            return (null, NotFound());
+        }
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
+            return (null, Forbid());
+        return (league, null);
     }
 
     /// <summary>

--- a/Server/Services/InvitationService.cs
+++ b/Server/Services/InvitationService.cs
@@ -46,6 +46,7 @@ public class InvitationService(IDbContextFactory<ApplicationDbContext> dbContext
             invitation.InvitedByUserId = invitedByUserId;
             invitation.ExpiresAt = DateTimeOffset.UtcNow.AddDays(7);
             Log.Information("Invitation for {Email} to league {LeagueId} refreshed by {UserId}", email, leagueId, invitedByUserId);
+            await dbContext.SaveChangesAsync();
         } else {
             invitation = new Invitation {
                 Email = email,
@@ -56,9 +57,17 @@ public class InvitationService(IDbContextFactory<ApplicationDbContext> dbContext
             };
             dbContext.Invitations.Add(invitation);
             Log.Information("Invitation created for {Email} by {UserId}", email, invitedByUserId);
+            try {
+                await dbContext.SaveChangesAsync();
+            } catch (DbUpdateException) {
+                // TOCTOU: a concurrent request already inserted this exact (Email, LeagueId) pair
+                // between our read and write — same race LeagueMembershipInviteService.CreateOrReopenAsync
+                // guards against. Re-read whichever row won so the caller gets a usable Invitation
+                // back instead of an unhandled 500.
+                invitation = await dbContext.Invitations
+                    .FirstAsync(i => i.Email == email && i.LeagueId == leagueId);
+            }
         }
-
-        await dbContext.SaveChangesAsync();
 
         if (!string.IsNullOrWhiteSpace(baseUrl)) {
             try {

--- a/Server/Services/Repositories/LeagueRepository.cs
+++ b/Server/Services/Repositories/LeagueRepository.cs
@@ -329,7 +329,12 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
             var weeks = await db.CfbSeasonWeekConfigs.Where(c => c.Season == season).ToListAsync();
             if (weeks.Count == 0) return null;
             var start = weeks.Min(w => w.WeekStartDate).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
-            var end = weeks.Max(w => w.WeekEndDate).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+            // MaxValue (end of day), not MinValue — a DateOnly season end means the whole of that
+            // calendar day is still in-season, matching CfbCurrentSlateService's convention for
+            // the same "end of this date" concept. /code-review caught this using MinValue
+            // (midnight at the *start* of the last day), which excluded anyone active later that
+            // same day.
+            var end = weeks.Max(w => w.WeekEndDate).ToDateTime(TimeOnly.MaxValue, DateTimeKind.Utc);
             return (start, end);
         } else {
             var weeks = await db.NflSeasonWeekConfigs.Where(c => c.Season == season).ToListAsync();


### PR DESCRIPTION
## Summary

All 5 were flagged as real but out-of-scope while reviewing PR #265, since they touched already-merged, unrelated code — fixing them now as their own focused PR so the season-window work could ship without scope creep, per the user's request to address them promptly.

1. **`InvitationService.CreateInvitationAsync`** had the identical TOCTOU race `LeagueMembershipInviteService.CreateOrReopenAsync` already guards against — two concurrent invites for the same not-yet-invited `(Email, LeagueId)` pair could both read `existing == null` before either wrote, and the loser's `SaveChangesAsync` threw an unhandled `DbUpdateException`. Fixed identically: catch the unique-index violation and re-read whichever row won.

2. **`LeagueController`**: `GetLeagueCost`/`UpdateLeagueJuice`/`RollForwardJuice`/`RemoveLeagueMember` called `GetLeagueInfoAsync(leagueId)` unguarded — a missing/deleted league 500'd instead of 404, inconsistent with 7 other endpoints in the same controller. Extracted the whole "load league, 404 if missing, 403 if not owner/admin" preamble (previously copy-pasted across all 11 call sites) into one shared `LoadOwnedLeagueAsync` helper, fixing the 4 unguarded endpoints and de-duplicating the other 7 in the same pass.

3. **`LeagueRepository.GetSeasonDateRangeAsync`**'s CFB branch computed the season end as `WeekEndDate.ToDateTime(TimeOnly.MinValue)` — midnight at the *start* of the last calendar day, not end-of-day — silently excluding a member who joined later that same, still-in-season day from that season's cost dashboard. Fixed to `TimeOnly.MaxValue`, matching `CfbCurrentSlateService`'s existing end-of-day convention for the same concept.

4. **`LeaderboardPage`**'s data-fetch effect had no staleness guard for `AppLayout`'s league-switcher chip (a separate control outside this page): switching leagues rapidly could let an abandoned request's response resolve after a newer one and silently overwrite the correct, currently-selected league's standings. Added the standard ignore-flag effect-cleanup guard.

Also searched the full repo for the `ConfiguredSeason`-style hardcoded-year bug class already fixed in PR #265 — found no other instance of that severity; two low-severity, non-urgent items noted (a now-mostly-dead frontend fallback constant, cosmetic example-copy in RulesPage) but not actioned here.

## Test plan
- [x] `dotnet test` — 686/686 passed
- [x] `npm run test -- --run` — 48 files / 440 tests passed
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:e2e -- --project=chromium` — 80/80 passed (1 flake under parallel load re-confirmed passing in isolation, unrelated to this diff)
- [x] Every fix has a dedicated regression test confirmed red before the fix, green after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs