### PR TITLE
Promote dev to main — PRs #265-#266

### DIFF
--- a/Client.React/src/__tests__/leaderboard.test.tsx
+++ b/Client.React/src/__tests__/leaderboard.test.tsx
@@ -245,6 +245,51 @@ describe('LeaderboardPage — season selector', () => {
     resolveLeagueTwo([createLeaderboardEntry({ userId: '789', userName: 'LeagueTwoUser', rank: '1', total: 9, weekResults: [] })]);
     await screen.findByText('LeagueTwoUser');
   });
+
+  // /code-review: the season selector's own race is prevented by disabling it mid-fetch (see the
+  // test above), but AppLayout's separate league-switcher chip lives outside this page — nothing
+  // stops a user from switching league A -> B -> A again while earlier fetches are still in
+  // flight, and the fetch effect had no staleness guard: whichever response happened to resolve
+  // last was applied, regardless of whether it matched the currently-selected league.
+  it('ignores a stale response from an abandoned league switch, even if it resolves after a newer one', async () => {
+    mockedGetLeaderboard.mockResolvedValueOnce([
+      createLeaderboardEntry({ userId: '1', userName: 'LeagueOneUser', rank: '1', total: 1, weekResults: [] }),
+    ]);
+    const { rerender } = renderPage();
+    await screen.findByText('LeagueOneUser');
+
+    const rerenderWithLeague = (leagueId: number) => {
+      sessionState.currentLeague = leagueId;
+      rerender(
+        <ThemeProvider theme={createAppTheme('light')}>
+          <MemoryRouter initialEntries={['/leaderboard']}>
+            <Routes>
+              <Route path="/leaderboard" element={<LeaderboardPage adapter={mockAdapter} />} />
+              <Route path="/leaguepicker" element={<div>League Picker</div>} />
+            </Routes>
+          </MemoryRouter>
+        </ThemeProvider>,
+      );
+    };
+
+    let resolveLeagueTwo!: (value: ReturnType<typeof createLeaderboardEntry>[]) => void;
+    mockedGetLeaderboard.mockImplementationOnce(() => new Promise((res) => { resolveLeagueTwo = res; }));
+    rerenderWithLeague(2); // switch to league 2 — fetch starts, left pending
+
+    let resolveLeagueThree!: (value: ReturnType<typeof createLeaderboardEntry>[]) => void;
+    mockedGetLeaderboard.mockImplementationOnce(() => new Promise((res) => { resolveLeagueThree = res; }));
+    rerenderWithLeague(3); // switch again before league 2's fetch ever resolved
+
+    resolveLeagueThree([createLeaderboardEntry({ userId: '3', userName: 'LeagueThreeUser', rank: '1', total: 3, weekResults: [] })]);
+    await screen.findByText('LeagueThreeUser');
+
+    // The abandoned league-2 request finally resolves — its data must NOT overwrite league 3's,
+    // which is what's actually selected now.
+    resolveLeagueTwo([createLeaderboardEntry({ userId: '2', userName: 'LeagueTwoUser', rank: '1', total: 2, weekResults: [] })]);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByText('LeagueTwoUser')).not.toBeInTheDocument();
+    expect(screen.getByText('LeagueThreeUser')).toBeInTheDocument();
+  });
 });
 
 describe('LeaderboardPage — week-cell colors', () => {

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -74,15 +74,24 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
 
   useEffect(() => {
     if (!currentLeague || season == null) return;
+    // /code-review: the season selector's own race is prevented elsewhere by disabling it
+    // mid-fetch, but AppLayout's separate league-switcher chip can change `currentLeague` while
+    // this effect's previous run is still in flight — nothing stops league A -> B -> A happening
+    // before any of those fetches resolve. `ignore` is this run's own flag, closed over fresh on
+    // every dependency change; a response is only applied if this exact run is still the latest
+    // one when it resolves.
+    let ignore = false;
     const run = async () => {
       if (hasLoadedOnce.current) setRefreshing(true); else setLoading(true);
       const data = await getLeaderboard(currentLeague, season);
+      if (ignore) return;
       setLeaderboard(data ?? []);
       hasLoadedOnce.current = true;
       setLoading(false);
       setRefreshing(false);
     };
     void run();
+    return () => { ignore = true; };
   }, [currentLeague, season]);
 
   const seasonOptions = useMemo(() => {

--- a/Server.UnitTests/CfbCacheServiceTests.cs
+++ b/Server.UnitTests/CfbCacheServiceTests.cs
@@ -23,14 +23,19 @@ public class CfbCacheServiceTests
     private readonly ICfbLiveScoreFetcher _fetcher;
     private readonly IServiceScopeFactory _scopeFactory;
 
+    // StartDate/EndDate relative to "now" (not a fixed calendar date) so this slate is always
+    // "currently active" for the SeasonWindowResolver-based gate CfbCacheService now checks
+    // before fetching — tests below shouldn't have to also fight an unrelated off-season skip.
+    private static readonly DateOnly Today = DateOnly.FromDateTime(DateTime.UtcNow);
+
     private static readonly CfbSlateInfo DefaultSlateInfo = new(
         Id: 1, Season: 2026, SlateNumber: 5, Label: "Week 5", SlateType: "RegularSeason",
-        StartDate: new DateOnly(2026, 9, 27), EndDate: new DateOnly(2026, 9, 28), FirstGameUtc: null,
-        SpreadLockDatetime: new DateTime(2026, 9, 20, 12, 0, 0, DateTimeKind.Utc));
+        StartDate: Today.AddDays(-1), EndDate: Today.AddDays(1), FirstGameUtc: null,
+        SpreadLockDatetime: DateTime.UtcNow.AddDays(-7));
 
     private static readonly CfbSlates DefaultSlate = new() {
         Id = 1, Season = 2026, SlateNumber = 5, Label = "Week 5", SlateType = "RegularSeason",
-        StartDate = new DateOnly(2026, 9, 27), EndDate = new DateOnly(2026, 9, 28),
+        StartDate = Today.AddDays(-1), EndDate = Today.AddDays(1),
         EspnWeekNumber = 5, ScoringFormat = "Spread",
     };
 
@@ -41,6 +46,9 @@ public class CfbCacheServiceTests
         _fetcher = Substitute.For<ICfbLiveScoreFetcher>();
         _currentSlateService.GetCurrentSlateAsync().Returns(DefaultSlateInfo);
         _cfbRepo.GetSlateByIdAsync(DefaultSlate.Id).Returns(DefaultSlate);
+        // Default: a season is active, so existing tests keep exercising the live-fetch branch
+        // unchanged by the new off-season gate.
+        _currentSlateService.IsSeasonActiveAsync().Returns(true);
 
         var services = new ServiceCollection();
         services.AddSingleton(_currentSlateService);
@@ -105,6 +113,22 @@ public class CfbCacheServiceTests
         await WaitForScoresChangedAsync(svc);
 
         Assert.Equal(1, fireCount);
+    }
+
+    // Off-season gating — the poller must not hit ESPN when no season is active (frizat plan:
+    // wobbly-chasing-lynx). Previously CfbCurrentSlateService's ConfiguredSeason hardcode meant
+    // GetCurrentSlateAsync's null-ness happened to gate this correctly by accident; now that it
+    // always resolves *something*, IsSeasonActive is the purpose-built check instead.
+    [Fact]
+    public async Task GetScoresAsync_NeverFetches_WhenNoSeasonIsCurrentlyActive()
+    {
+        _currentSlateService.IsSeasonActiveAsync().Returns(false);
+
+        await using var svc = new CfbCacheService(_scopeFactory, _fetcher, initialDelay: TimeSpan.FromMilliseconds(50));
+        await Task.Delay(300);
+
+        Assert.Null(await svc.GetScoresAsync());
+        await _fetcher.DidNotReceive().FetchForSlateAsync(Arg.Any<CfbSlates>());
     }
 
     [Fact]

--- a/Server.UnitTests/CfbCurrentSlateServiceTests.cs
+++ b/Server.UnitTests/CfbCurrentSlateServiceTests.cs
@@ -1,0 +1,128 @@
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Services;
+using FourPlayWebApp.Server.Services.Repositories.Interfaces;
+using NSubstitute;
+using Xunit;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+// Direct unit tests for CfbCurrentSlateService — written while replacing its hardcoded
+// `ConfiguredSeason = 2026` constant + manual "season - 1" fallback with the shared
+// SeasonWindowResolver (frizat plan: wobbly-chasing-lynx). The season-2030 case below is
+// the actual regression test for the bug: the old hardcoded-year implementation could
+// never resolve any season other than 2026/2025 without a code change.
+public class CfbCurrentSlateServiceTests
+{
+    private static CfbSlates Slate(int season, int slateNumber, DateOnly start, DateOnly end) => new() {
+        Id = season * 100 + slateNumber,
+        Season = season,
+        SlateNumber = slateNumber,
+        Label = $"Slate {slateNumber}",
+        SlateType = "RegularSeason",
+        StartDate = start,
+        EndDate = end,
+    };
+
+    private static CfbCurrentSlateService BuildService(List<CfbSlates> slates, CfbSeasonWeekConfig? matchingConfig = null) {
+        var repo = Substitute.For<ICfbRepository>();
+        repo.GetAllSlatesAsync().Returns(slates);
+        foreach (var season in slates.Select(s => s.Season).Distinct()) {
+            // One config per slate in this season, so whichever slate the resolver picks as
+            // "active" always has a matching CfbSeasonWeekConfig row — not just the first slate.
+            var configs = slates.Where(s => s.Season == season).Select(s =>
+                matchingConfig is not null && matchingConfig.Season == season && matchingConfig.IvLeagueWeekNumber == s.SlateNumber
+                    ? matchingConfig
+                    : new CfbSeasonWeekConfig {
+                        Season = season,
+                        IvLeagueWeekNumber = s.SlateNumber,
+                        SpreadLockDatetime = DateTime.UtcNow,
+                    }).ToList();
+            repo.GetWeekConfigsForSeasonAsync(season).Returns(configs);
+        }
+        return new CfbCurrentSlateService(repo);
+    }
+
+    [Fact]
+    public async Task GetCurrentSlateAsync_ResolvesFromAnySeasonInTheDb_NoHardcodedYear() {
+        // Regression test for the hardcoded-ConfiguredSeason bug: season 2030 has no
+        // special-casing anywhere in the service — it must resolve purely from what's in
+        // the DB.
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var config = new CfbSeasonWeekConfig { Season = 2030, IvLeagueWeekNumber = 1, SpreadLockDatetime = DateTime.UtcNow };
+        var svc = BuildService([
+            Slate(2030, 1, today.AddDays(-3), today.AddDays(4)),
+        ], config);
+
+        var result = await svc.GetCurrentSlateAsync();
+
+        Assert.NotNull(result);
+        Assert.Equal(2030, result.Season);
+        Assert.Equal(1, result.SlateNumber);
+    }
+
+    [Fact]
+    public async Task GetCurrentSlateAsync_ReturnsActiveSlate_WhenTodayIsWithinOne() {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var svc = BuildService([
+            Slate(2026, 1, today.AddDays(-10), today.AddDays(-4)),
+            Slate(2026, 2, today.AddDays(-3), today.AddDays(4)), // active
+        ]);
+
+        var result = await svc.GetCurrentSlateAsync();
+
+        Assert.Equal(2, result!.SlateNumber);
+    }
+
+    [Fact]
+    public async Task GetCurrentSlateAsync_ReturnsMostRecentlyCompleted_OffSeason() {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var svc = BuildService([
+            Slate(2025, 3, today.AddDays(-60), today.AddDays(-53)),
+            Slate(2025, 4, today.AddDays(-30), today.AddDays(-23)), // most recently completed
+        ]);
+
+        var result = await svc.GetCurrentSlateAsync();
+
+        Assert.Equal(2025, result!.Season);
+        Assert.Equal(4, result.SlateNumber);
+    }
+
+    [Fact]
+    public async Task GetCurrentSlateAsync_ReturnsNull_WhenNoSlatesExistAtAll() {
+        var svc = BuildService([]);
+
+        var result = await svc.GetCurrentSlateAsync();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetCurrentSlateAsync_Throws_WhenResolvedSlateHasNoMatchingWeekConfig() {
+        // Existing data-integrity invariant (unchanged by this refactor): every CfbSlates
+        // row must have a matching CfbSeasonWeekConfig row.
+        var repo = Substitute.For<ICfbRepository>();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var slate = Slate(2026, 1, today.AddDays(-1), today.AddDays(1));
+        repo.GetAllSlatesAsync().Returns(new List<CfbSlates> { slate });
+        repo.GetWeekConfigsForSeasonAsync(2026).Returns(new List<CfbSeasonWeekConfig>());
+        var svc = new CfbCurrentSlateService(repo);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.GetCurrentSlateAsync());
+    }
+
+    [Fact]
+    public async Task IsSeasonActiveAsync_True_WhenTodayIsWithinASlateWindow() {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var svc = BuildService([Slate(2026, 1, today.AddDays(-3), today.AddDays(4))]);
+
+        Assert.True(await svc.IsSeasonActiveAsync());
+    }
+
+    [Fact]
+    public async Task IsSeasonActiveAsync_False_OffSeason() {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var svc = BuildService([Slate(2025, 4, today.AddDays(-60), today.AddDays(-53))]);
+
+        Assert.False(await svc.IsSeasonActiveAsync());
+    }
+}

--- a/Server.UnitTests/CfbLiveScoreFetcherTests.cs
+++ b/Server.UnitTests/CfbLiveScoreFetcherTests.cs
@@ -1,8 +1,11 @@
 using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Services;
 using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models;
+using FourPlayWebApp.Shared.Models.Data;
 using FourPlayWebApp.Shared.Models.Enum;
+using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 
 namespace FourPlayWebApp.Server.UnitTests;
@@ -14,7 +17,19 @@ namespace FourPlayWebApp.Server.UnitTests;
 /// </summary>
 public class CfbLiveScoreFetcherTests {
     private readonly ICfbApiService _cfbApi = Substitute.For<ICfbApiService>();
-    private CfbLiveScoreFetcher BuildFetcher() => new(_cfbApi);
+    private readonly ICfbRepository _cfbRepo = Substitute.For<ICfbRepository>();
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public CfbLiveScoreFetcherTests() {
+        // Default: no persisted rows for any slate, so existing tests (which never seed the repo)
+        // keep exercising the live-ESPN branch exactly as before this DB-first check was added.
+        _cfbRepo.GetScoresForSlateAsync(Arg.Any<int>()).Returns((IEnumerable<CfbScores>)[]);
+        var services = new ServiceCollection();
+        services.AddSingleton(_cfbRepo);
+        _scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+
+    private CfbLiveScoreFetcher BuildFetcher() => new(_cfbApi, _scopeFactory);
 
     private static EspnScores BuildScoreboard(
         string eventId = "401677183",
@@ -136,5 +151,89 @@ public class CfbLiveScoreFetcherTests {
         Assert.Null(result);
         await _cfbApi.DidNotReceiveWithAnyArgs().GetScoresByWeekAsync(default, default);
         await _cfbApi.DidNotReceive().GetCfpGamesAsync();
+    }
+
+    // /code-review caught the DB-first branch silently defaulting a missing EspnWeekNumber to
+    // week 0 instead of applying the same guard the ESPN-fallback path already used — even with
+    // persisted rows present, a slate with no week number is a data-integrity problem, not
+    // something to paper over.
+    [Fact]
+    public async Task FetchForSlateAsync_MissingEspnWeekNumber_ReturnsNull_EvenWithPersistedRows() {
+        var slate = BuildSlateMissingWeekNumber(); // EndDate 2025-12-20 — already ended
+        var rows = new List<CfbScores> {
+            new() { Id = 1, CfbSlateId = slate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "STATUS_FINAL", GameTime = new DateTimeOffset(2025, 12, 19, 18, 0, 0, TimeSpan.Zero) },
+        };
+        _cfbRepo.GetScoresForSlateAsync(slate.Id).Returns((IEnumerable<CfbScores>)rows);
+
+        var result = await BuildFetcher().FetchForSlateAsync(slate);
+
+        Assert.Null(result);
+        await _cfbApi.DidNotReceiveWithAnyArgs().GetScoresByWeekAsync(default, default);
+        await _cfbApi.DidNotReceive().GetCfpGamesAsync();
+    }
+
+    // ── DB-first: a slate whose games are already persisted (always FINAL — CfbScoresJob only
+    // writes finished games) is served from CfbScores instead of a live ESPN call, so 100
+    // concurrent viewers of the same past slate share one DB read instead of each hitting ESPN. ──
+
+    [Fact]
+    public async Task FetchForSlateAsync_WhenDbHasPersistedRowsForTheSlate_ReturnsDbBuiltScores_NeverCallsEspn() {
+        var slate = BuildRegularSeasonSlate();
+        var rows = new List<CfbScores> {
+            new() { Id = 1, CfbSlateId = slate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "STATUS_FINAL", GameTime = new DateTimeOffset(2025, 9, 27, 18, 0, 0, TimeSpan.Zero) },
+        };
+        _cfbRepo.GetScoresForSlateAsync(slate.Id).Returns((IEnumerable<CfbScores>)rows);
+
+        var result = await BuildFetcher().FetchForSlateAsync(slate);
+
+        Assert.NotNull(result);
+        var comp = result!.Events!.Single().Competitions[0];
+        var home = comp.Competitors.Single(c => c.HomeAway == HomeAway.Home);
+        Assert.Equal("OSU", home.Team.Abbreviation);
+        Assert.Equal(28, home.Score);
+        Assert.Equal(TypeName.StatusFinal, comp.Status.Type.Name);
+        await _cfbApi.DidNotReceiveWithAnyArgs().GetScoresByWeekAsync(default, default);
+        await _cfbApi.DidNotReceive().GetCfpGamesAsync();
+    }
+
+    [Fact]
+    public async Task FetchForSlateAsync_WhenDbHasNoRowsForTheSlate_FallsBackToEspn() {
+        var slate = BuildRegularSeasonSlate();
+        _cfbRepo.GetScoresForSlateAsync(slate.Id).Returns((IEnumerable<CfbScores>)[]);
+        _cfbApi.GetScoresByWeekAsync(5, false).Returns(BuildScoreboardWithRanking());
+
+        var result = await BuildFetcher().FetchForSlateAsync(slate);
+
+        Assert.NotNull(result);
+        await _cfbApi.Received(1).GetScoresByWeekAsync(5, false);
+    }
+
+    // /code-review caught a real bug: gating DB-first purely on "rows.Count > 0" means the moment
+    // ONE game in a multi-game slate finishes and gets persisted, every subsequent call for that
+    // slate permanently stops calling ESPN — the rest of the slate's still-in-progress games are
+    // never discovered or persisted. This backs BOTH CfbScoresJob (which would then never finish
+    // collecting that slate's scores) AND CfbCacheService's live poll of the CURRENT slate (which
+    // would freeze the Scores page for every other game in progress). DB-first must only kick in
+    // once the slate's own window has fully ended — while a slate is still active, ESPN is always
+    // the source of truth regardless of how many of its games have already been persisted.
+    [Fact]
+    public async Task FetchForSlateAsync_WhenSlateStillActiveWithPartialRows_StillCallsEspn_NotJustDbRows() {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var activeSlate = new CfbSlates {
+            Id = 9, Season = 2026, SlateNumber = 3, Label = "Week 3", SlateType = "RegularSeason",
+            StartDate = today.AddDays(-1), EndDate = today.AddDays(1), EspnWeekNumber = 3, ScoringFormat = "Spread",
+        };
+        // One game in this slate already finished and was persisted; the rest are still live.
+        var partialRows = new List<CfbScores> {
+            new() { Id = 1, CfbSlateId = activeSlate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "STATUS_FINAL", GameTime = DateTimeOffset.UtcNow.AddHours(-3) },
+        };
+        _cfbRepo.GetScoresForSlateAsync(activeSlate.Id).Returns((IEnumerable<CfbScores>)partialRows);
+        _cfbApi.GetScoresByWeekAsync(3, false).Returns(BuildScoreboardWithRanking());
+
+        var result = await BuildFetcher().FetchForSlateAsync(activeSlate);
+
+        await _cfbApi.Received(1).GetScoresByWeekAsync(3, false);
+        Assert.NotNull(result);
+        Assert.Single(result!.Events!);
     }
 }

--- a/Server.UnitTests/CfbLiveScoreFetcherTests.cs
+++ b/Server.UnitTests/CfbLiveScoreFetcherTests.cs
@@ -5,6 +5,7 @@ using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models;
 using FourPlayWebApp.Shared.Models.Data;
 using FourPlayWebApp.Shared.Models.Enum;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 
@@ -19,6 +20,7 @@ public class CfbLiveScoreFetcherTests {
     private readonly ICfbApiService _cfbApi = Substitute.For<ICfbApiService>();
     private readonly ICfbRepository _cfbRepo = Substitute.For<ICfbRepository>();
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IMemoryCache _settledCache = new MemoryCache(new MemoryCacheOptions());
 
     public CfbLiveScoreFetcherTests() {
         // Default: no persisted rows for any slate, so existing tests (which never seed the repo)
@@ -29,7 +31,7 @@ public class CfbLiveScoreFetcherTests {
         _scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
     }
 
-    private CfbLiveScoreFetcher BuildFetcher() => new(_cfbApi, _scopeFactory);
+    private CfbLiveScoreFetcher BuildFetcher() => new(_cfbApi, _scopeFactory, _settledCache);
 
     private static EspnScores BuildScoreboard(
         string eventId = "401677183",
@@ -235,5 +237,26 @@ public class CfbLiveScoreFetcherTests {
         await _cfbApi.Received(1).GetScoresByWeekAsync(3, false);
         Assert.NotNull(result);
         Assert.Single(result!.Events!);
+    }
+
+    // A settled slate's DB-built response is immutable (a persisted row is always FINAL) — once
+    // built, repeated requests for the same slate should be served from an in-memory cache instead
+    // of re-querying the DB every time, so concurrent viewers of the same settled slate share one
+    // DB read total, not one DB read each.
+    [Fact]
+    public async Task FetchForSlateAsync_CachesTheDbBuiltResult_SecondCallForSameSlateNeverHitsDbAgain() {
+        var slate = BuildRegularSeasonSlate(); // EndDate 2025-9-28 — already ended
+        var rows = new List<CfbScores> {
+            new() { Id = 1, CfbSlateId = slate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "STATUS_FINAL", GameTime = new DateTimeOffset(2025, 9, 27, 18, 0, 0, TimeSpan.Zero) },
+        };
+        _cfbRepo.GetScoresForSlateAsync(slate.Id).Returns((IEnumerable<CfbScores>)rows);
+
+        var fetcher = BuildFetcher();
+        var first = await fetcher.FetchForSlateAsync(slate);
+        var second = await fetcher.FetchForSlateAsync(slate);
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        await _cfbRepo.Received(1).GetScoresForSlateAsync(slate.Id);
     }
 }

--- a/Server.UnitTests/CfbRepositoryTests.cs
+++ b/Server.UnitTests/CfbRepositoryTests.cs
@@ -121,4 +121,24 @@ public class CfbRepositoryTests
         Assert.Contains((2026, 3), weeksWithData);
         Assert.DoesNotContain((2026, 4), weeksWithData);
     }
+
+    // GetAllSlatesAsync mirrors the existing all-seasons GetAllWeekConfigsAsync pattern —
+    // added so CfbCurrentSlateService can resolve the current slate across every season in
+    // the DB instead of a single hardcoded ConfiguredSeason (frizat plan: wobbly-chasing-lynx).
+    [Fact]
+    public async Task GetAllSlatesAsync_ReturnsSlatesAcrossEverySeason_OrderedBySeasonThenSlateNumber()
+    {
+        var factory = new DbContextFactoryStub(nameof(GetAllSlatesAsync_ReturnsSlatesAcrossEverySeason_OrderedBySeasonThenSlateNumber));
+        var seedDb = factory.CreateDbContext();
+        seedDb.CfbSlates.Add(new CfbSlates { Id = 1, Season = 2026, SlateNumber = 2, Label = "Slate 2", SlateType = "RegularSeason" });
+        seedDb.CfbSlates.Add(new CfbSlates { Id = 2, Season = 2025, SlateNumber = 4, Label = "Slate 4", SlateType = "Championship" });
+        seedDb.CfbSlates.Add(new CfbSlates { Id = 3, Season = 2026, SlateNumber = 1, Label = "Slate 1", SlateType = "RegularSeason" });
+        await seedDb.SaveChangesAsync();
+        var repo = new CfbRepository(factory);
+
+        var all = (await repo.GetAllSlatesAsync()).ToList();
+
+        Assert.Equal(3, all.Count);
+        Assert.Equal([(2025, 4), (2026, 1), (2026, 2)], all.Select(s => (s.Season, s.SlateNumber)));
+    }
 }

--- a/Server.UnitTests/CfbScoresJobTests.cs
+++ b/Server.UnitTests/CfbScoresJobTests.cs
@@ -32,15 +32,21 @@ public class CfbScoresJobTests
 
     private CfbScoresJob BuildJob() => new(_fetcher, _repo);
 
-    private static CfbSlates BuildSlate() => new()
-    {
-        Id = 1, Season = 2025, SlateNumber = 1,
-        Label = "Week 1", SlateType = "RegularSeason",
-        StartDate = new DateOnly(2025, 12, 19),
-        EndDate   = new DateOnly(2025, 12, 20),
-        EspnWeekNumber = 1,
-        ScoringFormat = "Spread",
-    };
+    // Dates relative to "now" (not a fixed calendar date) so this slate is always "currently
+    // active" for the SeasonWindowResolver-based gate CfbScoresJob now checks before fetching —
+    // tests below that care about score-parsing/upsert behavior shouldn't also have to fight an
+    // unrelated off-season skip just because time passed since these dates were written.
+    private static CfbSlates BuildSlate() {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        return new() {
+            Id = 1, Season = 2025, SlateNumber = 1,
+            Label = "Week 1", SlateType = "RegularSeason",
+            StartDate = today.AddDays(-1),
+            EndDate   = today.AddDays(1),
+            EspnWeekNumber = 1,
+            ScoringFormat = "Spread",
+        };
+    }
 
     private static EspnScores BuildScoreboard(
         string eventId = "401677183",
@@ -72,6 +78,25 @@ public class CfbScoresJobTests
         await BuildJob().Execute(_context);
 
         await _fetcher.DidNotReceive().FetchForSlateAsync(Arg.Any<CfbSlates>());
+    }
+
+    // Beyond "slates exist" — the job must also check whether the season is actually happening
+    // right now (frizat plan: wobbly-chasing-lynx). Slates for the season can already be seeded
+    // while we're deep in the prior season's off-season (Season is a calendar-month cutoff).
+    [Fact]
+    public async Task Execute_WhenSlatesExistButSeasonNotCurrentlyActive_SkipsFetchEntirely()
+    {
+        var offSeasonSlate = new CfbSlates {
+            Id = 1, Season = 2025, SlateNumber = 4, Label = "Championship", SlateType = "Championship",
+            StartDate = new DateOnly(2026, 1, 5), EndDate = new DateOnly(2026, 1, 12),
+            EspnWeekNumber = 16, ScoringFormat = "Spread",
+        };
+        _repo.GetSlatesForSeasonAsync(Arg.Any<int>()).Returns([offSeasonSlate]);
+
+        await BuildJob().Execute(_context);
+
+        await _fetcher.DidNotReceive().FetchForSlateAsync(Arg.Any<CfbSlates>());
+        await _repo.DidNotReceive().UpsertCfbScoresAsync(Arg.Any<IEnumerable<CfbScores>>());
     }
 
     [Fact]

--- a/Server.UnitTests/EspnCacheServiceTests.cs
+++ b/Server.UnitTests/EspnCacheServiceTests.cs
@@ -3,6 +3,7 @@ using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models;
 using FourPlayWebApp.Shared.Models.Enum;
+using Microsoft.Extensions.Caching.Memory;
 using NSubstitute;
 
 namespace FourPlayWebApp.Server.UnitTests;
@@ -16,6 +17,7 @@ public class EspnCacheServiceTests
     private readonly IEspnApiService _espnApi;
     private readonly INflCurrentWeekService _nflCurrentWeekService;
     private readonly ILeagueRepository _leagueRepo;
+    private readonly IMemoryCache _memoryCache = new MemoryCache(new MemoryCacheOptions());
 
     // Default week returned by the mock — tests that don't care about the specific week use this
     private static readonly NflWeekInfo DefaultWeek = new(5, 5, 2025, false, "Week 5", "Standard", new DateTime(2025, 10, 2, 18, 0, 0, DateTimeKind.Utc));
@@ -58,7 +60,7 @@ public class EspnCacheServiceTests
         _espnApi.GetWeekScores(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<bool>())
                 .Returns(Task.FromResult<EspnScores?>(null));
 
-        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo);
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, _memoryCache);
 
         // API returns null → RefreshScoresAsync short-circuits before firing ScoresChanged, so
         // there's nothing to wait on deterministically; a null result is the correct outcome
@@ -85,7 +87,7 @@ public class EspnCacheServiceTests
         // without it, the mocked (near-instant) refresh can complete before ScoresChanged is
         // subscribed to below, and WaitForScoresChangedAsync would wait for an event that
         // already fired.
-        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, initialDelay: TimeSpan.FromMilliseconds(50));
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMilliseconds(50));
         await WaitForScoresChangedAsync(svc);
 
         var result = await svc.GetScoresAsync();
@@ -110,7 +112,7 @@ public class EspnCacheServiceTests
 
         // initialDelay gives the test time to subscribe before the first refresh fires — see
         // GetScoresAsync_WhenCacheHit_ReturnsCachedValue for why this is needed.
-        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, initialDelay: TimeSpan.FromMilliseconds(50));
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMilliseconds(50));
         await WaitForScoresChangedAsync(svc);
 
         // Even if a subsequent refresh throws, the previously cached value remains
@@ -135,7 +137,7 @@ public class EspnCacheServiceTests
 
         int fireCount = 0;
         // initialDelay gives us time to subscribe before the first refresh fires
-        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, initialDelay: TimeSpan.FromMilliseconds(50));
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMilliseconds(50));
         svc.ScoresChanged += () => Interlocked.Increment(ref fireCount);
 
         await WaitForScoresChangedAsync(svc);
@@ -151,7 +153,7 @@ public class EspnCacheServiceTests
         _espnApi.GetWeekScores(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<bool>()).Returns(Task.FromResult<EspnScores?>(scores));
 
         int fireCount = 0;
-        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, initialDelay: TimeSpan.FromMilliseconds(50));
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMilliseconds(50));
         svc.ScoresChanged += () => Interlocked.Increment(ref fireCount);
 
         await WaitForScoresChangedAsync(svc);
@@ -165,7 +167,7 @@ public class EspnCacheServiceTests
         _espnApi.GetWeekScores(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<bool>()).Returns(Task.FromResult<EspnScores?>(null));
 
         int fireCount = 0;
-        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, initialDelay: TimeSpan.FromMilliseconds(50));
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMilliseconds(50));
         svc.ScoresChanged += () => Interlocked.Increment(ref fireCount);
 
         // API returns null → ScoresChanged can never fire (RefreshScoresAsync short-circuits first),
@@ -186,7 +188,7 @@ public class EspnCacheServiceTests
     {
         _nflCurrentWeekService.IsSeasonActiveAsync().Returns(false);
 
-        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, initialDelay: TimeSpan.FromMilliseconds(50));
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMilliseconds(50));
         await Task.Delay(300);
 
         var result = await svc.GetScoresAsync();
@@ -209,7 +211,7 @@ public class EspnCacheServiceTests
         // Wild Card (ESPN week 1, postseason) = internal NflWeek 19 (GameHelpers.GetWeekFromEspnWeek).
         _leagueRepo.GetNflScoresAsync(2025, 19).Returns(rows);
 
-        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, initialDelay: TimeSpan.FromMinutes(5));
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMinutes(5));
         var result = await svc.GetWeekScoresAsync(1, 2025, postSeason: true);
 
         Assert.NotNull(result);
@@ -228,10 +230,31 @@ public class EspnCacheServiceTests
         var espnScores = new EspnScores { Season = new Season { Year = 2025 } };
         _espnApi.GetWeekScores(5, 2025, false).Returns(Task.FromResult<EspnScores?>(espnScores));
 
-        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, initialDelay: TimeSpan.FromMinutes(5));
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMinutes(5));
         var result = await svc.GetWeekScoresAsync(5, 2025, postSeason: false);
 
         Assert.Same(espnScores, result);
         await _espnApi.Received(1).GetWeekScores(5, 2025, false);
+    }
+
+    // A settled week's DB-built response is immutable (a persisted row is always FINAL) — once
+    // built, repeated requests for the same week should be served from an in-memory cache instead
+    // of re-querying the DB every time, so 100 concurrent viewers of the same past week share one
+    // DB read total, not one DB read each.
+    [Fact]
+    public async Task GetWeekScoresAsync_CachesTheDbBuiltResult_SecondCallForSameWeekNeverHitsDbAgain()
+    {
+        var rows = new List<Shared.Models.Data.NflScores> {
+            new() { Id = 1, Season = 2025, NflWeek = 1, HomeTeam = "KC", AwayTeam = "DEN", HomeTeamScore = 27, AwayTeamScore = 20, GameTime = new DateTimeOffset(2025, 9, 10, 18, 0, 0, TimeSpan.Zero) },
+        };
+        _leagueRepo.GetNflScoresAsync(2025, 1).Returns(rows);
+
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMinutes(5));
+        var first = await svc.GetWeekScoresAsync(1, 2025, postSeason: false);
+        var second = await svc.GetWeekScoresAsync(1, 2025, postSeason: false);
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        await _leagueRepo.Received(1).GetNflScoresAsync(2025, 1);
     }
 }

--- a/Server.UnitTests/EspnCacheServiceTests.cs
+++ b/Server.UnitTests/EspnCacheServiceTests.cs
@@ -1,5 +1,6 @@
 using FourPlayWebApp.Server.Services;
 using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models;
 using FourPlayWebApp.Shared.Models.Enum;
 using NSubstitute;
@@ -14,6 +15,7 @@ public class EspnCacheServiceTests
 {
     private readonly IEspnApiService _espnApi;
     private readonly INflCurrentWeekService _nflCurrentWeekService;
+    private readonly ILeagueRepository _leagueRepo;
 
     // Default week returned by the mock — tests that don't care about the specific week use this
     private static readonly NflWeekInfo DefaultWeek = new(5, 5, 2025, false, "Week 5", "Standard", new DateTime(2025, 10, 2, 18, 0, 0, DateTimeKind.Utc));
@@ -23,6 +25,13 @@ public class EspnCacheServiceTests
         _espnApi = Substitute.For<IEspnApiService>();
         _nflCurrentWeekService = Substitute.For<INflCurrentWeekService>();
         _nflCurrentWeekService.GetCurrentWeekAsync().Returns(DefaultWeek);
+        _leagueRepo = Substitute.For<ILeagueRepository>();
+        // Default: no persisted rows for any week, so existing tests (which never seed the repo)
+        // keep exercising the live-ESPN branch exactly as before this constructor param was added.
+        _leagueRepo.GetNflScoresAsync(Arg.Any<int>(), Arg.Any<int>()).Returns([]);
+        // Default: a season is active, so existing poller tests (GetScoresAsync_*/ScoresChanged_*)
+        // keep exercising the live-ESPN fetch branch unchanged by the new off-season gate.
+        _nflCurrentWeekService.IsSeasonActiveAsync().Returns(true);
     }
 
     // The service's constructor kicks off its refresh loop as a fire-and-forget background task
@@ -49,7 +58,7 @@ public class EspnCacheServiceTests
         _espnApi.GetWeekScores(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<bool>())
                 .Returns(Task.FromResult<EspnScores?>(null));
 
-        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService);
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo);
 
         // API returns null → RefreshScoresAsync short-circuits before firing ScoresChanged, so
         // there's nothing to wait on deterministically; a null result is the correct outcome
@@ -76,7 +85,7 @@ public class EspnCacheServiceTests
         // without it, the mocked (near-instant) refresh can complete before ScoresChanged is
         // subscribed to below, and WaitForScoresChangedAsync would wait for an event that
         // already fired.
-        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, initialDelay: TimeSpan.FromMilliseconds(50));
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, initialDelay: TimeSpan.FromMilliseconds(50));
         await WaitForScoresChangedAsync(svc);
 
         var result = await svc.GetScoresAsync();
@@ -101,7 +110,7 @@ public class EspnCacheServiceTests
 
         // initialDelay gives the test time to subscribe before the first refresh fires — see
         // GetScoresAsync_WhenCacheHit_ReturnsCachedValue for why this is needed.
-        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, initialDelay: TimeSpan.FromMilliseconds(50));
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, initialDelay: TimeSpan.FromMilliseconds(50));
         await WaitForScoresChangedAsync(svc);
 
         // Even if a subsequent refresh throws, the previously cached value remains
@@ -126,7 +135,7 @@ public class EspnCacheServiceTests
 
         int fireCount = 0;
         // initialDelay gives us time to subscribe before the first refresh fires
-        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, initialDelay: TimeSpan.FromMilliseconds(50));
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, initialDelay: TimeSpan.FromMilliseconds(50));
         svc.ScoresChanged += () => Interlocked.Increment(ref fireCount);
 
         await WaitForScoresChangedAsync(svc);
@@ -142,7 +151,7 @@ public class EspnCacheServiceTests
         _espnApi.GetWeekScores(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<bool>()).Returns(Task.FromResult<EspnScores?>(scores));
 
         int fireCount = 0;
-        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, initialDelay: TimeSpan.FromMilliseconds(50));
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, initialDelay: TimeSpan.FromMilliseconds(50));
         svc.ScoresChanged += () => Interlocked.Increment(ref fireCount);
 
         await WaitForScoresChangedAsync(svc);
@@ -156,7 +165,7 @@ public class EspnCacheServiceTests
         _espnApi.GetWeekScores(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<bool>()).Returns(Task.FromResult<EspnScores?>(null));
 
         int fireCount = 0;
-        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, initialDelay: TimeSpan.FromMilliseconds(50));
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, initialDelay: TimeSpan.FromMilliseconds(50));
         svc.ScoresChanged += () => Interlocked.Increment(ref fireCount);
 
         // API returns null → ScoresChanged can never fire (RefreshScoresAsync short-circuits first),
@@ -164,5 +173,65 @@ public class EspnCacheServiceTests
         await Task.Delay(500);
 
         Assert.Equal(0, fireCount);
+    }
+
+    // -----------------------------------------------------------------------
+    // Off-season gating — the poller must not hit ESPN when no season is active (frizat plan:
+    // wobbly-chasing-lynx — this is the fix for the always-on 5-min poller hitting ESPN 24/7/365
+    // regardless of season).
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetScoresAsync_NeverCallsEspn_WhenNoSeasonIsCurrentlyActive()
+    {
+        _nflCurrentWeekService.IsSeasonActiveAsync().Returns(false);
+
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, initialDelay: TimeSpan.FromMilliseconds(50));
+        await Task.Delay(300);
+
+        var result = await svc.GetScoresAsync();
+
+        Assert.Null(result);
+        await _espnApi.DidNotReceiveWithAnyArgs().GetWeekScores(default, default, default);
+    }
+
+    // -----------------------------------------------------------------------
+    // GetWeekScoresAsync — DB-first for historical weeks (100 concurrent users viewing the same
+    // past week shouldn't trigger 100 independent ESPN calls for games already FINAL and persisted)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetWeekScoresAsync_WhenDbHasPersistedRowsForTheWeek_ReturnsDbBuiltScores_NeverCallsEspn()
+    {
+        var rows = new List<Shared.Models.Data.NflScores> {
+            new() { Id = 1, Season = 2025, NflWeek = 19, HomeTeam = "KC", AwayTeam = "DEN", HomeTeamScore = 27, AwayTeamScore = 20, GameTime = new DateTimeOffset(2026, 1, 10, 18, 0, 0, TimeSpan.Zero) },
+        };
+        // Wild Card (ESPN week 1, postseason) = internal NflWeek 19 (GameHelpers.GetWeekFromEspnWeek).
+        _leagueRepo.GetNflScoresAsync(2025, 19).Returns(rows);
+
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, initialDelay: TimeSpan.FromMinutes(5));
+        var result = await svc.GetWeekScoresAsync(1, 2025, postSeason: true);
+
+        Assert.NotNull(result);
+        var comp = result!.Events!.Single().Competitions[0];
+        var home = comp.Competitors.Single(c => c.HomeAway == HomeAway.Home);
+        Assert.Equal("KC", home.Team.Abbreviation);
+        Assert.Equal(27, home.Score);
+        Assert.Equal(TypeName.StatusFinal, comp.Status.Type.Name);
+        await _espnApi.DidNotReceiveWithAnyArgs().GetWeekScores(default, default, default);
+    }
+
+    [Fact]
+    public async Task GetWeekScoresAsync_WhenDbHasNoRowsForTheWeek_FallsBackToEspn()
+    {
+        _leagueRepo.GetNflScoresAsync(Arg.Any<int>(), Arg.Any<int>()).Returns([]);
+        var espnScores = new EspnScores { Season = new Season { Year = 2025 } };
+        _espnApi.GetWeekScores(5, 2025, false).Returns(Task.FromResult<EspnScores?>(espnScores));
+
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, initialDelay: TimeSpan.FromMinutes(5));
+        var result = await svc.GetWeekScoresAsync(5, 2025, postSeason: false);
+
+        Assert.Same(espnScores, result);
+        await _espnApi.Received(1).GetWeekScores(5, 2025, false);
     }
 }

--- a/Server.UnitTests/EspnCacheServiceTests.cs
+++ b/Server.UnitTests/EspnCacheServiceTests.cs
@@ -31,6 +31,10 @@ public class EspnCacheServiceTests
         // Default: no persisted rows for any week, so existing tests (which never seed the repo)
         // keep exercising the live-ESPN branch exactly as before this constructor param was added.
         _leagueRepo.GetNflScoresAsync(Arg.Any<int>(), Arg.Any<int>()).Returns([]);
+        // Default: no configs, so GetWeekScoresAsync's "has this week ended" check finds no match
+        // and safely falls through to ESPN — tests that need the DB-first branch stub this
+        // explicitly with a matching config below.
+        _leagueRepo.GetNflSeasonWeekConfigsAsync().Returns(new List<Models.Data.NflSeasonWeekConfig>());
         // Default: a season is active, so existing poller tests (GetScoresAsync_*/ScoresChanged_*)
         // keep exercising the live-ESPN fetch branch unchanged by the new off-season gate.
         _nflCurrentWeekService.IsSeasonActiveAsync().Returns(true);
@@ -210,6 +214,14 @@ public class EspnCacheServiceTests
         };
         // Wild Card (ESPN week 1, postseason) = internal NflWeek 19 (GameHelpers.GetWeekFromEspnWeek).
         _leagueRepo.GetNflScoresAsync(2025, 19).Returns(rows);
+        // This week's own window has fully ended (well in the past) — DB-first only kicks in once
+        // that's true, mirroring CfbLiveScoreFetcher's identical fix.
+        _leagueRepo.GetNflSeasonWeekConfigsAsync().Returns(new List<Models.Data.NflSeasonWeekConfig> {
+            new() {
+                Season = 2025, WeekId = 19, WeekLabel = "Wild Card", WeekType = "PostSeason", ScoringFormat = "Standard",
+                WeekStartDatetime = new DateTime(2026, 1, 8), WeekEndDatetime = new DateTime(2026, 1, 12),
+            },
+        });
 
         await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMinutes(5));
         var result = await svc.GetWeekScoresAsync(1, 2025, postSeason: true);
@@ -248,6 +260,12 @@ public class EspnCacheServiceTests
             new() { Id = 1, Season = 2025, NflWeek = 1, HomeTeam = "KC", AwayTeam = "DEN", HomeTeamScore = 27, AwayTeamScore = 20, GameTime = new DateTimeOffset(2025, 9, 10, 18, 0, 0, TimeSpan.Zero) },
         };
         _leagueRepo.GetNflScoresAsync(2025, 1).Returns(rows);
+        _leagueRepo.GetNflSeasonWeekConfigsAsync().Returns(new List<Models.Data.NflSeasonWeekConfig> {
+            new() {
+                Season = 2025, WeekId = 1, WeekLabel = "Week 1", WeekType = "RegularSeason", ScoringFormat = "Standard",
+                WeekStartDatetime = new DateTime(2025, 9, 4), WeekEndDatetime = new DateTime(2025, 9, 15),
+            },
+        });
 
         await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMinutes(5));
         var first = await svc.GetWeekScoresAsync(1, 2025, postSeason: false);
@@ -256,5 +274,36 @@ public class EspnCacheServiceTests
         Assert.NotNull(first);
         Assert.NotNull(second);
         await _leagueRepo.Received(1).GetNflScoresAsync(2025, 1);
+    }
+
+    // /code-review caught that this exact bug (fixed for CFB in CfbLiveScoreFetcher — see its
+    // comment) was never ported to NFL: gating DB-first purely on "any row persisted" means the
+    // instant one game in a multi-game week finishes and gets persisted, the response is built
+    // from only that game and cached forever — the rest of that week's still-in-progress games
+    // are permanently dropped from every future response, even after they finish and get
+    // persisted too. DB-first must only kick in once the week's own window has fully ended.
+    [Fact]
+    public async Task GetWeekScoresAsync_WhenWeekStillActiveWithPartialRows_StillCallsEspn_NotJustDbRows()
+    {
+        var now = DateTime.UtcNow;
+        _leagueRepo.GetNflSeasonWeekConfigsAsync().Returns(new List<Models.Data.NflSeasonWeekConfig> {
+            new() {
+                Season = 2026, WeekId = 3, WeekLabel = "Week 3", WeekType = "RegularSeason", ScoringFormat = "Standard",
+                WeekStartDatetime = now.AddDays(-1), WeekEndDatetime = now.AddDays(1),
+            },
+        });
+        // One game in this week already finished and was persisted; the rest are still live.
+        var partialRows = new List<Shared.Models.Data.NflScores> {
+            new() { Id = 1, Season = 2026, NflWeek = 3, HomeTeam = "KC", AwayTeam = "DEN", HomeTeamScore = 27, AwayTeamScore = 20, GameTime = now.AddHours(-3) },
+        };
+        _leagueRepo.GetNflScoresAsync(2026, 3).Returns(partialRows);
+        var espnScores = new EspnScores { Season = new Season { Year = 2026 } };
+        _espnApi.GetWeekScores(3, 2026, false).Returns(Task.FromResult<EspnScores?>(espnScores));
+
+        await using var svc = new EspnCacheService(_espnApi, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMinutes(5));
+        var result = await svc.GetWeekScoresAsync(3, 2026, postSeason: false);
+
+        await _espnApi.Received(1).GetWeekScores(3, 2026, false);
+        Assert.Same(espnScores, result);
     }
 }

--- a/Server.UnitTests/FinalScoresEspnMapperTests.cs
+++ b/Server.UnitTests/FinalScoresEspnMapperTests.cs
@@ -1,0 +1,95 @@
+using FourPlayWebApp.Server.Services;
+using FourPlayWebApp.Shared.Models;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+/// <summary>
+/// FinalScoresEspnMapper builds an EspnScores wire-shape response from this app's own persisted,
+/// already-FINAL score rows (NflScores/CfbScores) — one shared implementation both sports' DB-first
+/// "serve historical weeks without hitting ESPN" paths call, instead of each hand-rolling the
+/// mapping. Extracted from what was previously a private, NFL-only helper in
+/// DemoEspnCacheService.BuildEvent.
+/// </summary>
+public class FinalScoresEspnMapperTests {
+    [Fact]
+    public void Build_MapsHomeAndAwayCompetitorsWithCorrectAbbreviationsAndScores() {
+        var games = new[] {
+            new FinalScoresEspnMapper.FinishedGame("1", "KC", "DEN", 27, 20, new DateTimeOffset(2026, 1, 10, 18, 0, 0, TimeSpan.Zero)),
+        };
+
+        var result = FinalScoresEspnMapper.Build(games, season: 2025, week: 19, postSeason: true);
+
+        var comp = result.Events!.Single().Competitions[0];
+        var home = comp.Competitors.Single(c => c.HomeAway == HomeAway.Home);
+        var away = comp.Competitors.Single(c => c.HomeAway == HomeAway.Away);
+        Assert.Equal("KC", home.Team.Abbreviation);
+        Assert.Equal(27, home.Score);
+        Assert.Equal("DEN", away.Team.Abbreviation);
+        Assert.Equal(20, away.Score);
+    }
+
+    [Fact]
+    public void Build_MarksEveryGameAsFinal_SincePersistedRowsAreAlwaysAlreadyDecided() {
+        var games = new[] {
+            new FinalScoresEspnMapper.FinishedGame("1", "BUF", "MIA", 31, 17, DateTimeOffset.UtcNow),
+        };
+
+        var result = FinalScoresEspnMapper.Build(games, season: 2025, week: 1, postSeason: false);
+
+        var status = result.Events!.Single().Competitions[0].Status;
+        Assert.Equal(TypeName.StatusFinal, status.Type.Name);
+        Assert.Equal(State.Post, status.Type.State);
+        Assert.True(status.Type.Completed);
+    }
+
+    [Fact]
+    public void Build_SetsSeasonWeekAndPostSeasonType_OnTheResultAndEachEvent() {
+        var games = new[] { new FinalScoresEspnMapper.FinishedGame("1", "KC", "DEN", 1, 0, DateTimeOffset.UtcNow) };
+
+        var result = FinalScoresEspnMapper.Build(games, season: 2025, week: 5, postSeason: true);
+
+        Assert.Equal(2025, result.Season!.Year);
+        Assert.Equal(3, result.Season!.Type); // postseason = 3, matches DemoEspnCacheService's convention
+        Assert.Equal(5, result.Week!.Number);
+        Assert.Equal(2025, result.Events!.Single().Season.Year);
+        Assert.Equal(5, result.Events!.Single().Week.Number);
+    }
+
+    [Fact]
+    public void Build_ReturnsOneEventPerGame_ForMultipleGames() {
+        var games = new[] {
+            new FinalScoresEspnMapper.FinishedGame("1", "KC", "DEN", 27, 20, DateTimeOffset.UtcNow),
+            new FinalScoresEspnMapper.FinishedGame("2", "BUF", "MIA", 31, 17, DateTimeOffset.UtcNow),
+        };
+
+        var result = FinalScoresEspnMapper.Build(games, season: 2025, week: 19, postSeason: true);
+
+        Assert.Equal(2, result.Events!.Length);
+    }
+
+    [Fact]
+    public void Build_OmitsWeather_WhenNotProvided() {
+        var games = new[] { new FinalScoresEspnMapper.FinishedGame("1", "KC", "DEN", 1, 0, DateTimeOffset.UtcNow) };
+
+        var result = FinalScoresEspnMapper.Build(games, season: 2025, week: 1, postSeason: false);
+
+        Assert.Null(result.Events!.Single().Weather);
+    }
+
+    [Fact]
+    public void Build_IncludesWeather_WhenProvided() {
+        var games = new[] {
+            new FinalScoresEspnMapper.FinishedGame(
+                "1", "KC", "DEN", 1, 0, DateTimeOffset.UtcNow,
+                Weather: new FinalScoresEspnMapper.WeatherInfo("Sunny", "1", 72)),
+        };
+
+        var result = FinalScoresEspnMapper.Build(games, season: 2025, week: 1, postSeason: false);
+
+        var weather = result.Events!.Single().Weather;
+        Assert.NotNull(weather);
+        Assert.Equal("Sunny", weather!.DisplayValue);
+        Assert.Equal("1", weather.ConditionId);
+        Assert.Equal(72, weather.Temperature);
+    }
+}

--- a/Server.UnitTests/InvitationServiceTests.cs
+++ b/Server.UnitTests/InvitationServiceTests.cs
@@ -1,7 +1,10 @@
 using FourPlayWebApp.Server.Data;
 using FourPlayWebApp.Server.Services;
 using FourPlayWebApp.Server.Models;
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Models.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 using Xunit;
@@ -193,6 +196,55 @@ namespace FourPlayWebApp.Server.UnitTests
             var (service, _) = BuildService(nameof(DeleteInvitationAsync_NonExistentId_DoesNotThrow));
 
             await service.DeleteInvitationAsync(999999);
+        }
+
+        // /code-review: CreateInvitationAsync's upsert has the identical TOCTOU race
+        // LeagueMembershipInviteService.CreateOrReopenAsync guards against (see its own comment
+        // and CreateOrReopenAsync_ConcurrentCallsForSameNewPair_BothSucceed_ExactlyOneRowCreated)
+        // — two concurrent requests inviting the same not-yet-invited (Email, LeagueId) pair can
+        // both read `existing == null` before either writes, and the loser's SaveChangesAsync
+        // throws an unhandled DbUpdateException on the unique-index violation instead of the
+        // caller getting a clean result. The InMemory provider used by BuildService above doesn't
+        // enforce unique indexes, so this needs a real constraint-enforcing provider (SQLite,
+        // mirroring LeagueMembershipInviteServiceTests' setup) to actually reproduce.
+        private static ApplicationDbContext OpenSqliteDb(string dbName) =>
+            new(new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseSqlite($"Data Source={dbName};Mode=Memory;Cache=Shared")
+                .Options);
+
+        private static IDbContextFactory<ApplicationDbContext> BuildSqliteFactory(string dbName)
+        {
+            var factory = Substitute.For<IDbContextFactory<ApplicationDbContext>>();
+            factory.CreateDbContextAsync().Returns(_ => Task.FromResult(OpenSqliteDb(dbName)));
+            return factory;
+        }
+
+        [Fact]
+        public async Task CreateInvitationAsync_ConcurrentCallsForSameNewPair_BothSucceed_ExactlyOneRowCreated()
+        {
+            var dbName = nameof(CreateInvitationAsync_ConcurrentCallsForSameNewPair_BothSucceed_ExactlyOneRowCreated);
+            await using var keepAlive = new SqliteConnection($"Data Source={dbName};Mode=Memory;Cache=Shared");
+            await keepAlive.OpenAsync();
+            await using (var init = OpenSqliteDb(dbName)) { await init.Database.EnsureCreatedAsync(); }
+            await using (var seed = OpenSqliteDb(dbName)) {
+                seed.Users.Add(new ApplicationUser {
+                    Id = "owner", UserName = "owner", NormalizedUserName = "OWNER", Email = "owner@example.com",
+                    SecurityStamp = Guid.NewGuid().ToString(), ConcurrencyStamp = Guid.NewGuid().ToString(),
+                });
+                seed.LeagueInfo.Add(new LeagueInfo { Id = 1, LeagueName = "Test", OwnerUserId = "owner" });
+                await seed.SaveChangesAsync();
+            }
+            var factory = BuildSqliteFactory(dbName);
+            var emailSender = Substitute.For<IEmailSender>();
+            var serviceA = new InvitationService(factory, emailSender);
+            var serviceB = new InvitationService(factory, emailSender);
+
+            await Task.WhenAll(
+                serviceA.CreateInvitationAsync("race@example.com", "owner", leagueId: 1),
+                serviceB.CreateInvitationAsync("race@example.com", "owner", leagueId: 1));
+
+            await using var verify = OpenSqliteDb(dbName);
+            Assert.Equal(1, await verify.Invitations.CountAsync(i => i.Email == "race@example.com" && i.LeagueId == 1));
         }
     }
 }

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -352,6 +352,55 @@ public class LeagueOwnershipTests
         await repo.DidNotReceive().GetLeagueMemberCountAsync(1, Arg.Any<int>(), Arg.Any<LeagueType>());
     }
 
+    // /code-review: GetLeagueCost/UpdateLeagueJuice/RollForwardJuice/RemoveLeagueMember all called
+    // GetLeagueInfoAsync(leagueId) unguarded — its real (non-mocked) implementation uses
+    // FirstAsync(), which throws InvalidOperationException for a missing league, same as
+    // DeleteLeague's existing guard above. Without a try/catch, a bad/deleted leagueId 500s
+    // instead of a clean 404, inconsistent with every other endpoint in this controller.
+    [Fact]
+    public async Task GetLeagueCost_ReturnsNotFound_WhenLeagueDoesNotExist()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(999).Returns(Task.FromException<LeagueInfo>(new InvalidOperationException("Sequence contains no elements")));
+
+        var result = await ctrl.GetLeagueCost(999);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdateLeagueJuice_ReturnsNotFound_WhenLeagueDoesNotExist()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(999).Returns(Task.FromException<LeagueInfo>(new InvalidOperationException("Sequence contains no elements")));
+
+        var result = await ctrl.UpdateLeagueJuice(999, 2025, new LeagueJuiceUpdateDto(13, 10, 6, 5));
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task RollForwardJuice_ReturnsNotFound_WhenLeagueDoesNotExist()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(999).Returns(Task.FromException<LeagueInfo>(new InvalidOperationException("Sequence contains no elements")));
+
+        var result = await ctrl.RollForwardJuice(999, 2026);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task RemoveLeagueMember_ReturnsNotFound_WhenLeagueDoesNotExist()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(999).Returns(Task.FromException<LeagueInfo>(new InvalidOperationException("Sequence contains no elements")));
+
+        var result = await ctrl.RemoveLeagueMember(999, "victim-003");
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
     // ── GetAllLeaguesCost (admin platform-wide cost dashboard, frizat-fug) ──────
 
     [Fact]

--- a/Server.UnitTests/LeagueRepositoryTests.cs
+++ b/Server.UnitTests/LeagueRepositoryTests.cs
@@ -244,6 +244,34 @@ public class LeagueRepositoryTests
         Assert.Equal(0, count);
     }
 
+    // /code-review: GetSeasonDateRangeAsync's CFB branch computed the season end as
+    // WeekEndDate.ToDateTime(TimeOnly.MinValue) — midnight at the *start* of the last calendar
+    // day, not end-of-day. A member joining later that same day (a real day, still within the
+    // season by any reasonable reading of WeekEndDate) was incorrectly excluded, inconsistent
+    // with CfbCurrentSlateService's TimeOnly.MaxValue convention for the same "end of this date"
+    // concept elsewhere in the codebase.
+    [Fact]
+    public async Task GetLeagueMemberCountAsync_SeasonAware_Cfb_CountsMemberWhoJoinedLaterOnTheSeasonsLastCalendarDay()
+    {
+        var factory = new DbContextFactoryStub(nameof(GetLeagueMemberCountAsync_SeasonAware_Cfb_CountsMemberWhoJoinedLaterOnTheSeasonsLastCalendarDay));
+        var seedDb = factory.CreateDbContext();
+        seedDb.CfbSeasonWeekConfigs.Add(new CfbSeasonWeekConfig {
+            Season = 2024, EspnWeekNumber = 1, IvLeagueWeekNumber = 1,
+            WeekStartDate = new DateOnly(2024, 8, 20), WeekEndDate = new DateOnly(2025, 1, 15),
+        });
+        // Joined at 6pm UTC on the season's last calendar day — still that day, still in-season.
+        seedDb.LeagueUserMapping.Add(new LeagueUserMapping {
+            LeagueId = 1, UserId = "joined-late-on-last-day",
+            DateCreated = new DateTimeOffset(2025, 1, 15, 18, 0, 0, TimeSpan.Zero),
+        });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        var count = await repo.GetLeagueMemberCountAsync(1, 2024, LeagueType.Cfb);
+
+        Assert.Equal(1, count);
+    }
+
     [Fact]
     public async Task GetLeagueMemberCountAsync_SeasonAware_ExcludesMemberWhoJoinedAfterTheSeasonEnded()
     {

--- a/Server.UnitTests/NflCurrentWeekServiceTests.cs
+++ b/Server.UnitTests/NflCurrentWeekServiceTests.cs
@@ -1,0 +1,106 @@
+using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Services;
+using FourPlayWebApp.Server.Services.Repositories.Interfaces;
+using NSubstitute;
+using Xunit;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+// Direct unit tests for NflCurrentWeekService's resolution logic — previously only
+// exercised indirectly through NflCurrentWeekEndpointTests (which mocks the service
+// itself, so never actually ran this fallback chain). Added while refactoring the service
+// to call the shared SeasonWindowResolver instead of its own hand-rolled ??= chain
+// (frizat plan: wobbly-chasing-lynx) — these lock in the documented off-season/pre-season
+// fallback behavior as a regression guard for that refactor.
+public class NflCurrentWeekServiceTests
+{
+    private static NflSeasonWeekConfig Config(int season, int weekId, DateTime start, DateTime end) => new() {
+        Season = season,
+        WeekId = weekId,
+        WeekLabel = $"Week {weekId}",
+        WeekType = "Regular",
+        ScoringFormat = "Standard",
+        WeekStartDatetime = start,
+        WeekEndDatetime = end,
+        SpreadLockDatetime = start,
+    };
+
+    private static NflCurrentWeekService BuildService(List<NflSeasonWeekConfig> configs) {
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetNflSeasonWeekConfigsAsync().Returns(configs);
+        return new NflCurrentWeekService(repo);
+    }
+
+    [Fact]
+    public async Task GetCurrentWeekAsync_ReturnsActiveWeek_WhenNowIsWithinOne() {
+        var now = DateTime.UtcNow;
+        var svc = BuildService([
+            Config(2026, 4, now.AddDays(-3), now.AddDays(4)),
+            Config(2026, 5, now.AddDays(4), now.AddDays(11)),
+        ]);
+
+        var result = await svc.GetCurrentWeekAsync();
+
+        Assert.Equal(4, result.WeekId);
+        Assert.Equal(2026, result.Season);
+    }
+
+    [Fact]
+    public async Task GetCurrentWeekAsync_ReturnsMostRecentlyCompleted_OffSeason() {
+        var now = DateTime.UtcNow;
+        var svc = BuildService([
+            Config(2025, 21, now.AddDays(-60), now.AddDays(-53)),
+            Config(2025, 22, now.AddDays(-30), now.AddDays(-23)), // most recently completed
+        ]);
+
+        var result = await svc.GetCurrentWeekAsync();
+
+        Assert.Equal(22, result.WeekId);
+        Assert.Equal(2025, result.Season);
+    }
+
+    [Fact]
+    public async Task GetCurrentWeekAsync_ReturnsSoonestUpcoming_PreSeason() {
+        var now = DateTime.UtcNow;
+        var svc = BuildService([
+            Config(2026, 1, now.AddDays(10), now.AddDays(17)), // soonest upcoming
+            Config(2026, 2, now.AddDays(17), now.AddDays(24)),
+        ]);
+
+        var result = await svc.GetCurrentWeekAsync();
+
+        Assert.Equal(1, result.WeekId);
+    }
+
+    [Fact]
+    public async Task GetCurrentWeekAsync_MapsEspnWeek_ForPostseasonRounds() {
+        // ToWeekInfo's WeekId -> ESPN week mapping is unchanged by this refactor — Super
+        // Bowl (WeekId 22) maps to ESPN week 5 (ESPN skips week 4 = Pro Bowl).
+        var now = DateTime.UtcNow;
+        var svc = BuildService([
+            Config(2025, 22, now.AddDays(-1), now.AddDays(1)),
+        ]);
+
+        var result = await svc.GetCurrentWeekAsync();
+
+        Assert.Equal(22, result.WeekId);
+        Assert.Equal(5, result.EspnWeek);
+        Assert.True(result.IsPostSeason);
+    }
+
+    [Fact]
+    public async Task IsSeasonActiveAsync_True_WhenNowIsWithinAWindow() {
+        var now = DateTime.UtcNow;
+        var svc = BuildService([Config(2026, 4, now.AddDays(-3), now.AddDays(4))]);
+
+        Assert.True(await svc.IsSeasonActiveAsync());
+    }
+
+    [Fact]
+    public async Task IsSeasonActiveAsync_False_OffSeason() {
+        var now = DateTime.UtcNow;
+        var svc = BuildService([Config(2025, 22, now.AddDays(-60), now.AddDays(-53))]);
+
+        Assert.False(await svc.IsSeasonActiveAsync());
+    }
+}

--- a/Server.UnitTests/NflScoresJobTests.cs
+++ b/Server.UnitTests/NflScoresJobTests.cs
@@ -31,9 +31,18 @@ public class NflScoresJobTests
         _espnApi.GetWeekScores(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<bool>())
                 .Returns((EspnScores?)null);
 
-        // Default: no season week configs (empty control table → no weeks to upsert)
+        // Default: a season-week config whose window is active right now, so existing
+        // score-fetching tests keep exercising the ESPN loop unchanged by the new
+        // IsSeasonActive off-season gate — tests that specifically care about the "no configs at
+        // all" / weekList-upsert behavior override this explicitly below.
         _repo.GetNflSeasonWeekConfigsAsync()
-             .Returns(new List<NflSeasonWeekConfig>());
+             .Returns(new List<NflSeasonWeekConfig> {
+                 new() {
+                     Season = DateTime.UtcNow.Year, WeekId = 1, WeekLabel = "Week 1",
+                     WeekType = "RegularSeason", ScoringFormat = "Standard",
+                     WeekStartDatetime = DateTime.UtcNow.AddDays(-1), WeekEndDatetime = DateTime.UtcNow.AddDays(1),
+                 },
+             });
     }
 
     private NflScoresJob BuildJob() => new(_espnApi, _repo);
@@ -163,6 +172,23 @@ public class NflScoresJobTests
     // UpsertNflScoresAsync — NOT called when no completed games
     // -----------------------------------------------------------------------
 
+    // Beyond "configs exist" — is a season actually happening right now? (frizat plan:
+    // wobbly-chasing-lynx). Without this, the job hits ESPN for up to 5 years x 22 weeks on
+    // every scheduled run, in-season or not — weekList/UpsertNflWeeksAsync is unaffected since
+    // that's a cheap DB-only sync, not an ESPN call.
+    [Fact]
+    public async Task Execute_WhenNoSeasonIsCurrentlyActive_SkipsEspnLoopEntirely()
+    {
+        _repo.GetNflSeasonWeekConfigsAsync().Returns(new List<NflSeasonWeekConfig> {
+            BuildConfig(weekId: 22, season: 2025), // fixed past date, unrelated to "now"
+        });
+
+        await BuildJob().Execute(_context);
+
+        await _espnApi.DidNotReceiveWithAnyArgs().GetWeekScores(default, default, default);
+        await _repo.DidNotReceive().UpsertNflScoresAsync(Arg.Any<List<NflScores>>());
+    }
+
     [Fact]
     public async Task Execute_WhenAllWeekCallsReturnNull_DoesNotCallUpsertScores()
     {
@@ -221,7 +247,8 @@ public class NflScoresJobTests
     [Fact]
     public async Task Execute_WhenSeasonWeekConfigIsEmpty_DoesNotCallUpsertWeeks()
     {
-        // Default constructor stub returns empty list
+        _repo.GetNflSeasonWeekConfigsAsync().Returns(new List<NflSeasonWeekConfig>());
+
         await BuildJob().Execute(_context);
 
         await _repo.DidNotReceive().UpsertNflWeeksAsync(Arg.Any<List<NflWeeks>>());

--- a/Server.UnitTests/SeasonWindowResolverTests.cs
+++ b/Server.UnitTests/SeasonWindowResolverTests.cs
@@ -1,0 +1,171 @@
+using FourPlayWebApp.Server.Services;
+using Xunit;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+// SeasonWindowResolver is the shared, pure NFL/CFB season-resolution logic (frizat plan:
+// wobbly-chasing-lynx) — replaces two independent hand-rolled implementations
+// (NflCurrentWeekService's ??= fallback chain, CfbCurrentSlateService's hardcoded
+// ConfiguredSeason hack) with one algorithm both sports call.
+public class SeasonWindowResolverTests
+{
+    private static SeasonWindowResolver.Window Window(int season, DateTime start, DateTime end) =>
+        new(season, start, end);
+
+    // -----------------------------------------------------------------------
+    // ResolveCurrentWeek — week-level: active window wins, else most-recently-completed,
+    // else soonest-upcoming, else null.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ResolveCurrentWeek_ReturnsActiveWindow_WhenNowIsWithinOne()
+    {
+        var now = new DateTime(2026, 10, 15, 12, 0, 0, DateTimeKind.Utc);
+        var windows = new[]
+        {
+            Window(2026, new DateTime(2026, 10, 1), new DateTime(2026, 10, 8)),
+            Window(2026, new DateTime(2026, 10, 8), new DateTime(2026, 10, 20)), // active
+            Window(2026, new DateTime(2026, 10, 20), new DateTime(2026, 10, 27)),
+        };
+
+        var result = SeasonWindowResolver.ResolveCurrentWeek(windows, now);
+
+        Assert.Equal(windows[1], result);
+    }
+
+    [Fact]
+    public void ResolveCurrentWeek_ReturnsMostRecentlyCompleted_WhenNoneActive_OffSeason()
+    {
+        // Now is well after every configured window (off-season) — matches
+        // NflCurrentWeekService's existing documented fallback behavior.
+        var now = new DateTime(2026, 8, 24, 12, 0, 0, DateTimeKind.Utc);
+        var windows = new[]
+        {
+            Window(2025, new DateTime(2025, 9, 1), new DateTime(2025, 9, 8)),
+            Window(2025, new DateTime(2025, 12, 1), new DateTime(2025, 12, 8)), // most recently completed
+        };
+
+        var result = SeasonWindowResolver.ResolveCurrentWeek(windows, now);
+
+        Assert.Equal(windows[1], result);
+    }
+
+    [Fact]
+    public void ResolveCurrentWeek_ReturnsSoonestUpcoming_WhenNoneActiveOrPast_PreSeason()
+    {
+        var now = new DateTime(2026, 8, 1, 12, 0, 0, DateTimeKind.Utc);
+        var windows = new[]
+        {
+            Window(2026, new DateTime(2026, 9, 10), new DateTime(2026, 9, 17)), // soonest upcoming
+            Window(2026, new DateTime(2026, 9, 17), new DateTime(2026, 9, 24)),
+        };
+
+        var result = SeasonWindowResolver.ResolveCurrentWeek(windows, now);
+
+        Assert.Equal(windows[0], result);
+    }
+
+    [Fact]
+    public void ResolveCurrentWeek_ReturnsNull_WhenNoWindowsConfigured()
+    {
+        var result = SeasonWindowResolver.ResolveCurrentWeek([], DateTime.UtcNow);
+
+        Assert.Null(result);
+    }
+
+    // -----------------------------------------------------------------------
+    // IsSeasonActive — season-level: true within a season's overall span (earliest
+    // window Start to latest window End, for that season), regardless of whether any
+    // single week window is active at this exact instant.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void IsSeasonActive_True_DuringAnInSeasonGapBetweenWeeks()
+    {
+        // The Tuesday between last Monday's game (window 1 already ended) and next
+        // Thursday's kickoff (window 2 hasn't started) — no single Window is active, but
+        // we are unambiguously still "in season."
+        var now = new DateTime(2026, 9, 16, 12, 0, 0, DateTimeKind.Utc); // Wednesday
+        var windows = new[]
+        {
+            Window(2026, new DateTime(2026, 9, 10), new DateTime(2026, 9, 15)), // ended Tue
+            Window(2026, new DateTime(2026, 9, 17), new DateTime(2026, 9, 22)), // starts Thu
+        };
+
+        Assert.True(SeasonWindowResolver.IsSeasonActive(windows, now));
+    }
+
+    [Fact]
+    public void IsSeasonActive_True_ExactlyAtSeasonSpanStart()
+    {
+        var start = new DateTime(2026, 9, 10, 0, 0, 0, DateTimeKind.Utc);
+        var windows = new[] { Window(2026, start, new DateTime(2026, 9, 20)) };
+
+        Assert.True(SeasonWindowResolver.IsSeasonActive(windows, start));
+    }
+
+    [Fact]
+    public void IsSeasonActive_True_ExactlyAtSeasonSpanEnd()
+    {
+        var end = new DateTime(2026, 9, 20, 0, 0, 0, DateTimeKind.Utc);
+        var windows = new[] { Window(2026, new DateTime(2026, 9, 10), end) };
+
+        Assert.True(SeasonWindowResolver.IsSeasonActive(windows, end));
+    }
+
+    [Fact]
+    public void IsSeasonActive_False_OneTickBeforeSeasonSpanStart()
+    {
+        var start = new DateTime(2026, 9, 10, 0, 0, 0, DateTimeKind.Utc);
+        var windows = new[] { Window(2026, start, new DateTime(2026, 9, 20)) };
+
+        Assert.False(SeasonWindowResolver.IsSeasonActive(windows, start.AddTicks(-1)));
+    }
+
+    [Fact]
+    public void IsSeasonActive_False_OneTickAfterSeasonSpanEnd()
+    {
+        var end = new DateTime(2026, 9, 20, 0, 0, 0, DateTimeKind.Utc);
+        var windows = new[] { Window(2026, new DateTime(2026, 9, 10), end) };
+
+        Assert.False(SeasonWindowResolver.IsSeasonActive(windows, end.AddTicks(1)));
+    }
+
+    [Fact]
+    public void IsSeasonActive_False_WellIntoTheOffSeason()
+    {
+        // This is the exact real bug: today (2026-08-24) is between the 2025 season's end
+        // (its Super Bowl / championship, ~Feb 2026) and the 2026 season's start (~Sept
+        // 2026) — the poller must not treat this as "in season."
+        var now = new DateTime(2026, 8, 24, 12, 0, 0, DateTimeKind.Utc);
+        var windows = new[]
+        {
+            Window(2025, new DateTime(2025, 9, 1), new DateTime(2026, 2, 8)),   // 2025 season, ended Feb 2026
+            Window(2026, new DateTime(2026, 9, 10), new DateTime(2027, 2, 7)),  // 2026 season, not started
+        };
+
+        Assert.False(SeasonWindowResolver.IsSeasonActive(windows, now));
+    }
+
+    [Fact]
+    public void IsSeasonActive_False_WhenNoWindowsConfigured()
+    {
+        Assert.False(SeasonWindowResolver.IsSeasonActive([], DateTime.UtcNow));
+    }
+
+    [Fact]
+    public void IsSeasonActive_UsesPerSeasonSpan_NotGlobalSpanAcrossAllSeasons()
+    {
+        // A gap between two DIFFERENT seasons (the actual off-season) must read as
+        // inactive even though it falls "between" the earliest and latest window overall
+        // — the span must be computed per-season, not across the whole windows list.
+        var now = new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc); // deep off-season
+        var windows = new[]
+        {
+            Window(2025, new DateTime(2025, 9, 1), new DateTime(2026, 2, 8)),
+            Window(2026, new DateTime(2026, 9, 10), new DateTime(2027, 2, 7)),
+        };
+
+        Assert.False(SeasonWindowResolver.IsSeasonActive(windows, now));
+    }
+}

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -738,12 +738,10 @@ public class LeagueController(
     [HttpGet("{leagueId:int}/cost")]
     [ProducesResponseType(typeof(LeagueCostDto), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetLeagueCost(int leagueId, int? season = null) {
-        var league = await repo.GetLeagueInfoAsync(leagueId);
-        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != userId)
-            return Forbid();
+        var (league, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         var count = season.HasValue
-            ? await repo.GetLeagueMemberCountAsync(leagueId, season.Value, league.LeagueType)
+            ? await repo.GetLeagueMemberCountAsync(leagueId, season.Value, league!.LeagueType)
             : await repo.GetLeagueMemberCountAsync(leagueId);
         return Ok(new LeagueCostDto(count, ComputeLeagueCost(count)));
     }
@@ -777,10 +775,8 @@ public class LeagueController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> UpdateLeagueJuice(int leagueId, int season, [FromBody] LeagueJuiceUpdateDto dto) {
-        var league = await repo.GetLeagueInfoAsync(leagueId);
-        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != userId)
-            return Forbid();
+        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         var existing = await repo.GetLeagueJuiceMappingAsync(leagueId, season);
         if (existing is null) return NotFound($"No juice mapping for league {leagueId} season {season}.");
         existing.Juice = dto.Juice;
@@ -796,10 +792,8 @@ public class LeagueController(
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> RollForwardJuice(int leagueId, int toSeason) {
-        var league = await repo.GetLeagueInfoAsync(leagueId);
-        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != userId)
-            return Forbid();
+        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         if (await repo.GetLeagueJuiceMappingAsync(leagueId, toSeason) is not null)
             return BadRequest($"Juice mapping for season {toSeason} already exists.");
         var priorMapping = (await repo.GetLeagueJuiceMappingAsync(leagueId))
@@ -823,10 +817,8 @@ public class LeagueController(
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> RemoveLeagueMember(int leagueId, string userId) {
-        var league = await repo.GetLeagueInfoAsync(leagueId);
-        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
-            return Forbid();
+        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         await repo.RemoveLeagueUserMappingAsync(leagueId, userId);
         return NoContent();
     }
@@ -839,18 +831,8 @@ public class LeagueController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> DeleteLeague(int leagueId) {
-        LeagueInfo league;
-        try {
-            league = await repo.GetLeagueInfoAsync(leagueId);
-        } catch (InvalidOperationException) {
-            // GetLeagueInfoAsync's real implementation throws (FirstAsync) rather than returning
-            // null for a missing league — realistic here specifically: a double-submitted delete
-            // (slow network, already-deleted league) should 404, not 500.
-            return NotFound();
-        }
-        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
-            return Forbid();
+        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         await repo.DeleteLeagueAsync(leagueId);
         return NoContent();
     }
@@ -861,14 +843,11 @@ public class LeagueController(
     [ProducesResponseType(typeof(LeagueInviteLinkDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<LeagueInviteLinkDto>> GenerateInviteLink(int leagueId) {
-        LeagueInfo league;
-        try { league = await repo.GetLeagueInfoAsync(leagueId); }
-        catch (InvalidOperationException) { return NotFound(); }
+        var (league, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
-            return Forbid();
         var link = await leagueInviteLinkService.GenerateAsync(leagueId, callerId);
-        return Ok(new LeagueInviteLinkDto(link.Token, link.LeagueId, league.LeagueName, link.ExpiresAt));
+        return Ok(new LeagueInviteLinkDto(link.Token, link.LeagueId, league!.LeagueName, link.ExpiresAt));
     }
 
     [HttpGet("join/{token}")]
@@ -924,27 +903,19 @@ public class LeagueController(
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<LeagueInviteLinkDto>> GetCurrentInviteLink(int leagueId) {
-        LeagueInfo league;
-        try { league = await repo.GetLeagueInfoAsync(leagueId); }
-        catch (InvalidOperationException) { return NotFound(); }
-        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
-            return Forbid();
+        var (league, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         var link = await leagueInviteLinkService.GetCurrentAsync(leagueId);
         if (link is null) return NotFound();
-        return Ok(new LeagueInviteLinkDto(link.Token, link.LeagueId, league.LeagueName, link.ExpiresAt));
+        return Ok(new LeagueInviteLinkDto(link.Token, link.LeagueId, league!.LeagueName, link.ExpiresAt));
     }
 
     [HttpDelete("{leagueId:int}/invite-link")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> RevokeInviteLink(int leagueId) {
-        LeagueInfo league;
-        try { league = await repo.GetLeagueInfoAsync(leagueId); }
-        catch (InvalidOperationException) { return NotFound(); }
-        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
-            return Forbid();
+        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         await leagueInviteLinkService.RevokeAsync(leagueId);
         return NoContent();
     }
@@ -953,12 +924,8 @@ public class LeagueController(
     [ProducesResponseType(typeof(IReadOnlyList<InvitationDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<IReadOnlyList<InvitationDto>>> GetLeagueInvitations(int leagueId) {
-        LeagueInfo league;
-        try { league = await repo.GetLeagueInfoAsync(leagueId); }
-        catch (InvalidOperationException) { return NotFound(); }
-        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
-            return Forbid();
+        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         var invitations = await invitationService.GetInvitationsByLeagueAsync(leagueId);
         return Ok(invitations.ToDtoList());
     }
@@ -967,12 +934,8 @@ public class LeagueController(
     [ProducesResponseType(typeof(IReadOnlyList<MembershipInviteStatusDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<IReadOnlyList<MembershipInviteStatusDto>>> GetLeagueMembershipInvites(int leagueId) {
-        LeagueInfo league;
-        try { league = await repo.GetLeagueInfoAsync(leagueId); }
-        catch (InvalidOperationException) { return NotFound(); }
-        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
-            return Forbid();
+        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         var invites = await membershipInviteService.GetByLeagueAsync(leagueId);
         return Ok(invites.ToStatusDtoList());
     }
@@ -983,12 +946,9 @@ public class LeagueController(
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> InviteToLeague(int leagueId, [FromBody] LeagueInviteDto dto) {
-        LeagueInfo league;
-        try { league = await repo.GetLeagueInfoAsync(leagueId); }
-        catch (InvalidOperationException) { return NotFound(); }
+        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+        if (error is not null) return error;
         var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
-        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
-            return Forbid();
 
         // Someone who already has an account (owns a league or belongs to one) must be
         // addable to a NEW league directly — routing them through CreateInvitationAsync would
@@ -1044,6 +1004,25 @@ public class LeagueController(
 
         await membershipInviteService.MarkDeclinedAsync(id);
         return NoContent();
+    }
+
+    /// <summary>
+    /// Shared preamble for the 10+ endpoints that load a league by id and require the caller to
+    /// own it (or be an admin): 404 if the league doesn't exist (GetLeagueInfoAsync's real
+    /// implementation uses FirstAsync(), which throws InvalidOperationException rather than
+    /// returning null), 403 if the caller is neither the owner nor an admin.
+    /// </summary>
+    private async Task<(LeagueInfo? league, ActionResult? error)> LoadOwnedLeagueAsync(int leagueId) {
+        LeagueInfo league;
+        try {
+            league = await repo.GetLeagueInfoAsync(leagueId);
+        } catch (InvalidOperationException) {
+            return (null, NotFound());
+        }
+        var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!User.IsInRole(AppRoles.Administrator) && league.OwnerUserId != callerId)
+            return (null, Forbid());
+        return (league, null);
     }
 
     /// <summary>

--- a/Server/Jobs/CfbScoresJob.cs
+++ b/Server/Jobs/CfbScoresJob.cs
@@ -1,3 +1,4 @@
+using FourPlayWebApp.Server.Services;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models;
@@ -19,6 +20,17 @@ public class CfbScoresJob(ICfbLiveScoreFetcher fetcher, ICfbRepository repo) : I
         var slates = (await repo.GetSlatesForSeasonAsync(Season)).ToList();
         if (slates.Count == 0) {
             Log.Warning("CfbScoresJob: no slates found for season {Season}", Season);
+            return;
+        }
+
+        // Beyond "slates exist" — are we actually within this season's window right now? Season
+        // is a calendar-month cutoff, so slates for the upcoming season can already be seeded
+        // while we're still deep in the prior season's off-season; without this check the job
+        // would keep hitting ESPN for a not-yet-started or long-finished season.
+        var windows = slates.Select(s => new SeasonWindowResolver.Window(
+            s.Season, s.StartDate.ToDateTime(TimeOnly.MinValue), s.EndDate.ToDateTime(TimeOnly.MaxValue)));
+        if (!SeasonWindowResolver.IsSeasonActive(windows, DateTime.UtcNow)) {
+            Log.Information("CfbScoresJob: season {Season} not currently active, skipping ESPN fetch", Season);
             return;
         }
 

--- a/Server/Jobs/NFLScoresJob.cs
+++ b/Server/Jobs/NFLScoresJob.cs
@@ -1,4 +1,5 @@
 using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Server.Services;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Helpers;
@@ -25,32 +26,39 @@ public class NflScoresJob(IEspnApiService espn, ILeagueRepository leagueReposito
             EndDate = c.WeekEndDatetime,
         }).ToList();
 
-        for (var i = -2; i < 2; i++) {
-            // Regular Season
-            for (var j = 1; j < 19; j++) {
-                var scores = await espn.GetWeekScores(j, DateTime.UtcNow.AddYears(i).Year);
-                if (scores is null || scores.Events is null)
-                    break;
-                var results = scores.Events.SelectMany(x => x.Competitions,
-                        (x, y) => new CompetitionBySeason { Id = int.Parse(x.Id), Season = x.Season, Competition = y })
-                    .Where(y => GameHelpers.IsGameOver(y.Competition)).ToList();
-                if (results.Count != 0) {
-                    scoreList.AddRange(results.ParseCompetitionToNflScore(GameHelpers.GetWeekFromEspnWeek(j)));
+        // Beyond "configs exist" — is a season actually happening right now? Without this, this
+        // loop hits ESPN for up to 5 years x 22 weeks every scheduled run, in-season or not.
+        var windows = configs.Select(c => new SeasonWindowResolver.Window(c.Season, c.WeekStartDatetime, c.WeekEndDatetime));
+        if (!SeasonWindowResolver.IsSeasonActive(windows, DateTime.UtcNow)) {
+            Log.Information("NflScoresJob: no season currently active, skipping ESPN fetch");
+        } else {
+            for (var i = -2; i < 2; i++) {
+                // Regular Season
+                for (var j = 1; j < 19; j++) {
+                    var scores = await espn.GetWeekScores(j, DateTime.UtcNow.AddYears(i).Year);
+                    if (scores is null || scores.Events is null)
+                        break;
+                    var results = scores.Events.SelectMany(x => x.Competitions,
+                            (x, y) => new CompetitionBySeason { Id = int.Parse(x.Id), Season = x.Season, Competition = y })
+                        .Where(y => GameHelpers.IsGameOver(y.Competition)).ToList();
+                    if (results.Count != 0) {
+                        scoreList.AddRange(results.ParseCompetitionToNflScore(GameHelpers.GetWeekFromEspnWeek(j)));
+                    }
                 }
-            }
 
-            for (var j = 1; j < 6; j++) {
-                if (j == 4)
-                    continue; // Skip week 4 as ESPN treats week 4 as the Pro Bowl
-                var scores = await espn.GetWeekScores(j, DateTime.UtcNow.AddYears(i).Year, true);
-                if (scores is null || scores.Events is null)
-                    break;
-                var results = scores.Events.SelectMany(x => x.Competitions,
-                        (x, y) => new CompetitionBySeason { Id = int.Parse(x.Id), Season = x.Season, Competition = y })
-                    .Where(y => GameHelpers.IsGameOver(y.Competition)).ToList();
-                if (results.Count != 0) {
-                    scoreList.AddRange(
-                        results.ParseCompetitionToNflScore(GameHelpers.GetWeekFromEspnWeek(j == 5 ? 4 : j, true)));
+                for (var j = 1; j < 6; j++) {
+                    if (j == 4)
+                        continue; // Skip week 4 as ESPN treats week 4 as the Pro Bowl
+                    var scores = await espn.GetWeekScores(j, DateTime.UtcNow.AddYears(i).Year, true);
+                    if (scores is null || scores.Events is null)
+                        break;
+                    var results = scores.Events.SelectMany(x => x.Competitions,
+                            (x, y) => new CompetitionBySeason { Id = int.Parse(x.Id), Season = x.Season, Competition = y })
+                        .Where(y => GameHelpers.IsGameOver(y.Competition)).ToList();
+                    if (results.Count != 0) {
+                        scoreList.AddRange(
+                            results.ParseCompetitionToNflScore(GameHelpers.GetWeekFromEspnWeek(j == 5 ? 4 : j, true)));
+                    }
                 }
             }
         }

--- a/Server/Services/CfbCacheService.cs
+++ b/Server/Services/CfbCacheService.cs
@@ -36,6 +36,12 @@ public class CfbCacheService : ICfbCacheService, IAsyncDisposable
                 var currentSlateService = scope.ServiceProvider.GetRequiredService<ICfbCurrentSlateService>();
                 var cfbRepo = scope.ServiceProvider.GetRequiredService<ICfbRepository>();
 
+                // CfbCurrentSlateService always resolves *something* now (most-recently-completed
+                // or soonest-upcoming slate, for UI-default purposes) — so its null-ness alone can
+                // no longer be used to gate off-season ESPN polling. IsSeasonActiveAsync is the
+                // purpose-built, season-level check for that (see SeasonWindowResolver).
+                if (!await currentSlateService.IsSeasonActiveAsync()) return null;
+
                 var currentSlate = await currentSlateService.GetCurrentSlateAsync();
                 if (currentSlate is null) return null;
 

--- a/Server/Services/CfbCurrentSlateService.cs
+++ b/Server/Services/CfbCurrentSlateService.cs
@@ -4,20 +4,22 @@ using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 namespace FourPlayWebApp.Server.Services;
 
 public class CfbCurrentSlateService(ICfbRepository repo) : ICfbCurrentSlateService {
-    private const int ConfiguredSeason = 2026;
-
     public async Task<CfbSlateInfo?> GetCurrentSlateAsync() {
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
-        var slates = (await repo.GetSlatesForSeasonAsync(ConfiguredSeason)).ToList();
+        var now = today.ToDateTime(TimeOnly.MinValue);
+        var slates = (await repo.GetAllSlatesAsync()).ToList();
 
-        // Empty or pre-season: no slates yet, or all are future — fall back to prior year
-        if (slates.All(s => s.StartDate > today))
-            slates = (await repo.GetSlatesForSeasonAsync(ConfiguredSeason - 1)).ToList();
+        // Active window wins; else most-recently-completed (off-season); else soonest
+        // upcoming (pre-season) — see SeasonWindowResolver for the shared NFL/CFB logic.
+        // No hardcoded season: resolves purely from whatever slates exist in the DB.
+        var windows = slates.Select(s => new SeasonWindowResolver.Window(
+            s.Season, s.StartDate.ToDateTime(TimeOnly.MinValue), s.EndDate.ToDateTime(TimeOnly.MaxValue)));
+        var resolved = SeasonWindowResolver.ResolveCurrentWeek(windows, now);
+        if (resolved is null) return null;
 
-        if (slates.Count == 0) return null;
-
-        // First slate whose end date hasn't passed = current; all past → show last (off-season)
-        var active = slates.FirstOrDefault(s => s.EndDate >= today) ?? slates[^1];
+        var active = slates.First(s => s.Season == resolved.Value.Season
+            && s.StartDate.ToDateTime(TimeOnly.MinValue) == resolved.Value.Start
+            && s.EndDate.ToDateTime(TimeOnly.MaxValue) == resolved.Value.End);
 
         var configs = await repo.GetWeekConfigsForSeasonAsync(active.Season);
         var matchingConfig = configs.FirstOrDefault(c => c.IvLeagueWeekNumber == active.SlateNumber);
@@ -31,5 +33,12 @@ public class CfbCurrentSlateService(ICfbRepository repo) : ICfbCurrentSlateServi
 
         return new CfbSlateInfo(active.Id, active.Season, active.SlateNumber, active.Label,
             active.SlateType, active.StartDate, active.EndDate, active.FirstGameUtc, matchingConfig.SpreadLockDatetime);
+    }
+
+    public async Task<bool> IsSeasonActiveAsync() {
+        var slates = await repo.GetAllSlatesAsync();
+        var windows = slates.Select(s => new SeasonWindowResolver.Window(
+            s.Season, s.StartDate.ToDateTime(TimeOnly.MinValue), s.EndDate.ToDateTime(TimeOnly.MaxValue)));
+        return SeasonWindowResolver.IsSeasonActive(windows, DateTime.UtcNow);
     }
 }

--- a/Server/Services/CfbLiveScoreFetcher.cs
+++ b/Server/Services/CfbLiveScoreFetcher.cs
@@ -40,7 +40,13 @@ public class CfbLiveScoreFetcher(ICfbApiService cfbApi, IServiceScopeFactory sco
         // only writes finished games), so 100 concurrent viewers of the same past slate share one
         // DB read instead of each triggering its own ESPN call — mirrors EspnCacheService's
         // identical fix for NFL's historical-week endpoint.
-        var slateHasEnded = slate.EndDate < DateOnly.FromDateTime(DateTime.UtcNow);
+        //
+        // EndDate is a DateOnly with no time component, but a late game (common for CFB evening
+        // kickoffs) can still be in progress after UTC midnight on that calendar date — a straight
+        // date compare would flip to "ended" mid-game. The 6-hour buffer past the end of EndDate
+        // covers that crossover; this now gets cached forever once true (see the caching layer
+        // below), so getting this boundary right matters more than it used to.
+        var slateHasEnded = slate.EndDate.ToDateTime(TimeOnly.MaxValue).AddHours(6) < DateTime.UtcNow;
         if (slateHasEnded) {
             var cacheKey = $"cfb-slate-scores_{slate.Id}";
             if (settledCache.TryGetValue<EspnScores>(cacheKey, out var cached)) return cached;

--- a/Server/Services/CfbLiveScoreFetcher.cs
+++ b/Server/Services/CfbLiveScoreFetcher.cs
@@ -1,12 +1,17 @@
 using FourPlayWebApp.Server.Jobs;
 using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 
 namespace FourPlayWebApp.Server.Services;
 
-public class CfbLiveScoreFetcher(ICfbApiService cfbApi) : ICfbLiveScoreFetcher {
+// ICfbRepository is registered Scoped, but this fetcher is a Singleton — resolving it directly in
+// the constructor would be a captive-dependency DI violation (same pattern CfbCacheService already
+// uses for the identical problem; see its own comment).
+public class CfbLiveScoreFetcher(ICfbApiService cfbApi, IServiceScopeFactory scopeFactory) : ICfbLiveScoreFetcher {
     public async Task<EspnScores?> FetchForSlateAsync(CfbSlates slate) {
         // CfbSeasonWeekConfig.EspnWeekNumber is non-nullable, and both known producers of CfbSlates
         // rows (CfbSlateSeederJob, DemoDataSeeder) always copy a real week number through — so every
@@ -14,11 +19,41 @@ public class CfbLiveScoreFetcher(ICfbApiService cfbApi) : ICfbLiveScoreFetcher {
         // date-range "scoreboard" calls. CfbSlates.EspnWeekNumber itself is still nullable at the
         // model/DB level though, so a future producer could leave it unset — a missing value here
         // means the control table wasn't seeded correctly, not a case to silently paper over with a
-        // date-range fallback.
+        // date-range fallback. Checked up front so it applies uniformly to the DB-first branch below
+        // too — /code-review caught that branch silently defaulting a missing value to week 0
+        // instead of applying this same guard.
         if (!slate.EspnWeekNumber.HasValue) {
             Log.Warning("CfbLiveScoreFetcher: slate {SlateId} has no EspnWeekNumber — skipping", slate.Id);
             return null;
         }
+
+        // DB-first: only once the slate's own window has fully ended — while a slate is still
+        // active, ESPN is always the source of truth regardless of how many of its games have
+        // already been persisted. /code-review caught a real bug in an earlier version of this
+        // check that gated purely on "any row persisted": the instant ONE game in a multi-game
+        // slate finished, every subsequent call permanently stopped calling ESPN, so the rest of
+        // that slate's still-in-progress games were never discovered or persisted — this backs
+        // both CfbScoresJob (which would never finish collecting that slate) and CfbCacheService's
+        // live poll of the CURRENT slate (which would freeze the Scores page mid-slate). Once the
+        // window has ended, a slate whose games are all persisted is always FINAL (CfbScoresJob
+        // only writes finished games), so 100 concurrent viewers of the same past slate share one
+        // DB read instead of each triggering its own ESPN call — mirrors EspnCacheService's
+        // identical fix for NFL's historical-week endpoint.
+        var slateHasEnded = slate.EndDate < DateOnly.FromDateTime(DateTime.UtcNow);
+        if (slateHasEnded) {
+            using var scope = scopeFactory.CreateScope();
+            var cfbRepo = scope.ServiceProvider.GetRequiredService<ICfbRepository>();
+            var rows = (await cfbRepo.GetScoresForSlateAsync(slate.Id)).ToList();
+            if (rows.Count > 0) {
+                var games = rows.Select(row => new FinalScoresEspnMapper.FinishedGame(
+                    row.Id.ToString(), row.HomeTeam, row.AwayTeam, row.HomeTeamScore, row.AwayTeamScore, row.GameTime,
+                    row.WeatherDisplayValue is null && row.WeatherConditionId is null && row.WeatherTemperatureF is null
+                        ? null
+                        : new FinalScoresEspnMapper.WeatherInfo(row.WeatherDisplayValue, row.WeatherConditionId, row.WeatherTemperatureF)));
+                return FinalScoresEspnMapper.Build(games, slate.Season, slate.EspnWeekNumber.Value, CfbSlateHelpers.IsCfpSlate(slate.ScoringFormat));
+            }
+        }
+
         return CfbSlateHelpers.IsCfpSlate(slate.ScoringFormat)
             ? await FetchCfpAsync(slate)
             : await FetchRankedWeekAsync(slate);

--- a/Server/Services/CfbLiveScoreFetcher.cs
+++ b/Server/Services/CfbLiveScoreFetcher.cs
@@ -3,6 +3,7 @@ using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 
@@ -11,7 +12,7 @@ namespace FourPlayWebApp.Server.Services;
 // ICfbRepository is registered Scoped, but this fetcher is a Singleton — resolving it directly in
 // the constructor would be a captive-dependency DI violation (same pattern CfbCacheService already
 // uses for the identical problem; see its own comment).
-public class CfbLiveScoreFetcher(ICfbApiService cfbApi, IServiceScopeFactory scopeFactory) : ICfbLiveScoreFetcher {
+public class CfbLiveScoreFetcher(ICfbApiService cfbApi, IServiceScopeFactory scopeFactory, IMemoryCache settledCache) : ICfbLiveScoreFetcher {
     public async Task<EspnScores?> FetchForSlateAsync(CfbSlates slate) {
         // CfbSeasonWeekConfig.EspnWeekNumber is non-nullable, and both known producers of CfbSlates
         // rows (CfbSlateSeederJob, DemoDataSeeder) always copy a real week number through — so every
@@ -41,6 +42,9 @@ public class CfbLiveScoreFetcher(ICfbApiService cfbApi, IServiceScopeFactory sco
         // identical fix for NFL's historical-week endpoint.
         var slateHasEnded = slate.EndDate < DateOnly.FromDateTime(DateTime.UtcNow);
         if (slateHasEnded) {
+            var cacheKey = $"cfb-slate-scores_{slate.Id}";
+            if (settledCache.TryGetValue<EspnScores>(cacheKey, out var cached)) return cached;
+
             using var scope = scopeFactory.CreateScope();
             var cfbRepo = scope.ServiceProvider.GetRequiredService<ICfbRepository>();
             var rows = (await cfbRepo.GetScoresForSlateAsync(slate.Id)).ToList();
@@ -50,7 +54,9 @@ public class CfbLiveScoreFetcher(ICfbApiService cfbApi, IServiceScopeFactory sco
                     row.WeatherDisplayValue is null && row.WeatherConditionId is null && row.WeatherTemperatureF is null
                         ? null
                         : new FinalScoresEspnMapper.WeatherInfo(row.WeatherDisplayValue, row.WeatherConditionId, row.WeatherTemperatureF)));
-                return FinalScoresEspnMapper.Build(games, slate.Season, slate.EspnWeekNumber.Value, CfbSlateHelpers.IsCfpSlate(slate.ScoringFormat));
+                var built = FinalScoresEspnMapper.Build(games, slate.Season, slate.EspnWeekNumber.Value, CfbSlateHelpers.IsCfpSlate(slate.ScoringFormat));
+                settledCache.Set(cacheKey, built);
+                return built;
             }
         }
 

--- a/Server/Services/DemoEspnCacheService.cs
+++ b/Server/Services/DemoEspnCacheService.cs
@@ -49,63 +49,9 @@ public class DemoEspnCacheService : IEspnCacheService
 
         if (rows.Count == 0) return null;
 
-        var events = rows.Select(row => BuildEvent(row, week, year, postSeason)).ToArray();
+        var games = rows.Select(row => new FinalScoresEspnMapper.FinishedGame(
+            row.Id.ToString(), row.HomeTeam, row.AwayTeam, row.HomeTeamScore, row.AwayTeamScore, row.GameTime));
 
-        return new EspnScores {
-            Leagues = [],
-            Season = new Season { Year = year, Type = postSeason ? 3 : 2 },
-            Week = new Week { Number = week },
-            Events = events,
-        };
-    }
-
-    private static Event BuildEvent(Shared.Models.Data.NflScores row, int week, int year, bool postSeason)
-    {
-        var id = row.Id.ToString();
-        var competition = new Competition {
-            Id = id,
-            Date = row.GameTime,
-            Competitors = [
-                new Competitor {
-                    Id = "1",
-                    HomeAway = HomeAway.Home,
-                    Team = new EspnTeam { Abbreviation = row.HomeTeam },
-                    Score = row.HomeTeamScore,
-                    Records = [],
-                },
-                new Competitor {
-                    Id = "2",
-                    HomeAway = HomeAway.Away,
-                    Team = new EspnTeam { Abbreviation = row.AwayTeam },
-                    Score = row.AwayTeamScore,
-                    Records = [],
-                },
-            ],
-            Status = new EspnStatus {
-                Clock = 0,
-                DisplayClock = "0:00",
-                Period = 4,
-                Type = new StatusType {
-                    Id = 3,
-                    Name = TypeName.StatusFinal,
-                    State = State.Post,
-                    Completed = true,
-                    Description = Description.Final,
-                    Detail = "Final",
-                    ShortDetail = "Final",
-                },
-            },
-            Odds = [],
-            Situation = null,
-        };
-
-        return new Event {
-            Id = id,
-            Season = new Season { Year = year, Type = postSeason ? 3 : 2 },
-            Week = new Week { Number = week },
-            Date = row.GameTime,
-            Competitions = [competition],
-            Weather = null,
-        };
+        return FinalScoresEspnMapper.Build(games, year, week, postSeason);
     }
 }

--- a/Server/Services/EspnCacheService.cs
+++ b/Server/Services/EspnCacheService.cs
@@ -1,4 +1,6 @@
 using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Server.Services.Repositories.Interfaces;
+using FourPlayWebApp.Shared.Helpers;
 using FourPlayWebApp.Shared.Models;
 
 namespace FourPlayWebApp.Server.Services;
@@ -10,6 +12,7 @@ namespace FourPlayWebApp.Server.Services;
 public class EspnCacheService : IEspnCacheService, IAsyncDisposable
 {
     private readonly IEspnApiService _espnApiService;
+    private readonly ILeagueRepository _leagueRepository;
     private readonly PeriodicRefreshCache<EspnScores> _cache;
 
     public event Action? ScoresChanged
@@ -18,11 +21,18 @@ public class EspnCacheService : IEspnCacheService, IAsyncDisposable
         remove => _cache.Changed -= value;
     }
 
-    public EspnCacheService(IEspnApiService espnApiService, INflCurrentWeekService nflCurrentWeekService, TimeSpan? initialDelay = null)
+    public EspnCacheService(IEspnApiService espnApiService, INflCurrentWeekService nflCurrentWeekService, ILeagueRepository leagueRepository, TimeSpan? initialDelay = null)
     {
         _espnApiService = espnApiService;
+        _leagueRepository = leagueRepository;
         _cache = new PeriodicRefreshCache<EspnScores>(
             fetch: async () => {
+                // NflCurrentWeekService always resolves *something* now (most-recently-completed
+                // or soonest-upcoming week, for UI-default purposes) — so its result alone can't
+                // gate off-season ESPN polling. IsSeasonActiveAsync is the purpose-built,
+                // season-level check for that (see SeasonWindowResolver).
+                if (!await nflCurrentWeekService.IsSeasonActiveAsync()) return null;
+
                 var week = await nflCurrentWeekService.GetCurrentWeekAsync();
                 return await espnApiService.GetWeekScores(week.EspnWeek, week.Season, week.IsPostSeason);
             },
@@ -33,8 +43,22 @@ public class EspnCacheService : IEspnCacheService, IAsyncDisposable
 
     public Task<EspnScores?> GetScoresAsync() => Task.FromResult(_cache.Current);
 
-    public Task<EspnScores?> GetWeekScoresAsync(int week, int year, bool postSeason = false) =>
-        _espnApiService.GetWeekScores(week, year, postSeason);
+    // Historical weeks are read straight from NflScores when persisted — every persisted row is
+    // already FINAL (NflScoresJob only writes finished games), so 100 concurrent viewers of the
+    // same past week share one DB read instead of each triggering its own ESPN call. Only a week
+    // NflScoresJob hasn't synced yet (or a genuinely current/future week — not this endpoint's
+    // real use, see EspnController's doc comment) falls through to a live ESPN call.
+    public async Task<EspnScores?> GetWeekScoresAsync(int week, int year, bool postSeason = false)
+    {
+        var nflWeek = GameHelpers.GetWeekFromEspnWeek(week, postSeason);
+        var rows = await _leagueRepository.GetNflScoresAsync(year, nflWeek);
+        if (rows.Count > 0) {
+            var games = rows.Select(row => new FinalScoresEspnMapper.FinishedGame(
+                row.Id.ToString(), row.HomeTeam, row.AwayTeam, row.HomeTeamScore, row.AwayTeamScore, row.GameTime));
+            return FinalScoresEspnMapper.Build(games, year, week, postSeason);
+        }
+        return await _espnApiService.GetWeekScores(week, year, postSeason);
+    }
 
     public ValueTask DisposeAsync() => _cache.DisposeAsync();
 }

--- a/Server/Services/EspnCacheService.cs
+++ b/Server/Services/EspnCacheService.cs
@@ -2,6 +2,7 @@ using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Helpers;
 using FourPlayWebApp.Shared.Models;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace FourPlayWebApp.Server.Services;
 
@@ -13,6 +14,7 @@ public class EspnCacheService : IEspnCacheService, IAsyncDisposable
 {
     private readonly IEspnApiService _espnApiService;
     private readonly ILeagueRepository _leagueRepository;
+    private readonly IMemoryCache _historicalCache;
     private readonly PeriodicRefreshCache<EspnScores> _cache;
 
     public event Action? ScoresChanged
@@ -21,10 +23,11 @@ public class EspnCacheService : IEspnCacheService, IAsyncDisposable
         remove => _cache.Changed -= value;
     }
 
-    public EspnCacheService(IEspnApiService espnApiService, INflCurrentWeekService nflCurrentWeekService, ILeagueRepository leagueRepository, TimeSpan? initialDelay = null)
+    public EspnCacheService(IEspnApiService espnApiService, INflCurrentWeekService nflCurrentWeekService, ILeagueRepository leagueRepository, IMemoryCache historicalCache, TimeSpan? initialDelay = null)
     {
         _espnApiService = espnApiService;
         _leagueRepository = leagueRepository;
+        _historicalCache = historicalCache;
         _cache = new PeriodicRefreshCache<EspnScores>(
             fetch: async () => {
                 // NflCurrentWeekService always resolves *something* now (most-recently-completed
@@ -45,17 +48,23 @@ public class EspnCacheService : IEspnCacheService, IAsyncDisposable
 
     // Historical weeks are read straight from NflScores when persisted — every persisted row is
     // already FINAL (NflScoresJob only writes finished games), so 100 concurrent viewers of the
-    // same past week share one DB read instead of each triggering its own ESPN call. Only a week
-    // NflScoresJob hasn't synced yet (or a genuinely current/future week — not this endpoint's
-    // real use, see EspnController's doc comment) falls through to a live ESPN call.
+    // same past week share one DB read (and one build, cached indefinitely — settled data never
+    // changes) instead of each triggering its own ESPN call or DB query. Only a week NflScoresJob
+    // hasn't synced yet (or a genuinely current/future week — not this endpoint's real use, see
+    // EspnController's doc comment) falls through to a live ESPN call.
     public async Task<EspnScores?> GetWeekScoresAsync(int week, int year, bool postSeason = false)
     {
+        var cacheKey = $"nfl-week-scores_{year}_{week}_{postSeason}";
+        if (_historicalCache.TryGetValue<EspnScores>(cacheKey, out var cached)) return cached;
+
         var nflWeek = GameHelpers.GetWeekFromEspnWeek(week, postSeason);
         var rows = await _leagueRepository.GetNflScoresAsync(year, nflWeek);
         if (rows.Count > 0) {
             var games = rows.Select(row => new FinalScoresEspnMapper.FinishedGame(
                 row.Id.ToString(), row.HomeTeam, row.AwayTeam, row.HomeTeamScore, row.AwayTeamScore, row.GameTime));
-            return FinalScoresEspnMapper.Build(games, year, week, postSeason);
+            var built = FinalScoresEspnMapper.Build(games, year, week, postSeason);
+            _historicalCache.Set(cacheKey, built);
+            return built;
         }
         return await _espnApiService.GetWeekScores(week, year, postSeason);
     }

--- a/Server/Services/EspnCacheService.cs
+++ b/Server/Services/EspnCacheService.cs
@@ -52,19 +52,36 @@ public class EspnCacheService : IEspnCacheService, IAsyncDisposable
     // changes) instead of each triggering its own ESPN call or DB query. Only a week NflScoresJob
     // hasn't synced yet (or a genuinely current/future week — not this endpoint's real use, see
     // EspnController's doc comment) falls through to a live ESPN call.
+    //
+    // DB-first only kicks in once the week's own window has fully ended — /code-review caught
+    // that this exact bug, already fixed for CFB in CfbLiveScoreFetcher (see its comment), had
+    // not been ported here: gating purely on "any row persisted" means the instant one game in a
+    // multi-game week finishes and gets persisted, the response is built from only that game and
+    // cached forever — every other game in that week, including ones that finish and get
+    // persisted later, is permanently dropped from every future response.
     public async Task<EspnScores?> GetWeekScoresAsync(int week, int year, bool postSeason = false)
     {
         var cacheKey = $"nfl-week-scores_{year}_{week}_{postSeason}";
         if (_historicalCache.TryGetValue<EspnScores>(cacheKey, out var cached)) return cached;
 
         var nflWeek = GameHelpers.GetWeekFromEspnWeek(week, postSeason);
-        var rows = await _leagueRepository.GetNflScoresAsync(year, nflWeek);
-        if (rows.Count > 0) {
-            var games = rows.Select(row => new FinalScoresEspnMapper.FinishedGame(
-                row.Id.ToString(), row.HomeTeam, row.AwayTeam, row.HomeTeamScore, row.AwayTeamScore, row.GameTime));
-            var built = FinalScoresEspnMapper.Build(games, year, week, postSeason);
-            _historicalCache.Set(cacheKey, built);
-            return built;
+        var configs = await _leagueRepository.GetNflSeasonWeekConfigsAsync();
+        var matchingConfig = configs.FirstOrDefault(c => c.Season == year && c.WeekId == nflWeek);
+        // 6-hour buffer past the configured end, mirroring CfbLiveScoreFetcher's identical
+        // safety margin — this now gets cached forever once true, so a week whose config end
+        // time turns out to be a little too tight against its actual last kickoff shouldn't
+        // permanently freeze a still-in-progress game out of every future response.
+        var weekHasEnded = matchingConfig is not null && matchingConfig.WeekEndDatetime.AddHours(6) < DateTime.UtcNow;
+
+        if (weekHasEnded) {
+            var rows = await _leagueRepository.GetNflScoresAsync(year, nflWeek);
+            if (rows.Count > 0) {
+                var games = rows.Select(row => new FinalScoresEspnMapper.FinishedGame(
+                    row.Id.ToString(), row.HomeTeam, row.AwayTeam, row.HomeTeamScore, row.AwayTeamScore, row.GameTime));
+                var built = FinalScoresEspnMapper.Build(games, year, week, postSeason);
+                _historicalCache.Set(cacheKey, built);
+                return built;
+            }
         }
         return await _espnApiService.GetWeekScores(week, year, postSeason);
     }

--- a/Server/Services/FinalScoresEspnMapper.cs
+++ b/Server/Services/FinalScoresEspnMapper.cs
@@ -1,0 +1,68 @@
+using FourPlayWebApp.Shared.Models;
+
+namespace FourPlayWebApp.Server.Services;
+
+// Builds an EspnScores wire-shape response from this app's own persisted, already-FINAL score
+// rows (NflScores/CfbScores) — one shared implementation both sports' "serve a historical
+// week/slate from the DB instead of a live ESPN call" paths call, since DB only ever persists a
+// game once it's FINAL (NflScoresJob, CfbScoresJob). Extracted from what was previously a
+// private, NFL-only helper in DemoEspnCacheService.BuildEvent.
+public static class FinalScoresEspnMapper {
+    public readonly record struct WeatherInfo(string? DisplayValue, string? ConditionId, int? TemperatureF);
+
+    public readonly record struct FinishedGame(
+        string Id, string HomeTeam, string AwayTeam,
+        int HomeScore, int AwayScore, DateTimeOffset GameTime,
+        WeatherInfo? Weather = null);
+
+    public static EspnScores Build(IEnumerable<FinishedGame> games, int season, int week, bool postSeason) {
+        var events = games.Select(g => BuildEvent(g, season, week, postSeason)).ToArray();
+        return new EspnScores {
+            Leagues = [],
+            Season = new Season { Year = season, Type = postSeason ? 3 : 2 },
+            Week = new Week { Number = week },
+            Events = events,
+        };
+    }
+
+    private static Event BuildEvent(FinishedGame game, int season, int week, bool postSeason) {
+        var competition = new Competition {
+            Id = game.Id,
+            Date = game.GameTime,
+            Competitors = [
+                new Competitor { Id = "1", HomeAway = HomeAway.Home, Team = new EspnTeam { Abbreviation = game.HomeTeam }, Score = game.HomeScore, Records = [] },
+                new Competitor { Id = "2", HomeAway = HomeAway.Away, Team = new EspnTeam { Abbreviation = game.AwayTeam }, Score = game.AwayScore, Records = [] },
+            ],
+            Status = new EspnStatus {
+                Clock = 0,
+                DisplayClock = "0:00",
+                Period = 4,
+                Type = new StatusType {
+                    Id = 3,
+                    Name = TypeName.StatusFinal,
+                    State = State.Post,
+                    Completed = true,
+                    Description = Description.Final,
+                    Detail = "Final",
+                    ShortDetail = "Final",
+                },
+            },
+            Odds = [],
+            Situation = null,
+        };
+
+        return new Event {
+            Id = game.Id,
+            Season = new Season { Year = season, Type = postSeason ? 3 : 2 },
+            Week = new Week { Number = week },
+            Date = game.GameTime,
+            Competitions = [competition],
+            Weather = game.Weather is { } w ? new EspnWeather {
+                DisplayValue = w.DisplayValue,
+                ConditionId = w.ConditionId,
+                Temperature = w.TemperatureF ?? 0,
+                HighTemperature = w.TemperatureF ?? 0,
+            } : null,
+        };
+    }
+}

--- a/Server/Services/Interfaces/ICfbCurrentSlateService.cs
+++ b/Server/Services/Interfaces/ICfbCurrentSlateService.cs
@@ -5,4 +5,9 @@ public record CfbSlateInfo(int Id, int Season, int SlateNumber, string Label, st
 
 public interface ICfbCurrentSlateService {
     Task<CfbSlateInfo?> GetCurrentSlateAsync();
+
+    // Season-level (not slate-level) check: is a season actually happening right now, at all?
+    // Callers that only need this yes/no answer (the ESPN cache poller) should use this instead
+    // of re-deriving it externally — this service already owns the row-fetch + window-mapping.
+    Task<bool> IsSeasonActiveAsync();
 }

--- a/Server/Services/Interfaces/INflCurrentWeekService.cs
+++ b/Server/Services/Interfaces/INflCurrentWeekService.cs
@@ -4,4 +4,9 @@ public record NflWeekInfo(int WeekId, int EspnWeek, int Season, bool IsPostSeaso
 
 public interface INflCurrentWeekService {
     Task<NflWeekInfo> GetCurrentWeekAsync();
+
+    // Season-level (not week-level) check: is a season actually happening right now, at all?
+    // Callers that only need this yes/no answer (the ESPN cache poller) should use this instead
+    // of re-deriving it externally — this service already owns the row-fetch + window-mapping.
+    Task<bool> IsSeasonActiveAsync();
 }

--- a/Server/Services/InvitationService.cs
+++ b/Server/Services/InvitationService.cs
@@ -46,6 +46,7 @@ public class InvitationService(IDbContextFactory<ApplicationDbContext> dbContext
             invitation.InvitedByUserId = invitedByUserId;
             invitation.ExpiresAt = DateTimeOffset.UtcNow.AddDays(7);
             Log.Information("Invitation for {Email} to league {LeagueId} refreshed by {UserId}", email, leagueId, invitedByUserId);
+            await dbContext.SaveChangesAsync();
         } else {
             invitation = new Invitation {
                 Email = email,
@@ -56,9 +57,17 @@ public class InvitationService(IDbContextFactory<ApplicationDbContext> dbContext
             };
             dbContext.Invitations.Add(invitation);
             Log.Information("Invitation created for {Email} by {UserId}", email, invitedByUserId);
+            try {
+                await dbContext.SaveChangesAsync();
+            } catch (DbUpdateException) {
+                // TOCTOU: a concurrent request already inserted this exact (Email, LeagueId) pair
+                // between our read and write — same race LeagueMembershipInviteService.CreateOrReopenAsync
+                // guards against. Re-read whichever row won so the caller gets a usable Invitation
+                // back instead of an unhandled 500.
+                invitation = await dbContext.Invitations
+                    .FirstAsync(i => i.Email == email && i.LeagueId == leagueId);
+            }
         }
-
-        await dbContext.SaveChangesAsync();
 
         if (!string.IsNullOrWhiteSpace(baseUrl)) {
             try {

--- a/Server/Services/NflCurrentWeekService.cs
+++ b/Server/Services/NflCurrentWeekService.cs
@@ -8,19 +8,21 @@ public class NflCurrentWeekService(ILeagueRepository repo) : INflCurrentWeekServ
         var now = DateTime.UtcNow;
         var configs = await repo.GetNflSeasonWeekConfigsAsync();
 
-        var active = configs.FirstOrDefault(c => c.WeekStartDatetime <= now && now <= c.WeekEndDatetime);
+        // Active window wins; else most-recently-completed (off-season); else soonest
+        // upcoming (pre-season) — see SeasonWindowResolver for the shared NFL/CFB logic.
+        var windows = configs.Select(c => new SeasonWindowResolver.Window(c.Season, c.WeekStartDatetime, c.WeekEndDatetime));
+        var resolved = SeasonWindowResolver.ResolveCurrentWeek(windows, now)
+            ?? throw new InvalidOperationException("No NflSeasonWeekConfig rows exist — cannot resolve a current week.");
 
-        // Off-season: return most recent completed week
-        active ??= configs.Where(c => c.WeekEndDatetime < now)
-                          .OrderByDescending(c => c.WeekEndDatetime)
-                          .FirstOrDefault();
+        var config = configs.First(c => c.Season == resolved.Season
+            && c.WeekStartDatetime == resolved.Start && c.WeekEndDatetime == resolved.End);
+        return ToWeekInfo(config);
+    }
 
-        // Pre-season: return upcoming Week 1
-        active ??= configs.Where(c => c.WeekStartDatetime > now)
-                          .OrderBy(c => c.WeekStartDatetime)
-                          .First();
-
-        return ToWeekInfo(active);
+    public async Task<bool> IsSeasonActiveAsync() {
+        var configs = await repo.GetNflSeasonWeekConfigsAsync();
+        var windows = configs.Select(c => new SeasonWindowResolver.Window(c.Season, c.WeekStartDatetime, c.WeekEndDatetime));
+        return SeasonWindowResolver.IsSeasonActive(windows, DateTime.UtcNow);
     }
 
     private static NflWeekInfo ToWeekInfo(Models.Data.NflSeasonWeekConfig cfg) {

--- a/Server/Services/Repositories/CfbRepository.cs
+++ b/Server/Services/Repositories/CfbRepository.cs
@@ -46,6 +46,13 @@ public class CfbRepository(IDbContextFactory<ApplicationDbContext> dbFactory) : 
             .ToListAsync();
     }
 
+    public async Task<IEnumerable<CfbSlates>> GetAllSlatesAsync() {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        return await db.CfbSlates
+            .OrderBy(s => s.Season).ThenBy(s => s.SlateNumber)
+            .ToListAsync();
+    }
+
     public async Task<CfbSlates?> GetSlateByIdAsync(int slateId) {
         await using var db = await dbFactory.CreateDbContextAsync();
         return await db.CfbSlates.FirstOrDefaultAsync(s => s.Id == slateId);

--- a/Server/Services/Repositories/Interfaces/ICfbRepository.cs
+++ b/Server/Services/Repositories/Interfaces/ICfbRepository.cs
@@ -10,6 +10,7 @@ public interface ICfbRepository : ISpreadRepository<CfbSpreads> {
     // CfbSpreads/CfbScores/CfbPicks data — see CfbRepositoryTests for the guard behavior.
     Task<bool> DeleteSlatesAsync(IEnumerable<CfbSlates> slates);
     Task<IEnumerable<CfbSlates>> GetSlatesForSeasonAsync(int season);
+    Task<IEnumerable<CfbSlates>> GetAllSlatesAsync();
     Task<CfbSlates?> GetSlateByIdAsync(int slateId);
     Task UpsertCfbScoresAsync(IEnumerable<CfbScores> scores);
     Task<IEnumerable<CfbSpreads>> GetSpreadsForSlateAsync(int cfbSlateId);

--- a/Server/Services/Repositories/LeagueRepository.cs
+++ b/Server/Services/Repositories/LeagueRepository.cs
@@ -329,7 +329,12 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
             var weeks = await db.CfbSeasonWeekConfigs.Where(c => c.Season == season).ToListAsync();
             if (weeks.Count == 0) return null;
             var start = weeks.Min(w => w.WeekStartDate).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
-            var end = weeks.Max(w => w.WeekEndDate).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+            // MaxValue (end of day), not MinValue — a DateOnly season end means the whole of that
+            // calendar day is still in-season, matching CfbCurrentSlateService's convention for
+            // the same "end of this date" concept. /code-review caught this using MinValue
+            // (midnight at the *start* of the last day), which excluded anyone active later that
+            // same day.
+            var end = weeks.Max(w => w.WeekEndDate).ToDateTime(TimeOnly.MaxValue, DateTimeKind.Utc);
             return (start, end);
         } else {
             var weeks = await db.NflSeasonWeekConfigs.Where(c => c.Season == season).ToListAsync();

--- a/Server/Services/SeasonWindowResolver.cs
+++ b/Server/Services/SeasonWindowResolver.cs
@@ -1,0 +1,48 @@
+namespace FourPlayWebApp.Server.Services;
+
+// Shared, pure NFL/CFB season-resolution logic. Both sports have a control table shaped as
+// "Season + a start/end window per week (NFL) or slate (CFB)" — this used to be two
+// independent, hand-written implementations (NflCurrentWeekService's fallback chain,
+// CfbCurrentSlateService's hardcoded-year hack) that had already drifted into a real bug.
+// No DB/ESPN dependency — callers map their own rows into Window and normalize any
+// DateOnly fields to DateTime first.
+public static class SeasonWindowResolver {
+    public readonly record struct Window(int Season, DateTime Start, DateTime End);
+
+    // WEEK-LEVEL: "which specific week/slate are we in (or nearest to)?" — fine-grained,
+    // used for UI defaults, the spread-lock schedule, and the spread-scheduling jobs. An
+    // active window wins; otherwise the most-recently-completed window; otherwise the
+    // soonest upcoming one; null only if the list is empty.
+    public static Window? ResolveCurrentWeek(IEnumerable<Window> windows, DateTime now) {
+        var list = windows as IReadOnlyCollection<Window> ?? windows.ToList();
+        if (list.Count == 0) return null;
+
+        var active = list.Where(w => w.Start <= now && now <= w.End)
+            .Cast<Window?>()
+            .FirstOrDefault();
+        if (active is not null) return active;
+
+        var mostRecentlyCompleted = list.Where(w => w.End < now)
+            .OrderByDescending(w => w.End)
+            .Cast<Window?>()
+            .FirstOrDefault();
+        if (mostRecentlyCompleted is not null) return mostRecentlyCompleted;
+
+        return list.Where(w => w.Start > now)
+            .OrderBy(w => w.Start)
+            .Cast<Window?>()
+            .FirstOrDefault();
+    }
+
+    // SEASON-LEVEL: "is a season actually happening right now, at all?" — coarse, used
+    // exclusively by the two ESPN cache pollers and the two score jobs to decide whether
+    // to do any ESPN-facing work this tick/run. A season's overall span is [earliest
+    // window's Start, latest window's End] *for that season* — deliberately coarser than
+    // "is one specific week window active," so a bye week or the gap between one week's
+    // Monday night game and the next week's Thursday kickoff still reads as in-season.
+    public static bool IsSeasonActive(IEnumerable<Window> windows, DateTime now) =>
+        windows
+            .GroupBy(w => w.Season)
+            .Select(g => (Start: g.Min(w => w.Start), End: g.Max(w => w.End)))
+            .Any(span => span.Start <= now && now <= span.End);
+}


### PR DESCRIPTION
## Summary
Promotes 2 PRs merged to `dev` since the last cutover (#264):

- #265 — fix: stop off-season ESPN polling; serve historical/settled scores from DB (unifies NFL/CFB season-window resolution, fixes the hardcoded `ConfiguredSeason` bug, caches settled scores in-memory)
- #266 — fix: address 5 follow-up findings from the season-window code-review pass (invite race condition, missing 404 guards + deduplication in LeagueController, CFB season end-date off-by-one-day bug, leaderboard stale-response race)

## Test plan
- [x] Each PR passed its own full CI (backend 686 tests, frontend 440 tests + typecheck + lint, mock e2e 80 tests, demo e2e, demo replay e2e, Docker parity, secret scan) before merging to `dev`
- [x] Both PRs went through `/code-review`; #266 exists specifically to close out findings from that review
- [x] Railway dev + Vercel preview both deployed cleanly for every merge commit in this range

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs