### PR TITLE
DTO cleanup, CFB e2e coverage, and prod-readiness polish

### DIFF
--- a/Client.React/e2e/helpers/auth.ts
+++ b/Client.React/e2e/helpers/auth.ts
@@ -8,7 +8,7 @@ import type { SetupRoutesOptions } from './routes';
  * /api/auth/me (which is mocked to return TEST_USER) to hydrate the auth
  * context. Presence of the cookie alone satisfies the client-side cookie check.
  */
-const FAKE_JWT =
+export const FAKE_JWT =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' +
   'eyJzdWIiOiJ0ZXN0LXVzZXItaWQtMDAxIiwibmFtZSI6IlRlc3RVc2VyIiwiaWF0IjoxNzAwMDAwMDAwfQ.' +
   'fake-signature-for-e2e-tests-only';

--- a/Client.React/e2e/helpers/cfbRoutes.ts
+++ b/Client.React/e2e/helpers/cfbRoutes.ts
@@ -1,0 +1,273 @@
+import type { Page } from '@playwright/test';
+import type { UserInfo } from '../../src/types/auth';
+import type { CfbPickDto, CfbSlateDto, CfbSpreadDto, LeagueUserMappingDto } from '../../src/types/league';
+import type { LeaderboardDto } from '../../src/types/leaderboard';
+import type { EspnScores } from '../../src/types/espn';
+import { createCompetition } from '../../src/test/fixtures';
+import { TEST_USER } from './routes';
+import { FAKE_JWT } from './auth';
+
+const mockInviteLink = () => ({
+  token: 'mocktokenabcdef1234567890abcdef12',
+  leagueId: 199,
+  leagueName: 'Test CFB League',
+  expiresAt: new Date(Date.now() + 86400000).toISOString(),
+});
+
+export const TEST_LEAGUE_ID = 2;
+export const TEST_SEASON = 2024;
+// Regular-season slate 1 → cfbSlateNumberToWeek gives week 1, non-postseason,
+// 4 required picks (getCfbRequiredPicks: slateNumber <= 14 => 4) — same shape as picks.spec.ts's
+// 2-games/4-buttons NFL setup.
+export const TEST_SLATE_ID = 501;
+export const TEST_SLATE_NUMBER = 1;
+
+export function createCfbPick(overrides: Partial<CfbPickDto> & { team: string }): CfbPickDto {
+  return {
+    id: 0,
+    userId: '123',
+    userName: 'TestUser',
+    leagueId: TEST_LEAGUE_ID,
+    cfbSlateId: TEST_SLATE_ID,
+    pickType: 'Spread',
+    season: TEST_SEASON,
+    ...overrides,
+  };
+}
+
+function cfbSpread(
+  cfbSlateId: number,
+  homeTeam: string,
+  awayTeam: string,
+  homeTeamSpread: number,
+  overUnder: number
+): CfbSpreadDto {
+  return {
+    id: cfbSlateId * 10 + homeTeam.length,
+    cfbSlateId,
+    homeTeam,
+    awayTeam,
+    homeTeamSpread,
+    awayTeamSpread: -homeTeamSpread,
+    overUnder,
+    gameTime: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+    dateCreated: new Date().toISOString(),
+  };
+}
+
+export interface SetupCfbRoutesOptions {
+  userPicks?: CfbPickDto[];
+  leaguePicks?: CfbPickDto[];
+  leaderboard?: LeaderboardDto[];
+  gameStarted?: boolean;
+  authUser?: UserInfo;
+}
+
+/**
+ * CFB counterpart to routes.ts's setupRoutes — mocks the DB-backed /api/cfb/* endpoints
+ * (spreads/picks/slate metadata) plus the ESPN live-overlay endpoints
+ * (/api/espn/cfb/*), matching cfbAdapter.ts's actual call graph. Intended for use with a
+ * cfb.localhost baseURL (see mockCfbAuth) so the app resolves the CFB adapter via
+ * useSportContext's hostname check.
+ */
+export async function setupCfbRoutes(page: Page, options: SetupCfbRoutesOptions = {}): Promise<void> {
+  const { userPicks = [], leaguePicks = [], leaderboard = [], gameStarted = false, authUser = TEST_USER } = options;
+
+  const slate: CfbSlateDto = {
+    id: TEST_SLATE_ID,
+    season: TEST_SEASON,
+    slateNumber: TEST_SLATE_NUMBER,
+    label: 'Week 1',
+    slateType: 'RegularSeason',
+    startDate: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+    endDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    firstGameUtc: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+  };
+
+  const spreads: CfbSpreadDto[] = [
+    cfbSpread(TEST_SLATE_ID, 'OSU', 'MICH', -6.5, 51.5),
+    cfbSpread(TEST_SLATE_ID, 'ALA', 'UGA', -3.5, 48.5),
+  ];
+
+  const league: LeagueUserMappingDto = {
+    id: 1,
+    leagueId: TEST_LEAGUE_ID,
+    userId: authUser.userId,
+    userName: authUser.name,
+    leagueName: 'Test CFB League',
+    leagueOwnerUserId: authUser.userId,
+    leagueType: 1, // 1 = CFB — satisfies hasCfbAccess check
+    dateCreated: new Date().toISOString(),
+  };
+
+  const scoresData: EspnScores = {
+    season: { year: TEST_SEASON, type: 2 },
+    week: { number: TEST_SLATE_NUMBER },
+    events: [
+      {
+        id: '1',
+        season: { year: TEST_SEASON, type: 2 },
+        week: { number: TEST_SLATE_NUMBER },
+        date: new Date().toISOString(),
+        competitions: [createCompetition({ homeTeam: 'OSU', awayTeam: 'MICH', homeScore: 24, awayScore: 17, gameStarted })],
+      },
+      {
+        id: '2',
+        season: { year: TEST_SEASON, type: 2 },
+        week: { number: TEST_SLATE_NUMBER },
+        date: new Date().toISOString(),
+        competitions: [createCompetition({ homeTeam: 'ALA', awayTeam: 'UGA', homeScore: 28, awayScore: 14, gameStarted })],
+      },
+    ],
+  };
+
+  await page.route('**/*', (route) => {
+    const url = route.request().url();
+    const method = route.request().method();
+
+    if (!url.includes('/api/')) {
+      void route.continue();
+      return;
+    }
+
+    // ── Auth ────────────────────────────────────────────────────────────────
+    if (url.includes('/api/auth/me') && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(authUser) });
+      return;
+    }
+    if (url.includes('/api/auth/')) {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+      return;
+    }
+
+    // ── Session hydration ────────────────────────────────────────────────────
+    if (url.includes('/api/league/user-mappings/by-user/') && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([league]) });
+      return;
+    }
+    if (url.includes('/api/league/my-leagues') && method === 'GET') {
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ id: TEST_LEAGUE_ID, leagueName: 'Test CFB League', leagueType: 'Cfb', ownerUserId: authUser.userId, dateCreated: new Date().toISOString() }]),
+      });
+      return;
+    }
+    if (url.includes('/api/league/membership-invites/mine') && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+      return;
+    }
+
+    // ── CFB slate/spread/score/pick endpoints (own DB, per cfbAdapter.ts) ────
+    if (url.includes('/api/cfb/current-slate') && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(slate) });
+      return;
+    }
+    if (url.match(/\/api\/cfb\/slates\/\d+$/) && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([slate]) });
+      return;
+    }
+    if (url.match(/\/api\/cfb\/spreads\/\d+$/) && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(spreads) });
+      return;
+    }
+    if (url.match(/\/api\/cfb\/scores\/\d+$/) && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+      return;
+    }
+    // Must check before the broader picks GET handler below.
+    if (url.match(/\/api\/cfb\/picks$/) && method === 'POST') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ added: 1 }) });
+      return;
+    }
+    if (url.match(/\/api\/cfb\/picks\/\d+\/\d+\/user$/) && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(userPicks) });
+      return;
+    }
+    if (url.match(/\/api\/cfb\/picks\/\d+\/\d+$/) && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(leaguePicks) });
+      return;
+    }
+    if (url.match(/\/api\/cfb\/picks\/\d+\/\d+$/) && method === 'DELETE') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+      return;
+    }
+    if (url.includes('/api/cfb/live-stream') && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' });
+      return;
+    }
+
+    // ── ESPN live-overlay endpoints (per src/api/espn.ts) ────────────────────
+    if (url.includes('/api/espn/cfb/livegames') && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+      return;
+    }
+    if (url.includes('/api/espn/cfb/scores/slate/') && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(scoresData) });
+      return;
+    }
+    if (url.includes('/api/espn/cfb/scores') && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(scoresData) });
+      return;
+    }
+
+    // ── Jerseys ────────────────────────────────────────────────────────────
+    if (url.includes('/api/jerseys/') && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+      return;
+    }
+
+    // ── Leaderboard ────────────────────────────────────────────────────────
+    if (url.includes('/api/leaderboard/') && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(leaderboard) });
+      return;
+    }
+
+    // ── Invite link / misc league bits some layouts probe on every page ─────
+    if (url.match(/\/api\/league\/\d+\/invite-link$/) && method === 'GET') {
+      void route.fulfill({ status: 404 });
+      return;
+    }
+    if (url.match(/\/api\/league\/\d+\/invite-link$/) && method === 'POST') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockInviteLink()) });
+      return;
+    }
+
+    void route.continue();
+  });
+}
+
+export interface MockCfbAuthOptions extends SetupCfbRoutesOptions {
+  navigateTo?: string;
+}
+
+/**
+ * CFB counterpart to auth.ts's mockAuth. Callers must run under a cfb.localhost baseURL
+ * (see playwright's per-file test.use({ baseURL }) at the top of *.cfb.spec.ts) so
+ * useSportContext resolves the CFB adapter.
+ */
+export async function mockCfbAuth(page: Page, options: MockCfbAuthOptions = {}): Promise<void> {
+  const { navigateTo, ...routeOptions } = options;
+
+  await setupCfbRoutes(page, routeOptions);
+
+  await page.goto('/');
+
+  // Domain 'localhost' domain-matches the 'cfb.localhost' subdomain per RFC 6265 —
+  // no separate cookie domain needed here (mirrors auth.ts's mockAuth).
+  await page.context().addCookies([
+    {
+      name: 'AuthToken',
+      value: FAKE_JWT,
+      domain: 'localhost',
+      path: '/',
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ]);
+
+  if (navigateTo) {
+    await page.goto(navigateTo);
+  }
+}

--- a/Client.React/e2e/picks.cfb.spec.ts
+++ b/Client.React/e2e/picks.cfb.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+import { mockCfbAuth } from './helpers/cfbRoutes';
+
+// CFB counterpart to picks.spec.ts. Runs under a cfb.localhost baseURL so
+// useSportContext resolves the CFB adapter (see cfbRoutes.ts's mockCfbAuth).
+test.use({ baseURL: 'http://cfb.localhost:5173' });
+
+test.describe('CFB Picks page (authenticated)', () => {
+  test('renders picks page for authenticated user', async ({ page }) => {
+    await mockCfbAuth(page, { navigateTo: '/picks' });
+
+    await expect(page.getByRole('progressbar')).not.toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('heading', { name: 'Picks', exact: true })).toBeVisible({ timeout: 5000 });
+
+    // 2 games x 2 teams = 4 Pick buttons (OSU/MICH, ALA/UGA)
+    await expect(page.getByRole('button', { name: /^Pick \w/i }).first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('shows pick buttons for upcoming games', async ({ page }) => {
+    await mockCfbAuth(page, { navigateTo: '/picks' });
+
+    await expect(page.getByRole('progressbar')).not.toBeVisible({ timeout: 10000 });
+
+    const pickButtons = page.getByRole('button', { name: /^Pick \w/i });
+    await expect(pickButtons.first()).toBeVisible({ timeout: 5000 });
+    await expect(pickButtons.first()).toBeEnabled();
+    await expect(pickButtons).toHaveCount(4, { timeout: 5000 });
+  });
+
+  test('user can click a pick button and it toggles to Picked', async ({ page }) => {
+    await mockCfbAuth(page, { navigateTo: '/picks' });
+
+    await expect(page.getByRole('progressbar')).not.toBeVisible({ timeout: 10000 });
+
+    const firstPickButton = page.getByRole('button', { name: /^Pick \w/i }).first();
+    await expect(firstPickButton).toBeVisible({ timeout: 5000 });
+    await firstPickButton.click();
+
+    await expect(page.getByRole('button', { name: /\bpicked\b/i })).toBeVisible({ timeout: 3000 });
+  });
+
+  test('submit button disabled with no picks selected', async ({ page }) => {
+    await mockCfbAuth(page, { navigateTo: '/picks' });
+
+    await expect(page.getByRole('progressbar')).not.toBeVisible({ timeout: 10000 });
+
+    const submitButton = page.getByRole('button', { name: /submit pick\(s\)/i });
+    await expect(submitButton).toBeVisible({ timeout: 5000 });
+    await expect(submitButton).toBeDisabled();
+  });
+
+  test('submitting picks calls POST /api/cfb/picks', async ({ page }) => {
+    await mockCfbAuth(page, { navigateTo: '/picks' });
+
+    await expect(page.getByRole('progressbar')).not.toBeVisible({ timeout: 10000 });
+
+    await page.getByRole('button', { name: /^Pick \w/i }).first().click();
+
+    const submitButton = page.getByRole('button', { name: /submit pick\(s\)/i });
+    await expect(submitButton).toBeEnabled({ timeout: 3000 });
+
+    const picksPostRequest = page.waitForRequest(
+      (req) => req.url().includes('/api/cfb/picks') && req.method() === 'POST'
+    );
+
+    await submitButton.click();
+
+    const request = await picksPostRequest;
+    expect(request.method()).toBe('POST');
+
+    const body = JSON.parse(request.postData() ?? '{}') as { leagueId: number; cfbSlateId: number; picks: unknown[] };
+    expect(body.picks.length).toBeGreaterThan(0);
+  });
+});

--- a/Client.React/e2e/scores.cfb.spec.ts
+++ b/Client.React/e2e/scores.cfb.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+import { mockCfbAuth, createCfbPick } from './helpers/cfbRoutes';
+
+// CFB counterpart to scores.spec.ts. Runs under a cfb.localhost baseURL so
+// useSportContext resolves the CFB adapter (see cfbRoutes.ts's mockCfbAuth).
+// gameStarted: true so shouldShowGamePicks() = true and badge counts are visible —
+// same reasoning as scores.spec.ts.
+test.use({ baseURL: 'http://cfb.localhost:5173' });
+
+test.describe('CFB Scores page (authenticated)', () => {
+  /**
+   * League picks for the two games:
+   *   OSU: 2 Spread picks (Alice, Bob)
+   *   ALA: 1 Spread pick  (Carol)
+   */
+  const leaguePicks = [
+    createCfbPick({ team: 'OSU', pickType: 'Spread', userId: 'u1', userName: 'Alice' }),
+    createCfbPick({ team: 'OSU', pickType: 'Spread', userId: 'u2', userName: 'Bob' }),
+    createCfbPick({ team: 'ALA', pickType: 'Spread', userId: 'u3', userName: 'Carol' }),
+  ];
+
+  const scoresOptions = { leaguePicks, gameStarted: true };
+
+  test('renders scores page for authenticated user', async ({ page }) => {
+    await mockCfbAuth(page, { navigateTo: '/scores', ...scoresOptions });
+
+    await expect(page.getByRole('progressbar')).not.toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('heading', { name: 'Scores' })).toBeVisible({ timeout: 5000 });
+  });
+
+  test('shows spread badge count for OSU (2 picks)', async ({ page }) => {
+    await mockCfbAuth(page, { navigateTo: '/scores', ...scoresOptions });
+
+    await expect(page.getByRole('progressbar')).not.toBeVisible({ timeout: 10000 });
+
+    const osuBadge = page.locator('[data-testid="badge-OSU-spread"]');
+    await expect(osuBadge).toBeVisible({ timeout: 5000 });
+    await expect(osuBadge.locator('.MuiBadge-badge')).toHaveText('2', { timeout: 5000 });
+  });
+
+  test('shows spread badge count for ALA (1 pick)', async ({ page }) => {
+    await mockCfbAuth(page, { navigateTo: '/scores', ...scoresOptions });
+
+    await expect(page.getByRole('progressbar')).not.toBeVisible({ timeout: 10000 });
+
+    const alaBadge = page.locator('[data-testid="badge-ALA-spread"]');
+    await expect(alaBadge).toBeVisible({ timeout: 5000 });
+    await expect(alaBadge.locator('.MuiBadge-badge')).toHaveText('1', { timeout: 5000 });
+  });
+});

--- a/Client.React/src/__tests__/HomePage.test.tsx
+++ b/Client.React/src/__tests__/HomePage.test.tsx
@@ -37,3 +37,13 @@ describe('HomePage — sport indicator', () => {
     expect(screen.queryByText(/^NFL$/)).not.toBeInTheDocument();
   });
 });
+
+describe('HomePage — promo video', () => {
+  // frizat-f29: the video had no native controls at all, so viewers couldn't resize or
+  // fullscreen it — only a custom mute button was rendered on top.
+  it('renders the promo video with native controls enabled', () => {
+    renderPage();
+    const video = document.querySelector('video');
+    expect(video).toHaveAttribute('controls');
+  });
+});

--- a/Client.React/src/__tests__/UpdateBanner.test.tsx
+++ b/Client.React/src/__tests__/UpdateBanner.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import UpdateBanner from '../components/UpdateBanner';
+
+describe('UpdateBanner', () => {
+  it('renders a snackbar with a refresh button when mismatch is true', () => {
+    render(<UpdateBanner mismatch />);
+
+    expect(screen.getByText(/new version is available/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
+  });
+
+  it('does not render when mismatch is false', () => {
+    render(<UpdateBanner mismatch={false} />);
+
+    expect(screen.queryByText(/new version is available/i)).not.toBeInTheDocument();
+  });
+
+  it('calls window.location.reload when the refresh button is clicked', async () => {
+    const reload = vi.fn();
+    vi.stubGlobal('location', { ...window.location, reload });
+
+    render(<UpdateBanner mismatch />);
+    await userEvent.click(screen.getByRole('button', { name: /refresh/i }));
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+});

--- a/Client.React/src/__tests__/VersionFooter.test.tsx
+++ b/Client.React/src/__tests__/VersionFooter.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import VersionFooter from '../components/VersionFooter';
+
+describe('VersionFooter', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('renders a truncated 7-char SHA linking to the GitHub commit', () => {
+    vi.stubEnv('VITE_APP_VERSION', 'abcdef1234567890');
+
+    render(<VersionFooter />);
+
+    const link = screen.getByRole('link', { name: 'abcdef1' });
+    expect(link).toHaveAttribute('href', 'https://github.com/frizat82/fourplay_web/commit/abcdef1234567890');
+  });
+
+  it('renders nothing when VITE_APP_VERSION is unset (local dev)', () => {
+    vi.stubEnv('VITE_APP_VERSION', '');
+
+    const { container } = render(<VersionFooter />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/Client.React/src/__tests__/base64.test.ts
+++ b/Client.React/src/__tests__/base64.test.ts
@@ -1,0 +1,27 @@
+import { decodeBase64Url, isValidBase64Url } from '../utils/base64';
+
+function encodeBase64Url(input: string): string {
+  return btoa(input).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+describe('decodeBase64Url', () => {
+  it('round-trips a value encoded with the URL-safe alphabet and no padding', () => {
+    const original = 'user-id-001:invite-code-abc123';
+    expect(decodeBase64Url(encodeBase64Url(original))).toBe(original);
+  });
+
+  it('handles inputs that need padding restored', () => {
+    // 'a' -> base64 'YQ==' -> url-safe 'YQ' (stripped padding, length 2, needs 2 chars of padding back)
+    expect(decodeBase64Url('YQ')).toBe('a');
+  });
+});
+
+describe('isValidBase64Url', () => {
+  it('returns true for validly-encoded input', () => {
+    expect(isValidBase64Url(encodeBase64Url('valid-token'))).toBe(true);
+  });
+
+  it('rejects garbage input that is not valid base64', () => {
+    expect(isValidBase64Url('!!!not-base64!!!')).toBe(false);
+  });
+});

--- a/Client.React/src/__tests__/leagueHelpers.test.ts
+++ b/Client.React/src/__tests__/leagueHelpers.test.ts
@@ -1,0 +1,14 @@
+import { computeLeagueCost } from '../utils/leagueHelpers';
+
+describe('computeLeagueCost', () => {
+  it('returns the flat base cost when memberCount is at or below the base member count', () => {
+    expect(computeLeagueCost(10)).toBe(100);
+    expect(computeLeagueCost(5)).toBe(100);
+    expect(computeLeagueCost(0)).toBe(100);
+  });
+
+  it('adds a per-head charge for each member above the base member count', () => {
+    expect(computeLeagueCost(12)).toBe(120);
+    expect(computeLeagueCost(20)).toBe(200);
+  });
+});

--- a/Client.React/src/__tests__/session.test.tsx
+++ b/Client.React/src/__tests__/session.test.tsx
@@ -2,8 +2,10 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import { SessionProvider, useSession } from '../services/session';
 
+const mockSport = vi.hoisted(() => ({ sport: 'NFL' as 'NFL' | 'CFB' }));
+
 vi.mock('../services/auth', () => ({ useAuth: () => ({ user: { userId: 'u1', name: 'Alice', claims: [] } }) }));
-vi.mock('../services/sport', () => ({ useSportContext: () => ({ sport: 'NFL', isCfb: false, isNfl: true }) }));
+vi.mock('../services/sport', () => ({ useSportContext: () => ({ sport: mockSport.sport, isCfb: mockSport.sport === 'CFB', isNfl: mockSport.sport === 'NFL' }) }));
 
 vi.mock('../api/league', () => ({
   getLeagueUserMappingsForUser: vi.fn().mockResolvedValue([]),
@@ -11,8 +13,10 @@ vi.mock('../api/league', () => ({
   getMyPendingMembershipInvites: vi.fn(),
 }));
 
-import { getMyPendingMembershipInvites } from '../api/league';
+import { getLeagueUserMappingsForUser, getMyLeagues, getMyPendingMembershipInvites } from '../api/league';
 const mockedGetPending = vi.mocked(getMyPendingMembershipInvites);
+const mockedGetMappings = vi.mocked(getLeagueUserMappingsForUser);
+const mockedGetMyLeagues = vi.mocked(getMyLeagues);
 
 function Consumer() {
   const { pendingMembershipInvites } = useSession();
@@ -22,6 +26,21 @@ function Consumer() {
         <li key={invite.id}>{invite.leagueName}</li>
       ))}
     </ul>
+  );
+}
+
+function LeaguesConsumer() {
+  const { ownedLeagues, availableLeagues, leaguesLoaded } = useSession();
+  if (!leaguesLoaded) return <span>loading</span>;
+  return (
+    <div>
+      <span data-testid="owned-count">{ownedLeagues.length}</span>
+      <ul>
+        {availableLeagues.map((l) => (
+          <li key={l.leagueId}>{l.leagueName}</li>
+        ))}
+      </ul>
+    </div>
   );
 }
 
@@ -53,5 +72,72 @@ describe('SessionProvider — pending membership invites', () => {
 
     await waitFor(() => expect(mockedGetPending).toHaveBeenCalled());
     expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
+  });
+});
+
+describe('SessionProvider — league ownership + sport filtering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSport.sport = 'NFL';
+  });
+
+  it('ownedLeagues is non-empty when the user owns a league in the current sport', async () => {
+    mockedGetMyLeagues.mockResolvedValue([
+      { id: 1, leagueName: 'My NFL League', dateCreated: '2026-01-01T00:00:00Z', ownerUserId: 'u1', leagueType: 'Nfl' },
+    ]);
+
+    render(
+      <SessionProvider>
+        <LeaguesConsumer />
+      </SessionProvider>
+    );
+
+    expect(await screen.findByTestId('owned-count')).toHaveTextContent('1');
+  });
+
+  it('ownedLeagues is empty when the user owns no leagues', async () => {
+    mockedGetMyLeagues.mockResolvedValue([]);
+
+    render(
+      <SessionProvider>
+        <LeaguesConsumer />
+      </SessionProvider>
+    );
+
+    expect(await screen.findByTestId('owned-count')).toHaveTextContent('0');
+  });
+
+  it('sport filter excludes CFB leagues on the NFL subdomain', async () => {
+    mockSport.sport = 'NFL';
+    mockedGetMappings.mockResolvedValue([
+      { id: 1, leagueId: 10, userId: 'u1', userName: 'Alice', leagueName: 'NFL League', leagueType: 0, dateCreated: '2026-01-01T00:00:00Z' },
+      { id: 2, leagueId: 20, userId: 'u1', userName: 'Alice', leagueName: 'CFB League', leagueType: 1, dateCreated: '2026-01-01T00:00:00Z' },
+    ]);
+
+    render(
+      <SessionProvider>
+        <LeaguesConsumer />
+      </SessionProvider>
+    );
+
+    expect(await screen.findByText('NFL League')).toBeInTheDocument();
+    expect(screen.queryByText('CFB League')).not.toBeInTheDocument();
+  });
+
+  it('sport filter excludes NFL leagues on the CFB subdomain', async () => {
+    mockSport.sport = 'CFB';
+    mockedGetMappings.mockResolvedValue([
+      { id: 1, leagueId: 10, userId: 'u1', userName: 'Alice', leagueName: 'NFL League', leagueType: 0, dateCreated: '2026-01-01T00:00:00Z' },
+      { id: 2, leagueId: 20, userId: 'u1', userName: 'Alice', leagueName: 'CFB League', leagueType: 1, dateCreated: '2026-01-01T00:00:00Z' },
+    ]);
+
+    render(
+      <SessionProvider>
+        <LeaguesConsumer />
+      </SessionProvider>
+    );
+
+    expect(await screen.findByText('CFB League')).toBeInTheDocument();
+    expect(screen.queryByText('NFL League')).not.toBeInTheDocument();
   });
 });

--- a/Client.React/src/__tests__/spreadRelease.test.ts
+++ b/Client.React/src/__tests__/spreadRelease.test.ts
@@ -1,0 +1,42 @@
+import { vi } from 'vitest';
+
+vi.mock('../api/http', () => ({
+  http: {
+    get: vi.fn(),
+  },
+}));
+
+import { http } from '../api/http';
+import { getNextSpreadJob } from '../services/spreadRelease';
+
+const mockedGet = vi.mocked(http.get);
+
+describe('getNextSpreadJob', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns the next scheduled time from the sport-agnostic endpoint when no sport is given', async () => {
+    mockedGet.mockResolvedValue({ data: '2026-09-09T14:20:00Z' } as never);
+
+    const result = await getNextSpreadJob();
+
+    expect(result).toBe('2026-09-09T14:20:00Z');
+    expect(mockedGet).toHaveBeenCalledWith('/api/jobmanager/get-next-spread-job');
+  });
+
+  it('scopes the request to the given sport, lowercased', async () => {
+    mockedGet.mockResolvedValue({ data: '2026-09-03T12:00:00Z' } as never);
+
+    const result = await getNextSpreadJob('CFB');
+
+    expect(result).toBe('2026-09-03T12:00:00Z');
+    expect(mockedGet).toHaveBeenCalledWith('/api/jobmanager/get-next-spread-job?sport=cfb');
+  });
+
+  it('returns null when the server has no next scheduled job', async () => {
+    mockedGet.mockResolvedValue({ data: null } as never);
+
+    const result = await getNextSpreadJob('NFL');
+
+    expect(result).toBeNull();
+  });
+});

--- a/Client.React/src/__tests__/useVersionCheck.test.tsx
+++ b/Client.React/src/__tests__/useVersionCheck.test.tsx
@@ -1,0 +1,65 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi } from 'vitest';
+
+vi.mock('../api/version', () => ({ getVersion: vi.fn() }));
+
+import { getVersion } from '../api/version';
+import { useVersionCheck } from '../utils/useVersionCheck';
+
+const mockedGetVersion = vi.mocked(getVersion);
+
+function renderWithClient() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: Infinity } } });
+  return renderHook(() => useVersionCheck(), {
+    wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>,
+  });
+}
+
+describe('useVersionCheck', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('VITE_APP_VERSION', 'client-sha-123');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('shows no banner when client SHA matches server SHA', async () => {
+    mockedGetVersion.mockResolvedValue({ sha: 'client-sha-123', env: 'Production', timestamp: '2026-01-01T00:00:00Z' });
+
+    const { result } = renderWithClient();
+
+    await waitFor(() => expect(mockedGetVersion).toHaveBeenCalled());
+    expect(result.current.mismatch).toBe(false);
+  });
+
+  it('sets mismatch flag when server SHA differs from client SHA', async () => {
+    mockedGetVersion.mockResolvedValue({ sha: 'server-sha-456', env: 'Production', timestamp: '2026-01-01T00:00:00Z' });
+
+    const { result } = renderWithClient();
+
+    await waitFor(() => expect(result.current.mismatch).toBe(true));
+  });
+
+  it('does not re-trigger after mismatch already detected', async () => {
+    mockedGetVersion.mockResolvedValue({ sha: 'server-sha-456', env: 'Production', timestamp: '2026-01-01T00:00:00Z' });
+
+    const { result } = renderWithClient();
+    await waitFor(() => expect(result.current.mismatch).toBe(true));
+
+    const callsAfterFirstMismatch = mockedGetVersion.mock.calls.length;
+
+    // Advance past several more poll intervals (5 min each) — a real mismatch already
+    // latched should not keep hammering the endpoint or flip state again.
+    vi.useFakeTimers();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000 * 3);
+    });
+    vi.useRealTimers();
+
+    expect(result.current.mismatch).toBe(true);
+    expect(mockedGetVersion.mock.calls.length).toBe(callsAfterFirstMismatch);
+  });
+});

--- a/Client.React/src/__tests__/weather.test.ts
+++ b/Client.React/src/__tests__/weather.test.ts
@@ -1,0 +1,50 @@
+import { mapWeatherFromEspn, toWeatherIconClass } from '../utils/weather';
+
+describe('mapWeatherFromEspn', () => {
+  it('returns "unknown" when displayValue is missing', () => {
+    expect(mapWeatherFromEspn(null, null)).toBe('unknown');
+    expect(mapWeatherFromEspn(undefined, undefined)).toBe('unknown');
+  });
+
+  it('maps known condition text to their weather keys', () => {
+    expect(mapWeatherFromEspn('Thunderstorms', null)).toBe('thunderstorm');
+    expect(mapWeatherFromEspn('Light Snow', null)).toBe('snow');
+    expect(mapWeatherFromEspn('Heavy Rain', null)).toBe('rain-heavy');
+    expect(mapWeatherFromEspn('Light Rain', null)).toBe('rain-light');
+    expect(mapWeatherFromEspn('Showers', null)).toBe('rain');
+    expect(mapWeatherFromEspn('Foggy', null)).toBe('fog');
+    expect(mapWeatherFromEspn('Mostly Sunny', null)).toBe('mostly-clear');
+    expect(mapWeatherFromEspn('Partly Cloudy', null)).toBe('partly-cloudy');
+    expect(mapWeatherFromEspn('Overcast', null)).toBe('cloudy');
+    expect(mapWeatherFromEspn('Clear', null)).toBe('clear');
+    expect(mapWeatherFromEspn('Indoor', null)).toBe('indoor');
+  });
+
+  it('falls back to conditionId when displayValue is purely numeric', () => {
+    expect(mapWeatherFromEspn('42', 'Sunny')).toBe('clear');
+  });
+
+  it('returns "unknown" for unrecognized text', () => {
+    expect(mapWeatherFromEspn('Tornado Watch', null)).toBe('unknown');
+  });
+});
+
+describe('toWeatherIconClass', () => {
+  it('maps each known weather key to its icon class', () => {
+    expect(toWeatherIconClass('clear')).toBe('wi-day-sunny');
+    expect(toWeatherIconClass('mostly-clear')).toBe('wi-day-sunny-overcast');
+    expect(toWeatherIconClass('partly-cloudy')).toBe('wi-day-cloudy');
+    expect(toWeatherIconClass('cloudy')).toBe('wi-cloudy');
+    expect(toWeatherIconClass('rain-light')).toBe('wi-day-rain');
+    expect(toWeatherIconClass('rain')).toBe('wi-rain');
+    expect(toWeatherIconClass('rain-heavy')).toBe('wi-showers');
+    expect(toWeatherIconClass('thunderstorm')).toBe('wi-thunderstorm');
+    expect(toWeatherIconClass('snow')).toBe('wi-snow');
+    expect(toWeatherIconClass('fog')).toBe('wi-fog');
+    expect(toWeatherIconClass('indoor')).toBe('wi-na');
+  });
+
+  it('falls back to "wi-na" for an unknown key', () => {
+    expect(toWeatherIconClass('unknown')).toBe('wi-na');
+  });
+});

--- a/Client.React/src/api/version.ts
+++ b/Client.React/src/api/version.ts
@@ -1,0 +1,7 @@
+import { http } from './http';
+import type { VersionResponse } from '../types/version';
+
+export async function getVersion(): Promise<VersionResponse> {
+  const { data } = await http.get<VersionResponse>('/api/version');
+  return data;
+}

--- a/Client.React/src/components/UpdateBanner.tsx
+++ b/Client.React/src/components/UpdateBanner.tsx
@@ -1,0 +1,24 @@
+import { Alert, Button, Snackbar } from '@mui/material';
+
+interface UpdateBannerProps {
+  mismatch: boolean;
+}
+
+export default function UpdateBanner({ mismatch }: UpdateBannerProps) {
+  if (!mismatch) return null;
+
+  return (
+    <Snackbar open anchorOrigin={{ vertical: 'top', horizontal: 'center' }}>
+      <Alert
+        severity="info"
+        action={
+          <Button color="inherit" size="small" onClick={() => window.location.reload()}>
+            Refresh
+          </Button>
+        }
+      >
+        A new version is available
+      </Alert>
+    </Snackbar>
+  );
+}

--- a/Client.React/src/components/VersionFooter.tsx
+++ b/Client.React/src/components/VersionFooter.tsx
@@ -1,0 +1,19 @@
+import { Box, Link, Typography } from '@mui/material';
+
+const REPO_URL = 'https://github.com/frizat82/fourplay_web';
+
+export default function VersionFooter() {
+  const sha = import.meta.env.VITE_APP_VERSION;
+  if (!sha) return null;
+  const shortSha = sha.slice(0, 7);
+
+  return (
+    <Box component="footer" sx={{ py: 1, textAlign: 'center' }}>
+      <Typography variant="caption" color="text.secondary">
+        <Link href={`${REPO_URL}/commit/${sha}`} target="_blank" rel="noopener noreferrer" color="inherit">
+          {shortSha}
+        </Link>
+      </Typography>
+    </Box>
+  );
+}

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -46,6 +46,7 @@ import { useSportContext } from '../services/sport';
 import { useThemeMode } from '../services/theme';
 import { isAdmin } from '../utils/auth';
 import PendingInviteBanner from '../components/PendingInviteBanner';
+import VersionFooter from '../components/VersionFooter';
 
 const drawerWidth = 260;
 
@@ -399,6 +400,7 @@ export default function AppLayout() {
           <PendingInviteBanner />
           {noAccessContent ?? <Outlet />}
         </Box>
+        <VersionFooter />
       </Box>
     </Box>
   );

--- a/Client.React/src/main.tsx
+++ b/Client.React/src/main.tsx
@@ -12,6 +12,8 @@ import { SessionProvider } from './services/session';
 import { SportsProvider } from './services/sport';
 import { ToastProvider } from './services/toast';
 import { ThemeModeProvider, useThemeMode } from './services/theme';
+import { useVersionCheck } from './utils/useVersionCheck';
+import UpdateBanner from './components/UpdateBanner';
 import './app/global.css';
 
 const queryClient = new QueryClient({
@@ -26,9 +28,11 @@ const queryClient = new QueryClient({
 function ThemedApp() {
   const { mode } = useThemeMode();
   const theme = useMemo(() => createAppTheme(mode), [mode]);
+  const { mismatch } = useVersionCheck();
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
+      <UpdateBanner mismatch={mismatch} />
       <BrowserRouter>
         <ToastProvider>
           <SportsProvider>

--- a/Client.React/src/pages/HomePage.tsx
+++ b/Client.React/src/pages/HomePage.tsx
@@ -5,10 +5,8 @@ import SportsTennisIcon from '@mui/icons-material/SportsTennis';
 import LeaderboardIcon from '@mui/icons-material/Leaderboard';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
-import VolumeOffIcon from '@mui/icons-material/VolumeOff';
-import VolumeUpIcon from '@mui/icons-material/VolumeUp';
 import { Link as RouterLink } from 'react-router-dom';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { useAuth } from '../services/auth';
 import { useSportContext } from '../services/sport';
 import { RulesContent } from './RulesPage';
@@ -50,16 +48,7 @@ export default function HomePage({ adapter }: HomePageProps) {
   const { user } = useAuth();
   const { isCfb } = useSportContext();
   const isAuthed = Boolean(user);
-  const videoRef = useRef<HTMLVideoElement>(null);
-  const [muted, setMuted] = useState(true);
   const [rulesOpen, setRulesOpen] = useState(false);
-
-  const toggleMute = () => {
-    if (videoRef.current) {
-      videoRef.current.muted = !videoRef.current.muted;
-      setMuted(videoRef.current.muted);
-    }
-  };
 
   return (
     <div>
@@ -136,30 +125,16 @@ export default function HomePage({ adapter }: HomePageProps) {
                 {!isAuthed && (
                   <Paper elevation={8} sx={{ position: 'relative', overflow: 'hidden', borderRadius: 2 }}>
                     <video
-                      ref={videoRef}
                       autoPlay
                       muted
                       loop
                       playsInline
+                      controls
                       style={{ width: '100%', display: 'block' }}
                       poster="/Images/fourplayhome.jpg"
                     >
                       <source src="/Videos/demo.mp4" type="video/mp4" />
                     </video>
-                    <IconButton
-                      onClick={toggleMute}
-                      size="small"
-                      sx={{
-                        position: 'absolute',
-                        bottom: 8,
-                        right: 8,
-                        bgcolor: 'rgba(0,0,0,0.5)',
-                        color: 'white',
-                        '&:hover': { bgcolor: 'rgba(0,0,0,0.75)' },
-                      }}
-                    >
-                      {muted ? <VolumeOffIcon fontSize="small" /> : <VolumeUpIcon fontSize="small" />}
-                    </IconButton>
                   </Paper>
                 )}
                 <Paper className="hero-image" elevation={8}>

--- a/Client.React/src/types/version.ts
+++ b/Client.React/src/types/version.ts
@@ -1,0 +1,5 @@
+export interface VersionResponse {
+  sha: string;
+  env: string;
+  timestamp: string;
+}

--- a/Client.React/src/utils/useVersionCheck.ts
+++ b/Client.React/src/utils/useVersionCheck.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import { getVersion } from '../api/version';
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Polls /api/version and compares it against the client build's own baked-in SHA
+ * (VITE_APP_VERSION, injected at build time — see vite.config.ts). Once a mismatch is observed,
+ * refetchInterval reads it straight from the query's own cached state and returns `false`, so
+ * polling stops on its own — the cached (mismatched) result is what keeps `mismatch` true for the
+ * rest of the session, with no separate latch ref/state needed. VITE_APP_VERSION is unset in
+ * local dev, so the check is a no-op there.
+ */
+export function useVersionCheck() {
+  const clientSha = import.meta.env.VITE_APP_VERSION;
+
+  const { data } = useQuery({
+    queryKey: ['version-check'],
+    queryFn: getVersion,
+    enabled: !!clientSha,
+    refetchInterval: (query) => {
+      const latest = query.state.data;
+      return latest && latest.sha !== clientSha ? false : POLL_INTERVAL_MS;
+    },
+    retry: false,
+  });
+
+  return { mismatch: !!data && !!clientSha && data.sha !== clientSha };
+}

--- a/Client.React/vite.config.ts
+++ b/Client.React/vite.config.ts
@@ -3,9 +3,18 @@ import react from '@vitejs/plugin-react';
 
 const apiTarget = process.env.VITE_API_TARGET ?? 'https://localhost:7209';
 
+// Vercel's own VERCEL_GIT_COMMIT_SHA is auto-injected into the build env for every git-connected
+// deploy, but it isn't VITE_-prefixed so Vite won't expose it to client code on its own — bridge
+// it into import.meta.env.VITE_APP_VERSION here (frizat-066). VITE_APP_VERSION itself is kept as
+// an override for any environment that sets it directly instead.
+const appVersion = process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.VITE_APP_VERSION ?? '';
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(appVersion),
+  },
   server: {
     proxy: {
       '/api': {

--- a/Server.UnitTests/LeagueRepositoryTests.cs
+++ b/Server.UnitTests/LeagueRepositoryTests.cs
@@ -354,4 +354,102 @@ public class LeagueRepositoryTests
 
         Assert.False(exists);
     }
+
+    // ── UpdatedAt audit column (frizat-b0t) ─────────────────────────────────────
+
+    [Fact]
+    public async Task LeagueInfo_UpdatedAt_IsNullImmediatelyAfterInsert()
+    {
+        var factory = new DbContextFactoryStub(nameof(LeagueInfo_UpdatedAt_IsNullImmediatelyAfterInsert));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueInfo.Add(new LeagueInfo { Id = 1, LeagueName = "L", OwnerUserId = "owner-1" });
+        await seedDb.SaveChangesAsync();
+
+        var db = factory.CreateDbContext();
+        var league = await db.LeagueInfo.SingleAsync(l => l.Id == 1);
+        Assert.Null(league.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task UpdateLeagueOwnerAsync_SetsUpdatedAt()
+    {
+        var factory = new DbContextFactoryStub(nameof(UpdateLeagueOwnerAsync_SetsUpdatedAt));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueInfo.Add(new LeagueInfo { Id = 1, LeagueName = "L", OwnerUserId = "owner-1" });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        await repo.UpdateLeagueOwnerAsync(1, "owner-2");
+
+        var db = factory.CreateDbContext();
+        var league = await db.LeagueInfo.SingleAsync(l => l.Id == 1);
+        Assert.Equal("owner-2", league.OwnerUserId);
+        Assert.NotNull(league.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task LeagueJuiceMapping_UpdatedAt_IsNullImmediatelyAfterInsert()
+    {
+        var factory = new DbContextFactoryStub(nameof(LeagueJuiceMapping_UpdatedAt_IsNullImmediatelyAfterInsert));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueJuiceMapping.Add(new LeagueJuiceMapping { Id = 1, LeagueId = 1, Season = 2025 });
+        await seedDb.SaveChangesAsync();
+
+        var db = factory.CreateDbContext();
+        var mapping = await db.LeagueJuiceMapping.SingleAsync(m => m.Id == 1);
+        Assert.Null(mapping.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task UpdateLeagueJuiceMappingAsync_SetsUpdatedAt()
+    {
+        var factory = new DbContextFactoryStub(nameof(UpdateLeagueJuiceMappingAsync_SetsUpdatedAt));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueJuiceMapping.Add(new LeagueJuiceMapping { Id = 1, LeagueId = 1, Season = 2025, Juice = 13 });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        await repo.UpdateLeagueJuiceMappingAsync(new LeagueJuiceMapping { Id = 1, LeagueId = 1, Season = 2025, Juice = 14 });
+
+        var db = factory.CreateDbContext();
+        var mapping = await db.LeagueJuiceMapping.SingleAsync(m => m.Id == 1);
+        Assert.Equal(14, mapping.Juice);
+        Assert.NotNull(mapping.UpdatedAt);
+    }
+
+    // /code-review: the controller's real call shape (LeagueController.UpdateLeagueJuice) always
+    // passes a mapping fetched via GetLeagueJuiceMappingAsync, which .Include()s the League
+    // navigation — so `mapping.League` is a populated, detached LeagueInfo snapshot from whenever
+    // it was fetched. A blind db.LeagueJuiceMapping.Update(mapping) would make EF Core's
+    // change-tracker walk that whole reachable graph and mark the stale League instance Modified
+    // too, silently overwriting the real row's other columns (including its own UpdatedAt) with
+    // the stale snapshot on save. This test mirrors that exact call shape and proves the league
+    // row is untouched.
+    [Fact]
+    public async Task UpdateLeagueJuiceMappingAsync_DoesNotClobberTheParentLeagueInfoRow()
+    {
+        var factory = new DbContextFactoryStub(nameof(UpdateLeagueJuiceMappingAsync_DoesNotClobberTheParentLeagueInfoRow));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueInfo.Add(new LeagueInfo { Id = 1, LeagueName = "Original Name", OwnerUserId = "original-owner" });
+        seedDb.LeagueJuiceMapping.Add(new LeagueJuiceMapping { Id = 1, LeagueId = 1, Season = 2025, Juice = 13 });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        // Simulates GetLeagueJuiceMappingAsync's real .Include(League) shape: a stale, detached
+        // League snapshot captured before a concurrent owner change lands.
+        var staleMapping = new LeagueJuiceMapping {
+            Id = 1, LeagueId = 1, Season = 2025, Juice = 13,
+            League = new LeagueInfo { Id = 1, LeagueName = "Original Name", OwnerUserId = "original-owner" },
+        };
+
+        // A concurrent request changes the league's owner after the stale snapshot was captured.
+        await repo.UpdateLeagueOwnerAsync(1, "new-owner");
+
+        staleMapping.Juice = 14;
+        await repo.UpdateLeagueJuiceMappingAsync(staleMapping);
+
+        var db = factory.CreateDbContext();
+        var league = await db.LeagueInfo.SingleAsync(l => l.Id == 1);
+        Assert.Equal("new-owner", league.OwnerUserId); // not reverted by the stale snapshot
+    }
 }

--- a/Server.UnitTests/VersionControllerTests.cs
+++ b/Server.UnitTests/VersionControllerTests.cs
@@ -1,0 +1,73 @@
+using FourPlayWebApp.Server.Controllers;
+using FourPlayWebApp.Shared.Models.Data.Dtos;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using Xunit;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+public class VersionControllerTests
+{
+    // /code-review: this repo deploys via Railway/Vercel's native git integration, not a custom
+    // GitHub-Actions-driven deploy step — GITHUB_SHA is never actually populated at runtime on
+    // either platform. Railway auto-injects RAILWAY_GIT_COMMIT_SHA for every git-connected deploy,
+    // so that's the primary source; GITHUB_SHA stays as a secondary fallback for any environment
+    // that does set it directly (e.g. a future custom deploy step), then "local" last.
+    private static VersionController BuildController(string? railwaySha, string? githubSha, string environmentName) {
+        var config = Substitute.For<IConfiguration>();
+        config["RAILWAY_GIT_COMMIT_SHA"].Returns(railwaySha);
+        config["GITHUB_SHA"].Returns(githubSha);
+        var env = Substitute.For<IWebHostEnvironment>();
+        env.EnvironmentName.Returns(environmentName);
+        return new VersionController(config, env);
+    }
+
+    [Fact]
+    public void GetVersion_Returns200_WithShaAndEnv() {
+        var controller = BuildController(railwaySha: null, githubSha: "abc1234def5678", "Production");
+
+        var result = controller.GetVersion();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var value = Assert.IsType<VersionDto>(ok.Value);
+        Assert.Equal("abc1234def5678", value.Sha);
+        Assert.Equal("Production", value.Env);
+    }
+
+    [Fact]
+    public void GetVersion_PrefersRailwayGitCommitSha_OverGithubSha() {
+        var controller = BuildController(railwaySha: "railway-sha-999", githubSha: "abc1234def5678", "Production");
+
+        var result = controller.GetVersion();
+
+        var value = Assert.IsType<VersionDto>(((OkObjectResult)result.Result!).Value);
+        Assert.Equal("railway-sha-999", value.Sha);
+    }
+
+    [Fact]
+    public void GetVersion_WhenEnvVarMissing_ReturnsFallback() {
+        var controller = BuildController(railwaySha: null, githubSha: null, "Development");
+
+        var result = controller.GetVersion();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var value = Assert.IsType<VersionDto>(ok.Value);
+        Assert.Equal("local", value.Sha);
+        Assert.Equal("Development", value.Env);
+    }
+
+    // /code-review: a plain `??` chain treats an explicitly-set empty string as a real value,
+    // not a missing one — some platforms/scripts export an unset build var as "" rather than
+    // omitting it, which would otherwise permanently show every client the stale-build banner.
+    [Fact]
+    public void GetVersion_WhenEnvVarIsEmptyString_FallsThroughToNextSource() {
+        var controller = BuildController(railwaySha: "", githubSha: "abc1234def5678", "Production");
+
+        var result = controller.GetVersion();
+
+        var value = Assert.IsType<VersionDto>(((OkObjectResult)result.Result!).Value);
+        Assert.Equal("abc1234def5678", value.Sha);
+    }
+}

--- a/Server/Controllers/AuthController.cs
+++ b/Server/Controllers/AuthController.cs
@@ -4,6 +4,7 @@ using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Shared.Models.Account;
 using FourPlayWebApp.Shared.Models.Account.Dto;
+using FourPlayWebApp.Shared.Models.Data.Dtos;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
@@ -163,7 +164,7 @@ public class AuthController(
 
         ExpireAuthCookies();
 
-        return Ok(new { ok = true });
+        return Ok(new OkResponseDto());
     }
     // GET /api/auth/me
     [Authorize]
@@ -463,7 +464,7 @@ public class AuthController(
         if (newRefresh is not null)
             Response.Cookies.Append("RefreshToken", newRefresh.Token, BuildCookieOptions(newRefresh.Expires));
 
-        return Ok(new { ok = true });
+        return Ok(new OkResponseDto());
     }
     [HttpPost("request-email-confirmation")]
     [AllowAnonymous]

--- a/Server/Controllers/CfbPicksController.cs
+++ b/Server/Controllers/CfbPicksController.cs
@@ -180,7 +180,7 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
         if (newPicks.Count > 0)
             await repo.AddPicksAsync(newPicks);
 
-        return Ok(new { added = newPicks.Count });
+        return Ok(new AddCfbPicksResponseDto(newPicks.Count));
     }
 
     [HttpDelete("picks/{leagueId}/{cfbSlateId}")]

--- a/Server/Controllers/JobManagerController.cs
+++ b/Server/Controllers/JobManagerController.cs
@@ -1,4 +1,5 @@
 ﻿using FourPlayWebApp.Shared.Models;
+using FourPlayWebApp.Shared.Models.Data.Dtos;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Quartz;
@@ -30,7 +31,7 @@ namespace FourPlayWebApp.Server.Controllers {
                     return NotFound();
                 await scheduler.TriggerJob(new JobKey(jobName.JobName));
                 Log.Information("Started Scores Job");
-                return Ok(new {message = "Started Scores Job"});
+                return Ok(new MessageResponseDto("Started Scores Job"));
             }
             catch (Exception e) {
                 return BadRequest(e.Message);
@@ -43,7 +44,7 @@ namespace FourPlayWebApp.Server.Controllers {
                 var scheduler = await schedulerFactory.GetScheduler();
                 await scheduler.TriggerJob(new JobKey("User Manager"));
                 Log.Information("Started User Manager Job");
-                return Ok(new {message = "Started User Manager Job"});
+                return Ok(new MessageResponseDto("Started User Manager Job"));
             }
             catch (Exception e) {
                 return BadRequest(e.Message);
@@ -56,7 +57,7 @@ namespace FourPlayWebApp.Server.Controllers {
                 var scheduler = await schedulerFactory.GetScheduler();
                 await scheduler.TriggerJob(new JobKey("CFB Slate Seeder"));
                 Log.Information("Started CFB Slate Seeder Job");
-                return Ok(new { message = "Started CFB Slate Seeder Job" });
+                return Ok(new MessageResponseDto("Started CFB Slate Seeder Job"));
             }
             catch (Exception e) {
                 return BadRequest(e.Message);
@@ -76,7 +77,7 @@ namespace FourPlayWebApp.Server.Controllers {
                 var scheduler = await schedulerFactory.GetScheduler();
                 await scheduler.TriggerJob(new JobKey("CFB Scores Job"));
                 Log.Information("Started CFB Scores Job");
-                return Ok(new { message = "Started CFB Scores Job" });
+                return Ok(new MessageResponseDto("Started CFB Scores Job"));
             }
             catch (Exception e) {
                 return BadRequest(e.Message);
@@ -183,7 +184,7 @@ namespace FourPlayWebApp.Server.Controllers {
                     await scheduler.TriggerJob(new JobKey(jobName.JobName));
                     Log.Information("Started {SportLabel} Job {JobName}", sportLabel, jobName.JobName);
                 }
-                return Ok(new { message = $"Started {sportLabel} Job" });
+                return Ok(new MessageResponseDto($"Started {sportLabel} Job"));
             }
             catch (Exception e) {
                 return BadRequest(e.Message);

--- a/Server/Controllers/ReplayController.cs
+++ b/Server/Controllers/ReplayController.cs
@@ -1,4 +1,5 @@
 using FourPlayWebApp.Server.Services;
+using FourPlayWebApp.Shared.Models.Data.Dtos;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -18,10 +19,10 @@ public class ReplayController(IServiceProvider serviceProvider) : ControllerBase
     private IActionResult RunOnReplayService(Action<ReplayCacheService> action, string successMessage) {
         var replayService = serviceProvider.GetService<ReplayCacheService>();
         if (replayService is null)
-            return NotFound(new { message = "Replay mode is not enabled (DEMO_REPLAY_MODE != true)." });
+            return NotFound(new MessageResponseDto("Replay mode is not enabled (DEMO_REPLAY_MODE != true)."));
 
         action(replayService);
-        return Ok(new { message = successMessage });
+        return Ok(new MessageResponseDto(successMessage));
     }
 
     [HttpPost("advance")]

--- a/Server/Controllers/VersionController.cs
+++ b/Server/Controllers/VersionController.cs
@@ -1,0 +1,25 @@
+using FourPlayWebApp.Shared.Models.Data.Dtos;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FourPlayWebApp.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[AllowAnonymous]
+[Microsoft.AspNetCore.RateLimiting.EnableRateLimiting("public")]
+public class VersionController(IConfiguration config, IWebHostEnvironment environment) : ControllerBase {
+    [HttpGet]
+    public ActionResult<VersionDto> GetVersion() {
+        // Railway (this app's actual deploy target) auto-injects RAILWAY_GIT_COMMIT_SHA on every
+        // git-connected deploy — no workflow config needed. GITHUB_SHA is only ever set by a
+        // GitHub-Actions-driven deploy step, which this repo doesn't have; kept as a fallback for
+        // any environment that does set it directly. IsNullOrEmpty (not a plain ??) because some
+        // platforms/scripts export an unset build var as "" rather than omitting it entirely.
+        var sha = FirstNonEmpty(config["RAILWAY_GIT_COMMIT_SHA"], config["GITHUB_SHA"]) ?? "local";
+        return Ok(new VersionDto(sha, environment.EnvironmentName, DateTimeOffset.UtcNow));
+    }
+
+    private static string? FirstNonEmpty(params string?[] values) =>
+        values.FirstOrDefault(v => !string.IsNullOrEmpty(v));
+}

--- a/Server/Migrations/20260825142405_AddUpdatedAtToLeagueInfoAndJuiceMapping.Designer.cs
+++ b/Server/Migrations/20260825142405_AddUpdatedAtToLeagueInfoAndJuiceMapping.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260825142405_AddUpdatedAtToLeagueInfoAndJuiceMapping")]
+    partial class AddUpdatedAtToLeagueInfoAndJuiceMapping
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/20260825142405_AddUpdatedAtToLeagueInfoAndJuiceMapping.cs
+++ b/Server/Migrations/20260825142405_AddUpdatedAtToLeagueInfoAndJuiceMapping.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUpdatedAtToLeagueInfoAndJuiceMapping : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                table: "LeagueJuiceMapping",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                table: "LeagueInfo",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UpdatedAt",
+                table: "LeagueJuiceMapping");
+
+            migrationBuilder.DropColumn(
+                name: "UpdatedAt",
+                table: "LeagueInfo");
+        }
+    }
+}

--- a/Server/Models/Data/LeagueInfo.cs
+++ b/Server/Models/Data/LeagueInfo.cs
@@ -6,6 +6,7 @@ public class LeagueInfo {
     public int Id { get; set; }
     public string LeagueName { get; set; }
     public DateTimeOffset DateCreated { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? UpdatedAt { get; set; }
     // Foreign key to the AspNetUsers table
     public string OwnerUserId { get; set; }
     public ApplicationUser Owner { get; set; } // Navigation property

--- a/Server/Models/Data/LeagueJuiceMapping.cs
+++ b/Server/Models/Data/LeagueJuiceMapping.cs
@@ -9,4 +9,5 @@ public class LeagueJuiceMapping {
     public int JuiceConference { get; set; } = 6;
     public int WeeklyCost { get; set; } = 5;
     public DateTimeOffset DateCreated { get; set; }
+    public DateTimeOffset? UpdatedAt { get; set; }
 }

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -224,6 +224,17 @@ builder.Services.AddRateLimiter(options =>
         opt.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
         opt.QueueLimit = 0;
     });
+
+    // Public, unauthenticated, no-side-effect endpoints (e.g. /api/version): generous but bounded,
+    // so an unthrottled scanner/bot can't hit them at unlimited volume the way every other
+    // anonymous endpoint in this app is already protected from.
+    options.AddFixedWindowLimiter("public", opt =>
+    {
+        opt.PermitLimit = 60;
+        opt.Window = TimeSpan.FromMinutes(1);
+        opt.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
+        opt.QueueLimit = 0;
+    });
 });
 
 

--- a/Server/Services/Repositories/LeagueRepository.cs
+++ b/Server/Services/Repositories/LeagueRepository.cs
@@ -253,12 +253,27 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
         await using var db = await dbContextFactory.CreateDbContextAsync();
         var league = await db.LeagueInfo.FirstAsync(l => l.Id == leagueId);
         league.OwnerUserId = newOwnerUserId;
+        league.UpdatedAt = DateTimeOffset.UtcNow;
         await db.SaveChangesAsync();
     }
 
+    // /code-review: the caller (LeagueController.UpdateLeagueJuice) fetches `mapping` via
+    // GetLeagueJuiceMappingAsync, which .Include()s the League navigation. A blind
+    // db.LeagueJuiceMapping.Update(mapping) on that detached graph would make EF Core's
+    // change-tracker walk the whole reachable graph and mark the stale, detached League
+    // instance as Modified too — clobbering LeagueInfo's columns (including its own new
+    // UpdatedAt) with whatever snapshot was captured back when the mapping was fetched,
+    // silently reverting any concurrent change to that league's other fields. Fetch fresh in
+    // this context and mutate only the juice scalars instead — same pattern as
+    // UpdateLeagueOwnerAsync above — so League is never touched.
     public async Task UpdateLeagueJuiceMappingAsync(LeagueJuiceMapping mapping) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
-        db.LeagueJuiceMapping.Update(mapping);
+        var existing = await db.LeagueJuiceMapping.FirstAsync(m => m.Id == mapping.Id);
+        existing.Juice = mapping.Juice;
+        existing.JuiceDivisional = mapping.JuiceDivisional;
+        existing.JuiceConference = mapping.JuiceConference;
+        existing.WeeklyCost = mapping.WeeklyCost;
+        existing.UpdatedAt = DateTimeOffset.UtcNow;
         await db.SaveChangesAsync();
     }
 

--- a/Shared/Models/Data/Dtos/AddCfbPicksResponseDto.cs
+++ b/Shared/Models/Data/Dtos/AddCfbPicksResponseDto.cs
@@ -1,0 +1,3 @@
+namespace FourPlayWebApp.Shared.Models.Data.Dtos;
+
+public record AddCfbPicksResponseDto(int Added);

--- a/Shared/Models/Data/Dtos/MessageResponseDto.cs
+++ b/Shared/Models/Data/Dtos/MessageResponseDto.cs
@@ -1,0 +1,3 @@
+namespace FourPlayWebApp.Shared.Models.Data.Dtos;
+
+public record MessageResponseDto(string Message);

--- a/Shared/Models/Data/Dtos/OkResponseDto.cs
+++ b/Shared/Models/Data/Dtos/OkResponseDto.cs
@@ -1,0 +1,3 @@
+namespace FourPlayWebApp.Shared.Models.Data.Dtos;
+
+public record OkResponseDto(bool Ok = true);

--- a/Shared/Models/Data/Dtos/VersionDto.cs
+++ b/Shared/Models/Data/Dtos/VersionDto.cs
@@ -1,0 +1,3 @@
+namespace FourPlayWebApp.Shared.Models.Data.Dtos;
+
+public record VersionDto(string Sha, string Env, DateTimeOffset Timestamp);


### PR DESCRIPTION
## Summary
- Replace anonymous controller returns with typed DTOs (`MessageResponseDto`, `OkResponseDto`, `AddCfbPicksResponseDto`) per the API-surface rule
- Add CFB mock-based Playwright specs (picks/scores) with a dedicated `cfbRoutes` helper mirroring the existing NFL mock setup
- Add `UpdatedAt` audit column to `LeagueJuiceMapping`/`LeagueInfo` — also fixes a latent bug where `UpdateLeagueJuiceMappingAsync`'s blind EF `.Update()` call clobbered the parent `LeagueInfo` row via its populated `League` navigation
- Add frontend utility test coverage: session ownership/sport-filtering, `leagueHelpers`, `base64`, `weather`, `spreadRelease`
- Add `/api/version` endpoint + stale-build-update banner + footer commit link, reading Railway/Vercel's own auto-injected commit SHA env vars (`GITHUB_SHA` is never actually set by this repo's real deploy path)
- Fix HomePage promo video to use native `controls` (resize/fullscreen)

Addresses beads: frizat-b0t, frizat-80l, frizat-066, frizat-f29 (plus the DTO/CFB-e2e follow-up from frizat-dcz).

## Test plan
- [x] `dotnet test` — 695/695 passing
- [x] `npm run test -- --run` — 468/468 passing
- [x] `npm run typecheck` — clean
- [x] `npm run test:e2e -- --project=chromium` — 88/88 passing
- [x] `/simplify` run — 3 findings applied (React Query refactor, dead-code removal)
- [x] `/code-review` run — 4 findings applied (LeagueInfo-clobber fix + regression test, GITHUB_SHA→Railway/Vercel var fix, rate limiting on /api/version, empty-string-safe SHA fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs