### PR TITLE
Consolidate NFL/CFB status and pick-type handling (bo1), b2y cleanup

### DIFF
--- a/Client.React/src/__tests__/gameStatusValue.test.ts
+++ b/Client.React/src/__tests__/gameStatusValue.test.ts
@@ -1,0 +1,40 @@
+import { isGameDecided, isGameFinal, isGameLive } from '../utils/gameHelpers';
+
+describe('isGameFinal', () => {
+  it('is true only for "final"', () => {
+    expect(isGameFinal('final')).toBe(true);
+  });
+
+  it('is false for in_progress, halftime, scheduled, and null', () => {
+    expect(isGameFinal('in_progress')).toBe(false);
+    expect(isGameFinal('halftime')).toBe(false);
+    expect(isGameFinal('scheduled')).toBe(false);
+    expect(isGameFinal(null)).toBe(false);
+  });
+});
+
+describe('isGameLive', () => {
+  it('is true for in_progress and halftime', () => {
+    expect(isGameLive('in_progress')).toBe(true);
+    expect(isGameLive('halftime')).toBe(true);
+  });
+
+  it('is false for final, scheduled, and null', () => {
+    expect(isGameLive('final')).toBe(false);
+    expect(isGameLive('scheduled')).toBe(false);
+    expect(isGameLive(null)).toBe(false);
+  });
+});
+
+describe('isGameDecided', () => {
+  it('is true once a game has started or finished', () => {
+    expect(isGameDecided('final')).toBe(true);
+    expect(isGameDecided('in_progress')).toBe(true);
+    expect(isGameDecided('halftime')).toBe(true);
+  });
+
+  it('is false while still scheduled', () => {
+    expect(isGameDecided('scheduled')).toBe(false);
+    expect(isGameDecided(null)).toBe(false);
+  });
+});

--- a/Client.React/src/components/sports/GameCard.tsx
+++ b/Client.React/src/components/sports/GameCard.tsx
@@ -2,8 +2,9 @@ import { Box, Button, Card, CardContent, Chip, Stack, Typography } from '@mui/ma
 import CheckIcon from '@mui/icons-material/Check';
 import TeamHelmet from './TeamHelmet';
 import WeatherIcon from '../WeatherIcon';
-import { spreadLabel } from '../../utils/gameHelpers';
+import { isGameFinal, isGameLive, spreadLabel } from '../../utils/gameHelpers';
 import { toLocalDisplay } from '../../utils/time';
+import type { GameStatusValue } from '../../services/sportAdapter';
 
 export type PickState = 'none' | 'pending' | 'submitted';
 
@@ -18,7 +19,7 @@ export interface GameCardProps {
   // Score display
   homeScore?: number;
   awayScore?: number;
-  gameStatus?: string;
+  gameStatus?: GameStatusValue;
   gameDetail?: string;
   // Pick mode
   homePickState?: PickState;
@@ -57,12 +58,9 @@ function formatShortDateTime(iso: string) {
   });
 }
 
-function statusChip(status: string | undefined, gameTime: string) {
-  const isFinal = status === 'StatusFinal' || status === 'status_final';
-  const isLive = status === 'StatusInProgress' || status === 'status_in_progress';
-
-  if (isFinal) return <Chip label="Final" size="small" color="default" />;
-  if (isLive) return <Chip label="Live" size="small" color="success" />;
+function statusChip(status: GameStatusValue | undefined, gameTime: string) {
+  if (isGameFinal(status ?? null)) return <Chip label="Final" size="small" color="default" />;
+  if (isGameLive(status ?? null)) return <Chip label="Live" size="small" color="success" />;
   return (
     <Typography variant="caption" color="text.secondary">
       {formatShortDateTime(gameTime)}
@@ -89,8 +87,8 @@ export default function GameCard({
   homePickers, awayPickers,
   spreadPostedAt,
 }: GameCardProps) {
-  const isFinal = gameStatus === 'StatusFinal' || gameStatus === 'status_final';
-  const isLive = gameStatus === 'StatusInProgress' || gameStatus === 'status_in_progress';
+  const isFinal = isGameFinal(gameStatus ?? null);
+  const isLive = isGameLive(gameStatus ?? null);
   const showScore = mode === 'score' && (isFinal || isLive);
 
   // frizat: "Picked" (with its checkmark icon) renders ~29px wider than "Pick" at minWidth alone

--- a/Client.React/src/pages/PicksPage.tsx
+++ b/Client.React/src/pages/PicksPage.tsx
@@ -16,8 +16,9 @@ import SpreadRelease from '../components/SpreadRelease';
 import GameCard, { type PickState } from '../components/sports/GameCard';
 import { useSession } from '../services/session';
 import { useAuth } from '../services/auth';
-import type { SportAdapter, GameView, WeekState } from '../services/sportAdapter';
+import type { SportAdapter, GameView, PickType, WeekState } from '../services/sportAdapter';
 import { useToast } from '../services/toast';
+import { isGameDecided } from '../utils/gameHelpers';
 
 // Pick key: "gameId|team|pickType" — stable across NFL and CFB
 function pickKey(gameId: string, team: string, pickType: string) {
@@ -25,7 +26,7 @@ function pickKey(gameId: string, team: string, pickType: string) {
 }
 
 function gameIsLocked(game: GameView): boolean {
-  if (game.gameStatus === 'final' || game.gameStatus === 'in_progress' || game.gameStatus === 'halftime') return true;
+  if (isGameDecided(game.gameStatus)) return true;
   return new Date(game.gameTime) <= new Date();
 }
 
@@ -130,12 +131,12 @@ export default function PicksPage({ adapter }: PicksPageProps) {
   const remainingPicks = requiredPicks - userPicks.size - existingPicks.size;
   const isPicksLocked = () => remainingPicks <= 0;
 
-  const selectPick = (gameId: string, team: string, pickType = 'Spread') => {
+  const selectPick = (gameId: string, team: string, pickType: PickType = 'Spread') => {
     if (isPicksLocked()) return;
     setUserPicks(prev => new Set(prev).add(pickKey(gameId, team, pickType)));
   };
 
-  const unselectPick = (gameId: string, team: string, pickType = 'Spread') => {
+  const unselectPick = (gameId: string, team: string, pickType: PickType = 'Spread') => {
     const key = pickKey(gameId, team, pickType);
     setUserPicks(prev => { const s = new Set(prev); s.delete(key); return s; });
   };
@@ -146,7 +147,7 @@ export default function PicksPage({ adapter }: PicksPageProps) {
     try {
       const picks = [...userPicks].map(key => {
         const [gameId, team, pickType] = key.split('|');
-        return { gameId, team, pickType };
+        return { gameId, team, pickType: pickType as PickType };
       });
       await adapter.submitPicks(currentLeague, { season, week, isPostSeason }, picks);
       toast.push(`${picks.length} Pick(s) Added`, 'success');

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -18,19 +18,17 @@ import PickDialog from '../components/PickDialog';
 import FieldPosition from '../components/FieldPosition';
 import { useSession } from '../services/session';
 import { useAuth } from '../services/auth';
-import { spreadLabel } from '../utils/gameHelpers';
+import { isGameDecided, isGameFinal, isGameLive, spreadLabel } from '../utils/gameHelpers';
 import { useShareLink } from '../utils/useShareLink';
-import type { SportAdapter, GameView, WeekState } from '../services/sportAdapter';
-
-// GameView.gameStatus is canonical GameStatusValue — use === directly, no string parsing
+import type { SportAdapter, GameView, WeekState, PickType } from '../services/sportAdapter';
 
 // ─── Icon + color helpers (use pre-computed adapter fields) ──────────────────
 
 function isDecided(game: GameView): boolean {
-  return game.gameStatus === 'final' || game.gameStatus === 'in_progress' || game.gameStatus === 'halftime';
+  return isGameDecided(game.gameStatus);
 }
 
-function teamWins(game: GameView, team: string, pickType: 'Spread' | 'Over' | 'Under'): boolean | null {
+function teamWins(game: GameView, team: string, pickType: PickType): boolean | null {
   if (!isDecided(game)) return null;
   if (pickType === 'Spread') {
     if (game.homeCovers == null) return null;
@@ -310,8 +308,8 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
             )}
 
             {data?.hasOdds && games.map(game => {
-              const isFinal = game.gameStatus === 'final';
-              const isLive = game.gameStatus === 'in_progress' || game.gameStatus === 'halftime';
+              const isFinal = isGameFinal(game.gameStatus);
+              const isLive = isGameLive(game.gameStatus);
               const hc = game.homeCovers ?? null;
               const ov = game.overWins ?? null;
 

--- a/Client.React/src/services/cfbAdapter.ts
+++ b/Client.React/src/services/cfbAdapter.ts
@@ -1,10 +1,10 @@
 import { getCfbCurrentSlate, getCfbSlates, getCfbSpreads, getCfbScores as getCfbDbScores, getCfbUserPicks, getCfbAllPicks, addCfbPicks, deleteCfbPicks } from '../api/cfb';
 import { loadCfbScoresWithRetry, getCfbScoresForSlate, getCfbLiveGames } from '../api/espn';
-import { cfbSlateNumberToWeek, cfbWeekToSlateNumber, getCfbWeekName, computeHomeCovers, computeOverWins, getCfbRequiredPicks } from '../utils/gameHelpers';
+import { cfbSlateNumberToWeek, cfbWeekToSlateNumber, getCfbWeekName, computeHomeCovers, computeOverWins, getCfbRequiredPicks, isGameLive } from '../utils/gameHelpers';
 import type { CfbSlateDto, CfbSpreadDto, CfbScoreDto, CfbPickDto } from '../types/league';
 import type { EspnScores } from '../types/espn';
 import { getHomeTeamScore, getAwayTeamScore, toGameStatus, isHomeAway } from '../utils/gameHelpers';
-import type { SportAdapter, GameView, GameStatusValue, PickView, WeekState } from './sportAdapter';
+import type { SportAdapter, GameView, GameStatusValue, PickView, PickType, WeekState } from './sportAdapter';
 import { revealPicksForStartedGames } from './sportAdapter';
 
 /** Map CFB backend status strings to canonical GameStatusValue */
@@ -129,7 +129,7 @@ function cfbPickToPickView(pick: CfbPickDto, teamToHomeTeam: Map<string, string>
   return {
     gameId: teamToHomeTeam.get(pick.team) ?? pick.team,
     team: pick.team,
-    pickType: pick.pickType as PickView['pickType'],
+    pickType: pick.pickType as PickType,
     userId: pick.userId,
     userName: pick.userName ?? '',
   };
@@ -276,7 +276,7 @@ export function createCfbAdapter(): SportAdapter {
       }
       const weekState = slateToWeekState(active);
       const { games, allPicks, userPicks } = await loadScoresForSlate(leagueId, userId, active, true);
-      const hasActiveGames = games.some(g => g.gameStatus === 'in_progress' || g.gameStatus === 'halftime');
+      const hasActiveGames = games.some(g => isGameLive(g.gameStatus));
       return { ...weekState, games, allPicks, userPicks, hasOdds: games.length > 0, hasActiveGames, requiredPicks: getCfbRequiredPicks(active.slateNumber), maxWeek: weekState.week, maxSeason: active.season };
     },
 

--- a/Client.React/src/services/nflAdapter.ts
+++ b/Client.React/src/services/nflAdapter.ts
@@ -2,7 +2,7 @@ import { loadScoresWithRetry, getWeekScores, getLiveGames } from '../api/espn';
 import { getUserPicks, doOddsExist, spreadBatch, addPicks, getLeaguePicks, getNflCurrentWeek } from '../api/league';
 import { getAllJerseys } from '../api/jersey';
 import type { Competition, Event } from '../types/espn';
-import type { NflPickDto, PickType, SpreadResponse } from '../types/picks';
+import type { NflPickDto, SpreadResponse } from '../types/picks';
 import {
   getHomeTeamAbbr, getAwayTeamAbbr,
   getHomeTeam, getAwayTeam,
@@ -13,7 +13,7 @@ import {
   isGameOver, isGameStarted, toGameStatus,
   computeHomeCovers, computeOverWins,
 } from '../utils/gameHelpers';
-import type { SportAdapter, GameView, PickView } from './sportAdapter';
+import type { SportAdapter, GameView, PickView, PickType } from './sportAdapter';
 import { revealPicksForStartedGames } from './sportAdapter';
 
 function competitionToGameView(
@@ -63,7 +63,7 @@ function nflPickToPickView(pick: NflPickDto, games: GameView[]): PickView | null
   return {
     gameId: game.id,
     team: pick.team,
-    pickType: pick.pick as PickView['pickType'],
+    pickType: pick.pick as PickType,
     userId: pick.userId,
     userName: pick.userName,
   };

--- a/Client.React/src/services/sportAdapter.ts
+++ b/Client.React/src/services/sportAdapter.ts
@@ -1,3 +1,8 @@
+import { isGameDecided } from '../utils/gameHelpers';
+import type { PickType } from '../types/picks';
+
+export type { PickType };
+
 /** Canonical game status — both adapters normalize to this before populating GameView */
 export type GameStatusValue = 'final' | 'in_progress' | 'halftime' | 'scheduled' | null;
 
@@ -13,7 +18,7 @@ export function revealPicksForStartedGames(allPicks: PickView[], games: GameView
     games
       .filter(g => {
         // ESPN confirmed the game is underway or finished
-        if (g.gameStatus !== 'scheduled' && g.gameStatus !== null) return true;
+        if (isGameDecided(g.gameStatus)) return true;
         // ESPN still says scheduled but kickoff time has passed — cache is stale
         if (g.gameStatus === 'scheduled' && g.gameTime != null && new Date(g.gameTime) <= now) return true;
         return false;
@@ -52,7 +57,7 @@ export interface GameView {
 export interface PickView {
   gameId: string;
   team: string;
-  pickType: 'Spread' | 'Over' | 'Under';
+  pickType: PickType;
   userId: string;
   userName: string;
 }
@@ -88,7 +93,7 @@ export interface SportAdapter {
   // Picks page
   loadCurrentGames(leagueId: number, userId: string): Promise<LoadedWeek>;
   loadHistoricalGames(leagueId: number, userId: string, week: WeekState): Promise<LoadedWeek | null>;
-  submitPicks(leagueId: number, state: WeekState, picks: { gameId: string; team: string; pickType: string }[]): Promise<void>;
+  submitPicks(leagueId: number, state: WeekState, picks: { gameId: string; team: string; pickType: PickType }[]): Promise<void>;
   clearPicks(leagueId: number, state: WeekState): Promise<PickView[]>;
   loadJerseys?(season: number, week: number): Promise<Record<string, string>>;
 

--- a/Client.React/src/utils/gameHelpers.ts
+++ b/Client.React/src/utils/gameHelpers.ts
@@ -1,6 +1,22 @@
 import type { Competition, Competitor, EspnScores, Event, TypeName, HomeAway, EspnRecordType } from '../types/espn';
 import { toLocalDisplay } from './time';
 import type { PickType } from '../types/picks';
+import type { GameStatusValue } from '../services/sportAdapter';
+
+/** True only once a game has finished — the canonical GameView.gameStatus check. */
+export function isGameFinal(status: GameStatusValue): boolean {
+  return status === 'final';
+}
+
+/** True while a game is underway (including halftime) — the canonical GameView.gameStatus check. */
+export function isGameLive(status: GameStatusValue): boolean {
+  return status === 'in_progress' || status === 'halftime';
+}
+
+/** True once a game has started or finished — i.e. no longer just "scheduled". */
+export function isGameDecided(status: GameStatusValue): boolean {
+  return isGameFinal(status) || isGameLive(status);
+}
 
 export function getWeekFromEspnWeek(week: number, isPostSeason = false) {
   if (!isPostSeason) return week;
@@ -232,12 +248,6 @@ export function getPickLabel(pickType: PickType) {
 // ─── Shared cover/over computation used by all sport adapters ────────────────
 // Both NFL and CFB adapters should call these instead of duplicating the logic.
 
-import type { GameStatusValue } from '../services/sportAdapter';
-
-function isDecidedStatus(status: GameStatusValue): boolean {
-  return status === 'final' || status === 'in_progress' || status === 'halftime';
-}
-
 /**
  * Returns whether the home team is covering the spread, or null if the game
  * hasn't started or spread data isn't available.
@@ -249,7 +259,7 @@ export function computeHomeCovers(
   homeScore: number | null,
   awayScore: number | null,
 ): boolean | null {
-  if (!isDecidedStatus(status) || homeSpread == null || homeScore == null || awayScore == null) return null;
+  if (!isGameDecided(status) || homeSpread == null || homeScore == null || awayScore == null) return null;
   return (homeScore + homeSpread) > awayScore;
 }
 
@@ -262,7 +272,7 @@ export function computeOverWins(
   homeScore: number | null,
   awayScore: number | null,
 ): boolean | null {
-  if (!isDecidedStatus(status) || overUnder == null || homeScore == null || awayScore == null) return null;
+  if (!isGameDecided(status) || overUnder == null || homeScore == null || awayScore == null) return null;
   return (homeScore + awayScore) > overUnder;
 }
 

--- a/Server.UnitTests/CfbLiveScoreFetcherTests.cs
+++ b/Server.UnitTests/CfbLiveScoreFetcherTests.cs
@@ -163,7 +163,7 @@ public class CfbLiveScoreFetcherTests {
     public async Task FetchForSlateAsync_MissingEspnWeekNumber_ReturnsNull_EvenWithPersistedRows() {
         var slate = BuildSlateMissingWeekNumber(); // EndDate 2025-12-20 — already ended
         var rows = new List<CfbScores> {
-            new() { Id = 1, CfbSlateId = slate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "STATUS_FINAL", GameTime = new DateTimeOffset(2025, 12, 19, 18, 0, 0, TimeSpan.Zero) },
+            new() { Id = 1, CfbSlateId = slate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal, GameTime = new DateTimeOffset(2025, 12, 19, 18, 0, 0, TimeSpan.Zero) },
         };
         _cfbRepo.GetScoresForSlateAsync(slate.Id).Returns((IEnumerable<CfbScores>)rows);
 
@@ -182,7 +182,7 @@ public class CfbLiveScoreFetcherTests {
     public async Task FetchForSlateAsync_WhenDbHasPersistedRowsForTheSlate_ReturnsDbBuiltScores_NeverCallsEspn() {
         var slate = BuildRegularSeasonSlate();
         var rows = new List<CfbScores> {
-            new() { Id = 1, CfbSlateId = slate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "STATUS_FINAL", GameTime = new DateTimeOffset(2025, 9, 27, 18, 0, 0, TimeSpan.Zero) },
+            new() { Id = 1, CfbSlateId = slate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal, GameTime = new DateTimeOffset(2025, 9, 27, 18, 0, 0, TimeSpan.Zero) },
         };
         _cfbRepo.GetScoresForSlateAsync(slate.Id).Returns((IEnumerable<CfbScores>)rows);
 
@@ -227,7 +227,7 @@ public class CfbLiveScoreFetcherTests {
         };
         // One game in this slate already finished and was persisted; the rest are still live.
         var partialRows = new List<CfbScores> {
-            new() { Id = 1, CfbSlateId = activeSlate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "STATUS_FINAL", GameTime = DateTimeOffset.UtcNow.AddHours(-3) },
+            new() { Id = 1, CfbSlateId = activeSlate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal, GameTime = DateTimeOffset.UtcNow.AddHours(-3) },
         };
         _cfbRepo.GetScoresForSlateAsync(activeSlate.Id).Returns((IEnumerable<CfbScores>)partialRows);
         _cfbApi.GetScoresByWeekAsync(3, false).Returns(BuildScoreboardWithRanking());
@@ -247,7 +247,7 @@ public class CfbLiveScoreFetcherTests {
     public async Task FetchForSlateAsync_CachesTheDbBuiltResult_SecondCallForSameSlateNeverHitsDbAgain() {
         var slate = BuildRegularSeasonSlate(); // EndDate 2025-9-28 — already ended
         var rows = new List<CfbScores> {
-            new() { Id = 1, CfbSlateId = slate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "STATUS_FINAL", GameTime = new DateTimeOffset(2025, 9, 27, 18, 0, 0, TimeSpan.Zero) },
+            new() { Id = 1, CfbSlateId = slate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal, GameTime = new DateTimeOffset(2025, 9, 27, 18, 0, 0, TimeSpan.Zero) },
         };
         _cfbRepo.GetScoresForSlateAsync(slate.Id).Returns((IEnumerable<CfbScores>)rows);
 

--- a/Server.UnitTests/CfbPicksControllerTests.cs
+++ b/Server.UnitTests/CfbPicksControllerTests.cs
@@ -1,8 +1,10 @@
 using FourPlayWebApp.Server.Controllers;
 using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
+using FourPlayWebApp.Shared.Models;
 using FourPlayWebApp.Shared.Models.Data;
 using FourPlayWebApp.Shared.Models.Data.Dtos;
+using FourPlayWebApp.Shared.Models.Enum;
 using NSubstitute;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -81,7 +83,7 @@ public class CfbPicksControllerTests
             LeagueId = 1,
             CfbSlateId = 1,
             Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = PickType.Spread }]
         };
         _repo.GetUserPicksAsync(1, 1, UserId).Returns([]);
         _repo.AddPicksAsync(Arg.Any<IEnumerable<CfbPicks>>()).Returns(Task.CompletedTask);
@@ -106,7 +108,7 @@ public class CfbPicksControllerTests
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = PickType.Spread }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -124,7 +126,7 @@ public class CfbPicksControllerTests
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = PickType.Spread }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -144,7 +146,7 @@ public class CfbPicksControllerTests
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = PickType.Spread }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -164,7 +166,7 @@ public class CfbPicksControllerTests
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = PickType.Spread }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -184,7 +186,7 @@ public class CfbPicksControllerTests
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = PickType.Spread }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -203,7 +205,7 @@ public class CfbPicksControllerTests
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = PickType.Spread }]
         };
 
         var result = await BuildController().AddPicks(request);
@@ -228,8 +230,8 @@ public class CfbPicksControllerTests
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
             Picks =
             [
-                new CfbPickItem { Team = "ORE", PickType = "Spread" },
-                new CfbPickItem { Team = "ALA", PickType = "Spread" },
+                new CfbPickItem { Team = "ORE", PickType = PickType.Spread },
+                new CfbPickItem { Team = "ALA", PickType = PickType.Spread },
             ]
         };
 
@@ -355,7 +357,7 @@ public class CfbPicksControllerTests
     private static CfbScores MakeScore(string home = "ORE", string away = "OSU") => new()
     {
         CfbSlateId = 1, HomeTeam = home, AwayTeam = away,
-        HomeTeamScore = 24, AwayTeamScore = 17, GameStatus = "STATUS_FINAL",
+        HomeTeamScore = 24, AwayTeamScore = 17, GameStatus = TypeName.StatusFinal,
     };
 
     [Fact]
@@ -413,7 +415,7 @@ public class CfbPicksControllerTests
         var request = new AddCfbPicksRequest
         {
             LeagueId = 1, CfbSlateId = 1, Season = 2025,
-            Picks = [new CfbPickItem { Team = "ORE", PickType = "Spread" }]
+            Picks = [new CfbPickItem { Team = "ORE", PickType = PickType.Spread }]
         };
 
         var result = await BuildController().AddPicks(request);

--- a/Server.UnitTests/CfbPicksControllerTests.cs
+++ b/Server.UnitTests/CfbPicksControllerTests.cs
@@ -57,20 +57,27 @@ public class CfbPicksControllerTests
         IsLeagueEligible = isLeagueEligible,
     };
 
+    // /code-review + live CI failure: this endpoint used to return the raw CfbPicks entity
+    // directly (Ok(picks)) — harmless while PickType was a plain string, but once PickType became
+    // an enum, the entity (no JsonStringEnumConverter) silently started serializing it as an int
+    // instead of "Spread"/"Over"/"Under", breaking every frontend consumer that matches by that
+    // string. Must go through CfbPickDto like every other picks-returning endpoint already does.
     [Fact]
     public async Task GetUserPicks_ReturnsPicksForUser()
     {
         var picks = new List<CfbPicks>
         {
-            new() { Id = 1, UserId = UserId, LeagueId = 1, CfbSlateId = 1, Team = "ORE" }
+            new() { Id = 1, UserId = UserId, LeagueId = 1, CfbSlateId = 1, Team = "ORE", PickType = PickType.Spread }
         };
         _repo.GetUserPicksAsync(1, 1, UserId).Returns(picks);
 
         var result = await BuildController().GetUserPicks(1, 1);
 
         var ok = Assert.IsType<OkObjectResult>(result);
-        var returned = Assert.IsAssignableFrom<IEnumerable<CfbPicks>>(ok.Value);
+        var returned = Assert.IsAssignableFrom<IEnumerable<CfbPickDto>>(ok.Value).ToList();
         Assert.Single(returned);
+        Assert.Equal(PickType.Spread, returned[0].PickType);
+        Assert.Equal("ORE", returned[0].Team);
     }
 
     [Fact]

--- a/Server.UnitTests/CfbPicksRepositoryTests.cs
+++ b/Server.UnitTests/CfbPicksRepositoryTests.cs
@@ -1,0 +1,26 @@
+using FourPlayWebApp.Server.Services.Repositories;
+using FourPlayWebApp.Shared.Models.Data;
+using FourPlayWebApp.Shared.Models.Enum;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+// frizat-bo1: CfbPicks.PickType was a raw string — migrated to reuse NflPicks' existing PickType
+// enum (same values, same concept) rather than a CFB-only duplicate.
+public class CfbPicksRepositoryTests
+{
+    [Fact]
+    public async Task AddPicksAsync_PersistsPickTypeEnum_AndReadsItBack()
+    {
+        var factory = new DbContextFactoryStub(nameof(AddPicksAsync_PersistsPickTypeEnum_AndReadsItBack));
+        var repo = new CfbPicksRepository(factory);
+
+        await repo.AddPicksAsync([
+            new CfbPicks { UserId = "u1", LeagueId = 1, CfbSlateId = 1, Team = "ALA", PickType = PickType.Over, Season = 2026 },
+        ]);
+
+        var saved = await factory.CreateDbContext().CfbPicks.SingleAsync(p => p.Team == "ALA");
+        Assert.Equal(PickType.Over, saved.PickType);
+    }
+}

--- a/Server.UnitTests/CfbRepositoryTests.cs
+++ b/Server.UnitTests/CfbRepositoryTests.cs
@@ -1,5 +1,6 @@
 using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Services.Repositories;
+using FourPlayWebApp.Shared.Models;
 using FourPlayWebApp.Shared.Models.Data;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
@@ -140,5 +141,43 @@ public class CfbRepositoryTests
 
         Assert.Equal(3, all.Count);
         Assert.Equal([(2025, 4), (2026, 1), (2026, 2)], all.Select(s => (s.Season, s.SlateNumber)));
+    }
+
+    // frizat-b2y: CapturedAtUtc changed from DateTime to DateTimeOffset for unambiguous instant
+    // representation, matching DateCreated/UpdatedAt elsewhere in this codebase. Note: Postgres's
+    // timestamptz (what this column maps to either way) always normalizes to UTC and never
+    // preserves an arbitrary input offset — DateTimeOffset.Equals compares by absolute instant,
+    // not literal offset, so a non-UTC input still round-trips correctly here without asserting
+    // (falsely) that the original -5 offset itself survives storage.
+    [Fact]
+    public async Task AddRankingsAsync_PreservesCapturedAtUtcInstant()
+    {
+        var factory = new DbContextFactoryStub(nameof(AddRankingsAsync_PreservesCapturedAtUtcInstant));
+        var repo = new CfbRepository(factory);
+        var capturedAt = new DateTimeOffset(2026, 8, 26, 9, 0, 0, TimeSpan.FromHours(-5));
+
+        await repo.AddRankingsAsync([
+            new CfbRanking { Season = 2026, EspnWeekNumber = 1, EspnEventId = 1, TeamAbbreviation = "ALA", CuratedRank = 3, CapturedAtUtc = capturedAt },
+        ]);
+
+        var saved = await factory.CreateDbContext().CfbRankings.SingleAsync(r => r.TeamAbbreviation == "ALA");
+        Assert.Equal(capturedAt, saved.CapturedAtUtc);
+    }
+
+    // frizat-bo1: CfbScores.GameStatus was a raw string ("StatusFinal", "StatusInProgress", ...) —
+    // migrated to reuse the existing TypeName enum (the same one ESPN status parsing already uses
+    // everywhere else) rather than either a loose string or a brand-new duplicate enum.
+    [Fact]
+    public async Task UpsertCfbScoresAsync_PersistsGameStatusEnum_AndReadsItBack()
+    {
+        var factory = new DbContextFactoryStub(nameof(UpsertCfbScoresAsync_PersistsGameStatusEnum_AndReadsItBack));
+        var repo = new CfbRepository(factory);
+
+        await repo.UpsertCfbScoresAsync([
+            new CfbScores { CfbSlateId = 1, HomeTeam = "A", AwayTeam = "B", HomeTeamScore = 21, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal },
+        ]);
+
+        var saved = (await repo.GetScoresForSlateAsync(1)).Single();
+        Assert.Equal(TypeName.StatusFinal, saved.GameStatus);
     }
 }

--- a/Server.UnitTests/CfbScoresJobTests.cs
+++ b/Server.UnitTests/CfbScoresJobTests.cs
@@ -140,7 +140,7 @@ public class CfbScoresJobTests
         Assert.Equal("OSU", score.AwayTeam);
         Assert.Equal(41,    score.HomeTeamScore);
         Assert.Equal(21,    score.AwayTeamScore);
-        Assert.Equal("StatusFinal", score.GameStatus);
+        Assert.Equal(TypeName.StatusFinal, score.GameStatus);
         Assert.Equal(slate.Id, score.CfbSlateId);
     }
 

--- a/Server.UnitTests/LeaderboardTests.cs
+++ b/Server.UnitTests/LeaderboardTests.cs
@@ -350,12 +350,12 @@ public class LeaderboardServiceTests {
             new CfbSpreads { Id = 1, CfbSlateId = slateId, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -7, AwayTeamSpread = 7, OverUnder = 50, IsLeagueEligible = true }
         ]);
         cfbRepo.GetScoresForSlateAsync(slateId).Returns((IEnumerable<CfbScores>)[
-            new CfbScores { Id = 1, CfbSlateId = slateId, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "StatusFinal" }
+            new CfbScores { Id = 1, CfbSlateId = slateId, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal }
         ]);
 
         var picksRepo = Substitute.For<ICfbPicksRepository>();
         picksRepo.GetUserPicksAsync(leagueId, slateId, userId).Returns((IEnumerable<CfbPicks>)[
-            new CfbPicks { UserId = userId, LeagueId = leagueId, CfbSlateId = slateId, Team = "IU", PickType = "Spread", Season = 2025 }
+            new CfbPicks { UserId = userId, LeagueId = leagueId, CfbSlateId = slateId, Team = "IU", PickType = PickType.Spread, Season = 2025 }
         ]);
 
         return (leagueRepo, cfbRepo, picksRepo);
@@ -381,7 +381,7 @@ public class LeaderboardServiceTests {
 
         // Override scores: IU loses badly — 7 to 35, so IU 7 + (-7+5) = 5; 5 - 35 = -30 < 0 → loss
         cfbRepo.GetScoresForSlateAsync(1).Returns((IEnumerable<CfbScores>)[
-            new CfbScores { Id = 1, CfbSlateId = 1, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 7, AwayTeamScore = 35, GameStatus = "StatusFinal" }
+            new CfbScores { Id = 1, CfbSlateId = 1, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 7, AwayTeamScore = 35, GameStatus = TypeName.StatusFinal }
         ]);
 
         var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo);
@@ -441,17 +441,17 @@ public class LeaderboardServiceTests {
             new CfbSpreads { Id = 1, CfbSlateId = slateId, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -7, AwayTeamSpread = 7, OverUnder = 50, IsLeagueEligible = true }
         ]);
         cfbRepo.GetScoresForSlateAsync(slateId).Returns((IEnumerable<CfbScores>)[
-            new CfbScores { Id = 1, CfbSlateId = slateId, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = "StatusFinal" }
+            new CfbScores { Id = 1, CfbSlateId = slateId, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal }
         ]);
 
         var picksRepo = Substitute.For<ICfbPicksRepository>();
         picksRepo.GetUserPicksAsync(leagueId, slateId, Arg.Is<string>(uid => winnerIds.Contains(uid)))
             .Returns((IEnumerable<CfbPicks>)[
-                new CfbPicks { CfbSlateId = slateId, Team = "IU", PickType = "Spread", Season = 2025 }
+                new CfbPicks { CfbSlateId = slateId, Team = "IU", PickType = PickType.Spread, Season = 2025 }
             ]);
         picksRepo.GetUserPicksAsync(leagueId, slateId, Arg.Is<string>(uid => loserIds.Contains(uid)))
             .Returns((IEnumerable<CfbPicks>)[
-                new CfbPicks { CfbSlateId = slateId, Team = "OSU", PickType = "Spread", Season = 2025 }
+                new CfbPicks { CfbSlateId = slateId, Team = "OSU", PickType = PickType.Spread, Season = 2025 }
             ]);
 
         return (leagueRepo, cfbRepo, picksRepo);
@@ -471,7 +471,7 @@ public class LeaderboardServiceTests {
             new CfbSpreads { Id = 1, CfbSlateId = 1, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -10, AwayTeamSpread = 10, OverUnder = 50, IsLeagueEligible = true }
         ]);
         cfbRepo.GetScoresForSlateAsync(1).Returns((IEnumerable<CfbScores>)[
-            new CfbScores { Id = 1, CfbSlateId = 1, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 20, GameStatus = "StatusFinal" }
+            new CfbScores { Id = 1, CfbSlateId = 1, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 20, GameStatus = TypeName.StatusFinal }
         ]);
 
         var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo);

--- a/Server.UnitTests/SpreadOddsFetcherTests.cs
+++ b/Server.UnitTests/SpreadOddsFetcherTests.cs
@@ -1,0 +1,94 @@
+using FourPlayWebApp.Server.Jobs;
+using FourPlayWebApp.Shared.Models;
+using Xunit;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+// frizat-bo1: NflSpreadJob and CfbSpreadJob each duplicated the "fetch odds, prefer DraftKings,
+// fall back to any available provider, parse the American spread strings" logic — extracted here
+// as the one piece that was genuinely identical, while each job keeps its own sport-specific
+// current-week/slate resolution and CfbSpreads/NflSpreads construction untouched.
+public class SpreadOddsFetcherTests
+{
+    private static EspnCoreOddsItem MakeOdds(string homeAmerican, string awayAmerican, double overUnder = 45.5, string providerName = "ESPN BET") => new() {
+        Provider = new EspnCoreOddsProvider { Name = providerName },
+        OverUnder = overUnder,
+        HomeTeamOdds = new EspnCoreTeamOdds { Current = new EspnCoreTeamOddsDetail { PointSpread = new EspnCorePointSpread { American = homeAmerican } } },
+        AwayTeamOdds = new EspnCoreTeamOdds { Current = new EspnCoreTeamOddsDetail { PointSpread = new EspnCorePointSpread { American = awayAmerican } } },
+    };
+
+    [Fact]
+    public async Task FetchAsync_UsesDraftKingsResult_WhenAvailable()
+    {
+        var draftKingsOdds = MakeOdds("-3.5", "+3.5");
+
+        var result = await SpreadOddsFetcher.FetchAsync(
+            getByProvider: (_, _) => Task.FromResult<EspnCoreOddsItem?>(draftKingsOdds),
+            getAny: _ => Task.FromResult<EspnCoreOddsApiResponse?>(null),
+            eventId: 1,
+            gameLabel: "TEST");
+
+        Assert.NotNull(result);
+        Assert.Equal(-3.5, result.Value.HomeSpread);
+        Assert.Equal(3.5, result.Value.AwaySpread);
+        Assert.Equal(45.5, result.Value.OverUnder);
+    }
+
+    [Fact]
+    public async Task FetchAsync_FallsBackToFirstAvailableProvider_WhenDraftKingsUnavailable()
+    {
+        var fallbackOdds = MakeOdds("-6.5", "+6.5", overUnder: 51.0, providerName: "Other Book");
+
+        var result = await SpreadOddsFetcher.FetchAsync(
+            getByProvider: (_, _) => Task.FromResult<EspnCoreOddsItem?>(null),
+            getAny: _ => Task.FromResult<EspnCoreOddsApiResponse?>(new EspnCoreOddsApiResponse { Count = 1, Items = [fallbackOdds] }),
+            eventId: 1,
+            gameLabel: "TEST");
+
+        Assert.NotNull(result);
+        Assert.Equal(-6.5, result.Value.HomeSpread);
+        Assert.Equal(6.5, result.Value.AwaySpread);
+        Assert.Equal(51.0, result.Value.OverUnder);
+    }
+
+    [Fact]
+    public async Task FetchAsync_ReturnsNull_WhenNoProviderHasOdds()
+    {
+        var result = await SpreadOddsFetcher.FetchAsync(
+            getByProvider: (_, _) => Task.FromResult<EspnCoreOddsItem?>(null),
+            getAny: _ => Task.FromResult<EspnCoreOddsApiResponse?>(new EspnCoreOddsApiResponse { Items = [] }),
+            eventId: 1,
+            gameLabel: "TEST");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FetchAsync_StripsLeadingPlusSign_FromPositiveAmericanSpreads()
+    {
+        var odds = MakeOdds("-2.5", "+2.5");
+
+        var result = await SpreadOddsFetcher.FetchAsync(
+            getByProvider: (_, _) => Task.FromResult<EspnCoreOddsItem?>(odds),
+            getAny: _ => Task.FromResult<EspnCoreOddsApiResponse?>(null),
+            eventId: 1,
+            gameLabel: "TEST");
+
+        Assert.NotNull(result);
+        Assert.Equal(2.5, result.Value.AwaySpread);
+    }
+
+    [Fact]
+    public async Task FetchAsync_ReturnsNull_WhenSpreadIsNotParseable()
+    {
+        var odds = MakeOdds("PK", "PK"); // pick'em games can render as non-numeric text
+
+        var result = await SpreadOddsFetcher.FetchAsync(
+            getByProvider: (_, _) => Task.FromResult<EspnCoreOddsItem?>(odds),
+            getAny: _ => Task.FromResult<EspnCoreOddsApiResponse?>(null),
+            eventId: 1,
+            gameLabel: "TEST");
+
+        Assert.Null(result);
+    }
+}

--- a/Server.UnitTests/TolerantEnumConverterTests.cs
+++ b/Server.UnitTests/TolerantEnumConverterTests.cs
@@ -1,0 +1,33 @@
+using FourPlayWebApp.Server.Data.Configurations;
+using FourPlayWebApp.Shared.Models.Enum;
+using Xunit;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+// /code-review: HasConversion<string>() alone throws on read for any stored value that doesn't
+// exactly match an enum member name — a single malformed row would 500 the whole query instead
+// of degrading gracefully. TolerantEnumConverter is the fallback-instead-of-throw version used by
+// CfbPicksConfiguration/CfbScoresConfiguration.
+public class TolerantEnumConverterTests
+{
+    [Fact]
+    public void Parse_ReturnsMatchingEnumMember_ForExactName()
+    {
+        var result = TolerantEnumConverter.Parse("Spread", PickType.Over);
+        Assert.Equal(PickType.Spread, result);
+    }
+
+    [Fact]
+    public void Parse_FallsBackToDefault_ForUnrecognizedText()
+    {
+        var result = TolerantEnumConverter.Parse("banana", PickType.Spread);
+        Assert.Equal(PickType.Spread, result);
+    }
+
+    [Fact]
+    public void Parse_FallsBackToDefault_ForNullOrEmpty()
+    {
+        Assert.Equal(PickType.Spread, TolerantEnumConverter.Parse(null, PickType.Spread));
+        Assert.Equal(PickType.Spread, TolerantEnumConverter.Parse("", PickType.Spread));
+    }
+}

--- a/Server/Controllers/CfbPicksController.cs
+++ b/Server/Controllers/CfbPicksController.cs
@@ -5,9 +5,11 @@ using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Helpers;
 using FourPlayWebApp.Shared.Models.Data;
 using FourPlayWebApp.Shared.Models.Data.Dtos;
+using FourPlayWebApp.Shared.Models.Enum;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
+using System.Text.Json.Serialization;
 using FourPlayWebApp.Server.Infrastructure;
 
 namespace FourPlayWebApp.Server.Controllers;
@@ -73,7 +75,7 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
             AwayTeam            = s.AwayTeam,
             HomeTeamScore       = s.HomeTeamScore,
             AwayTeamScore       = s.AwayTeamScore,
-            GameStatus          = s.GameStatus,
+            GameStatus          = s.GameStatus.ToString(),
             GameTime            = s.GameTime.ToString("O"),
             WeatherDisplayValue = s.WeatherDisplayValue,
             WeatherConditionId  = s.WeatherConditionId,
@@ -207,6 +209,7 @@ public record AddCfbPicksRequest {
 }
 
 public record CfbPickItem {
-    public string Team        { get; init; } = string.Empty;
-    public string PickType    { get; init; } = "Spread";
+    public string Team { get; init; } = string.Empty;
+    [property: JsonConverter(typeof(JsonStringEnumConverter))]
+    public PickType PickType { get; init; } = PickType.Spread;
 }

--- a/Server/Controllers/CfbPicksController.cs
+++ b/Server/Controllers/CfbPicksController.cs
@@ -121,7 +121,19 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
     [HttpGet("picks/{leagueId}/{cfbSlateId}/user")]
     public async Task<IActionResult> GetUserPicks(int leagueId, int cfbSlateId) {
         var picks = await repo.GetUserPicksAsync(leagueId, cfbSlateId, CurrentUserId);
-        return Ok(picks);
+        // Must map to CfbPickDto, not return the entity directly — CfbPicks.PickType has no
+        // JsonStringEnumConverter, so it would silently serialize as an int instead of
+        // "Spread"/"Over"/"Under" and break every frontend consumer matching by that string.
+        var dtos = picks.Select(p => new CfbPickDto {
+            Id = p.Id,
+            UserId = p.UserId,
+            LeagueId = p.LeagueId,
+            CfbSlateId = p.CfbSlateId,
+            Team = p.Team,
+            PickType = p.PickType,
+            Season = p.Season,
+        });
+        return Ok(dtos);
     }
 
     [HttpPost("picks")]

--- a/Server/Data/Configurations/CfbPicksConfiguration.cs
+++ b/Server/Data/Configurations/CfbPicksConfiguration.cs
@@ -1,6 +1,7 @@
 using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Shared.Models.Data;
+using FourPlayWebApp.Shared.Models.Enum;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -14,6 +15,13 @@ public class CfbPicksConfiguration : IEntityTypeConfiguration<CfbPicks>
         entity.Property(e => e.DateCreated)
             .HasColumnType("timestamptz")
             .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+        // Store as the enum's string name ("Spread"/"Over"/"Under"), not its int ordinal — the
+        // exact literal values this previously-string column already held, so existing rows keep
+        // parsing correctly with zero data migration needed. Tolerant (not HasConversion<string>()
+        // directly) so a malformed/legacy row logs a warning and falls back instead of throwing
+        // and failing the whole query.
+        entity.Property(e => e.PickType).HasConversion(TolerantEnumConverter.Create(PickType.Spread));
 
         // Mirrors NflPicks' unique index — CfbPicksController already checks for an existing pick
         // before inserting, but that's a read-then-write race (two concurrent submits can both

--- a/Server/Data/Configurations/CfbScoresConfiguration.cs
+++ b/Server/Data/Configurations/CfbScoresConfiguration.cs
@@ -1,4 +1,5 @@
 using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Shared.Models;
 using FourPlayWebApp.Shared.Models.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -13,6 +14,13 @@ public class CfbScoresConfiguration : IEntityTypeConfiguration<CfbScores>
         entity.Property(e => e.DateCreated)
             .HasColumnType("timestamptz")
             .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+        // Store as the enum's string name (e.g. "StatusFinal"), not its int ordinal — this is the
+        // exact literal value CfbScoresJob's status.ToString() was already writing to this
+        // previously-string column, so existing rows keep parsing correctly with zero data
+        // migration needed. Tolerant (not HasConversion<string>() directly) so a malformed/legacy
+        // row logs a warning and falls back instead of throwing and failing the whole query.
+        entity.Property(e => e.GameStatus).HasConversion(TolerantEnumConverter.Create(TypeName.StatusScheduled));
 
         // Natural key mirroring NflScoresConfiguration's (Season, NflWeek, HomeTeam) — see
         // CfbSpreadsConfiguration's comment for the full rationale. Backstops

--- a/Server/Data/Configurations/TolerantEnumConverter.cs
+++ b/Server/Data/Configurations/TolerantEnumConverter.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Serilog;
+
+namespace FourPlayWebApp.Server.Data.Configurations;
+
+// /code-review: a plain HasConversion<string>() throws on read for any stored value that doesn't
+// exactly match an enum member name — one malformed row would fail the entire query instead of
+// degrading gracefully. This is the tolerant version: an unparseable value logs a warning and
+// falls back to the given default rather than throwing, keeping the rest of the result set intact.
+public static class TolerantEnumConverter {
+    public static TEnum Parse<TEnum>(string? raw, TEnum fallback) where TEnum : struct, System.Enum {
+        if (!string.IsNullOrEmpty(raw) && System.Enum.TryParse<TEnum>(raw, out var parsed)) return parsed;
+        Log.Warning("TolerantEnumConverter: unparseable {EnumType} value {Raw} — falling back to {Fallback}", typeof(TEnum).Name, raw, fallback);
+        return fallback;
+    }
+
+    public static ValueConverter<TEnum, string> Create<TEnum>(TEnum fallback) where TEnum : struct, System.Enum =>
+        new(v => v.ToString(), v => Parse(v, fallback));
+}

--- a/Server/Jobs/CfbScoresJob.cs
+++ b/Server/Jobs/CfbScoresJob.cs
@@ -70,7 +70,7 @@ public class CfbScoresJob(ICfbLiveScoreFetcher fetcher, ICfbRepository repo) : I
                 AwayTeam            = away.Team.Abbreviation,
                 HomeTeamScore       = (int)home.Score,
                 AwayTeamScore       = (int)away.Score,
-                GameStatus          = status.ToString(),
+                GameStatus          = status,
                 GameTime            = comp.Date,
                 WeatherDisplayValue = evt.Weather?.DisplayValue,
                 WeatherConditionId  = evt.Weather?.ConditionId,

--- a/Server/Jobs/CfbSpreadJob.cs
+++ b/Server/Jobs/CfbSpreadJob.cs
@@ -78,28 +78,17 @@ public class CfbSpreadJob(
                 || (CfbSlateHelpers.HasRankedTeam(comp.Competitors) && !CfbSlateHelpers.IsMidweekGame(comp.Date));
 
             try {
-                var odds = await oddsService.GetCfbEventsWithOddsAsync(eventId, (int)EspnOddsProviders.DraftKings);
-                if (odds is null) {
-                    var allOdds = await oddsService.GetCfbEventsWithOddsAsync(eventId);
-                    if (allOdds is null || allOdds.Count == 0) {
-                        Log.Warning("CfbSpreadJob: no odds for event {EventId} ({Home} vs {Away})", eventId, home, away);
-                        continue;
-                    }
-                    odds = allOdds.Items.First();
-                }
-
-                var homeSpread = odds.HomeTeamOdds.Current.PointSpread.American.Replace("+", "");
-                var awaySpread = odds.AwayTeamOdds.Current.PointSpread.American.Replace("+", "");
-                if (!double.TryParse(homeSpread, out var parsedHome)) continue;
-                if (!double.TryParse(awaySpread, out var parsedAway)) continue;
+                var parsed = await SpreadOddsFetcher.FetchAsync(
+                    oddsService.GetCfbEventsWithOddsAsync, oddsService.GetCfbEventsWithOddsAsync, eventId, $"{home} vs {away}");
+                if (parsed is null) continue;
 
                 spreads.Add(new CfbSpreads {
                     CfbSlateId    = slate.Id,
                     HomeTeam      = home,
                     AwayTeam      = away,
-                    HomeTeamSpread = parsedHome,
-                    AwayTeamSpread = parsedAway,
-                    OverUnder     = odds.OverUnder,
+                    HomeTeamSpread = parsed.Value.HomeSpread,
+                    AwayTeamSpread = parsed.Value.AwaySpread,
+                    OverUnder     = parsed.Value.OverUnder,
                     GameTime      = comp.Date,
                     IsLeagueEligible = isEligible,
                 });

--- a/Server/Jobs/NFLSpreadJob.cs
+++ b/Server/Jobs/NFLSpreadJob.cs
@@ -41,34 +41,12 @@ public class NflSpreadJob(IEspnCoreOddsService sportsOdds, IEspnApiService espn,
             }
             Log.Information("Grabbing NFL Spreads for {Game} {Time}",spread.HomeTeam, DateTime.UtcNow);
             try {
-                var result = await sportsOdds.GetEventsWithOddsAsync(games.Id, (int)EspnOddsProviders.DraftKings);
-                if (result is null) {
-                    Log.Error("Spread not available using DraftKings for {Game}, trying default Spreads", spread.HomeTeam);
-                    var allResults = await sportsOdds.GetEventsWithOddsAsync(games.Id);
-                    if (allResults is null || allResults.Count == 0) {
-                        Log.Error("No spreads available for {Game}, moving on", spread.HomeTeam);
-                        continue;
-                    }
-                    Log.Warning("Not using ESPNBet, found spread from {Provider} {Game}", allResults.Items.First().Provider.Name, spread.HomeTeam);
-                    result = allResults.Items.First();
-                }
-                var cleanHomeSpread = result.HomeTeamOdds.Current.PointSpread.American.Replace("+", "");
-                var cleanAwaySpread = result.AwayTeamOdds.Current.PointSpread.American.Replace("+", "");
-                if (cleanHomeSpread == "FK") {
-                    Log.Error("Error");
-                }
-
-                if (cleanAwaySpread == "FK") {
-                    Log.Error("Error");
-                }
-
-                if (!double.TryParse(cleanHomeSpread, out var parsedSpread))
-                    continue;
-                spread.HomeTeamSpread = parsedSpread;
-                if (!double.TryParse(cleanAwaySpread, out parsedSpread))
-                    continue;
-                spread.AwayTeamSpread = parsedSpread;
-                spread.OverUnder = result.OverUnder;
+                var parsed = await SpreadOddsFetcher.FetchAsync(
+                    sportsOdds.GetEventsWithOddsAsync, sportsOdds.GetEventsWithOddsAsync, games.Id, spread.HomeTeam);
+                if (parsed is null) continue;
+                spread.HomeTeamSpread = parsed.Value.HomeSpread;
+                spread.AwayTeamSpread = parsed.Value.AwaySpread;
+                spread.OverUnder = parsed.Value.OverUnder;
                 spreads.Add(spread);
             }
             catch (Exception ex) {

--- a/Server/Jobs/SpreadOddsFetcher.cs
+++ b/Server/Jobs/SpreadOddsFetcher.cs
@@ -1,0 +1,48 @@
+using FourPlayWebApp.Shared.Models;
+using FourPlayWebApp.Shared.Models.Enum;
+using Serilog;
+
+namespace FourPlayWebApp.Server.Jobs;
+
+/// <summary>
+/// Shared "fetch odds, prefer DraftKings, fall back to any available provider, parse the American
+/// spread strings" logic — the one piece of NflSpreadJob/CfbSpreadJob that was genuinely
+/// identical (frizat-bo1). Each job still owns its own current-week/slate resolution and
+/// NflSpreads/CfbSpreads construction; only this odds-fetch-and-parse step is shared. Callers pass
+/// their own provider-specific delegates rather than this depending on IEspnCoreOddsService
+/// directly, since NFL and CFB call different methods on it (GetEventsWithOddsAsync vs
+/// GetCfbEventsWithOddsAsync).
+/// </summary>
+public static class SpreadOddsFetcher {
+    public readonly record struct ParsedSpread(double HomeSpread, double AwaySpread, double OverUnder);
+
+    public static async Task<ParsedSpread?> FetchAsync(
+        Func<int, int, Task<EspnCoreOddsItem?>> getByProvider,
+        Func<int, Task<EspnCoreOddsApiResponse?>> getAny,
+        int eventId,
+        string gameLabel) {
+        var result = await getByProvider(eventId, (int)EspnOddsProviders.DraftKings);
+        if (result is null) {
+            // Warning, not Error — a game with no DraftKings line (or no market at all) is routine,
+            // especially for CFB where most non-marquee matchups aren't covered by every book. This
+            // is the common case, not an incident; treating it as Error here previously made
+            // CfbSpreadJob (which calls this far more often than NflSpreadJob) needlessly noisy.
+            Log.Warning("Spread not available using DraftKings for {Game} (event {EventId}), trying default Spreads", gameLabel, eventId);
+            var allResults = await getAny(eventId);
+            if (allResults is null || allResults.Count == 0) {
+                Log.Warning("No spreads available for {Game} (event {EventId}), moving on", gameLabel, eventId);
+                return null;
+            }
+            Log.Warning("Not using ESPNBet, found spread from {Provider} {Game} (event {EventId})", allResults.Items.First().Provider.Name, gameLabel, eventId);
+            result = allResults.Items.First();
+        }
+
+        var cleanHomeSpread = result.HomeTeamOdds.Current.PointSpread.American.Replace("+", "");
+        var cleanAwaySpread = result.AwayTeamOdds.Current.PointSpread.American.Replace("+", "");
+
+        if (!double.TryParse(cleanHomeSpread, out var homeSpread)) return null;
+        if (!double.TryParse(cleanAwaySpread, out var awaySpread)) return null;
+
+        return new ParsedSpread(homeSpread, awaySpread, result.OverUnder);
+    }
+}

--- a/Server/Migrations/20260825194312_ChangeCfbRankingCapturedAtUtcToDateTimeOffset.Designer.cs
+++ b/Server/Migrations/20260825194312_ChangeCfbRankingCapturedAtUtcToDateTimeOffset.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260825194312_ChangeCfbRankingCapturedAtUtcToDateTimeOffset")]
+    partial class ChangeCfbRankingCapturedAtUtcToDateTimeOffset
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/20260825194312_ChangeCfbRankingCapturedAtUtcToDateTimeOffset.cs
+++ b/Server/Migrations/20260825194312_ChangeCfbRankingCapturedAtUtcToDateTimeOffset.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangeCfbRankingCapturedAtUtcToDateTimeOffset : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/Server/Migrations/20260825195444_ConvertCfbScoresGameStatusToEnum.Designer.cs
+++ b/Server/Migrations/20260825195444_ConvertCfbScoresGameStatusToEnum.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260825195444_ConvertCfbScoresGameStatusToEnum")]
+    partial class ConvertCfbScoresGameStatusToEnum
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/20260825195444_ConvertCfbScoresGameStatusToEnum.cs
+++ b/Server/Migrations/20260825195444_ConvertCfbScoresGameStatusToEnum.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class ConvertCfbScoresGameStatusToEnum : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/Server/Migrations/20260825195759_ConvertCfbPicksPickTypeToEnum.Designer.cs
+++ b/Server/Migrations/20260825195759_ConvertCfbPicksPickTypeToEnum.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260825195759_ConvertCfbPicksPickTypeToEnum")]
+    partial class ConvertCfbPicksPickTypeToEnum
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/20260825195759_ConvertCfbPicksPickTypeToEnum.cs
+++ b/Server/Migrations/20260825195759_ConvertCfbPicksPickTypeToEnum.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class ConvertCfbPicksPickTypeToEnum : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/Server/Models/Data/CfbRanking.cs
+++ b/Server/Models/Data/CfbRanking.cs
@@ -10,5 +10,5 @@ public class CfbRanking {
     public int EspnEventId { get; set; }
     public string TeamAbbreviation { get; set; } = string.Empty;
     public int CuratedRank { get; set; }
-    public DateTime CapturedAtUtc { get; set; } = DateTime.UtcNow;
+    public DateTimeOffset CapturedAtUtc { get; set; } = DateTimeOffset.UtcNow;
 }

--- a/Server/Services/CfbLeaderboardService.cs
+++ b/Server/Services/CfbLeaderboardService.cs
@@ -109,9 +109,9 @@ public class CfbLeaderboardService(
         var rawSpread = isHome ? spread.HomeTeamSpread : spread.AwayTeamSpread;
 
         return pick.PickType switch {
-            "Spread" => teamScore + rawSpread + juice - otherScore > 0,
-            "Over" => teamScore + otherScore > spread.OverUnder - juice,
-            "Under" => teamScore + otherScore < spread.OverUnder + juice,
+            PickType.Spread => teamScore + rawSpread + juice - otherScore > 0,
+            PickType.Over => teamScore + otherScore > spread.OverUnder - juice,
+            PickType.Under => teamScore + otherScore < spread.OverUnder + juice,
             _ => false,
         };
     }

--- a/Server/Services/DemoDataSeeder.cs
+++ b/Server/Services/DemoDataSeeder.cs
@@ -2,6 +2,7 @@ using FourPlayWebApp.Server.Data;
 using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Shared.Models;
 using FourPlayWebApp.Shared.Models.Data;
 using FourPlayWebApp.Shared.Models.Enum;
 using Microsoft.AspNetCore.Identity;
@@ -1125,7 +1126,7 @@ public class DemoDataSeeder(
             HomeTeamScore = g.HomeScore,
             AwayTeamScore = g.AwayScore,
             // Championship (slate 18) is in-progress so we can show field position in demo
-            GameStatus    = g.SlateIdx == 18 ? "StatusInProgress" : "StatusFinal",
+            GameStatus    = g.SlateIdx == 18 ? TypeName.StatusInProgress : TypeName.StatusFinal,
             GameTime      = g.GameTime,
         }).ToList();
 
@@ -1252,7 +1253,7 @@ public class DemoDataSeeder(
         var picks = new List<CfbPicks>();
 
         void AddPick(int leagueId, string userId, int slateId, string team) =>
-            picks.Add(new CfbPicks { UserId = userId, LeagueId = leagueId, CfbSlateId = slateId, Team = team, PickType = "Spread", Season = CfbDemoSeason });
+            picks.Add(new CfbPicks { UserId = userId, LeagueId = leagueId, CfbSlateId = slateId, Team = team, PickType = PickType.Spread, Season = CfbDemoSeason });
 
         // frizat: Over/Under is an alternate PICK TYPE for a game, not an additional pick beyond
         // the slate's required count — CfbPicksController's server-side validation enforces total
@@ -1264,11 +1265,11 @@ public class DemoDataSeeder(
         // replaces their game-0 spread pick instead of adding to it.
         void AddFirstPickOrOverUnder(string uName, string userId, int slateId, string homeTeam, string pickedTeam) {
             if (uName == "Bob") {
-                picks.Add(new CfbPicks { UserId = userId, LeagueId = league.Id, CfbSlateId = slateId, Team = homeTeam, PickType = "Over", Season = CfbDemoSeason });
+                picks.Add(new CfbPicks { UserId = userId, LeagueId = league.Id, CfbSlateId = slateId, Team = homeTeam, PickType = PickType.Over, Season = CfbDemoSeason });
                 return;
             }
             if (uName == "Dana") {
-                picks.Add(new CfbPicks { UserId = userId, LeagueId = league.Id, CfbSlateId = slateId, Team = homeTeam, PickType = "Under", Season = CfbDemoSeason });
+                picks.Add(new CfbPicks { UserId = userId, LeagueId = league.Id, CfbSlateId = slateId, Team = homeTeam, PickType = PickType.Under, Season = CfbDemoSeason });
                 return;
             }
             AddPick(league.Id, userId, slateId, pickedTeam);

--- a/Shared/Models/Data/CfbPicks.cs
+++ b/Shared/Models/Data/CfbPicks.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
+using FourPlayWebApp.Shared.Models.Enum;
 
 namespace FourPlayWebApp.Shared.Models.Data;
 
@@ -11,7 +12,9 @@ public class CfbPicks {
     public int LeagueId { get; set; }
     public int CfbSlateId { get; set; }
     public string Team { get; set; } = string.Empty;
-    public string PickType { get; set; } = "Spread"; // "Spread" | "Over" | "Under"
+    // Reuses NflPicks' PickType enum — same set of values, same concept, no reason for a
+    // separate CFB-only type.
+    public PickType PickType { get; set; } = PickType.Spread;
     public int Season { get; set; }
     public DateTimeOffset DateCreated { get; set; } = DateTimeOffset.UtcNow;
 }

--- a/Shared/Models/Data/CfbScores.cs
+++ b/Shared/Models/Data/CfbScores.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
+using FourPlayWebApp.Shared.Models;
 
 namespace FourPlayWebApp.Shared.Models.Data;
 
@@ -12,7 +13,10 @@ public class CfbScores {
     public string AwayTeam { get; set; } = string.Empty;
     public int HomeTeamScore { get; set; }
     public int AwayTeamScore { get; set; }
-    public string GameStatus { get; set; } = string.Empty; // STATUS_FINAL, STATUS_IN_PROGRESS, STATUS_SCHEDULED
+    // Reuses the same TypeName enum ESPN status parsing already uses everywhere else — only
+    // StatusFinal is ever actually persisted here (CfbScoresJob only ever writes final games),
+    // but the column preserves whatever the real ESPN status was rather than assuming.
+    public TypeName GameStatus { get; set; } = TypeName.StatusScheduled;
     public DateTimeOffset GameTime { get; set; }
     public string? WeatherDisplayValue { get; set; }
     public string? WeatherConditionId { get; set; }

--- a/Shared/Models/Data/Dtos/CfbPickDto.cs
+++ b/Shared/Models/Data/Dtos/CfbPickDto.cs
@@ -1,3 +1,6 @@
+using System.Text.Json.Serialization;
+using FourPlayWebApp.Shared.Models.Enum;
+
 namespace FourPlayWebApp.Shared.Models.Data.Dtos;
 
 public class CfbPickDto {
@@ -7,6 +10,7 @@ public class CfbPickDto {
     public int LeagueId { get; set; }
     public int CfbSlateId { get; set; }
     public string Team { get; set; } = string.Empty;
-    public string PickType { get; set; } = "Spread";
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public PickType PickType { get; set; } = PickType.Spread;
     public int Season { get; set; }
 }

--- a/Shared/Models/Data/Dtos/NflPickDto.cs
+++ b/Shared/Models/Data/Dtos/NflPickDto.cs
@@ -11,7 +11,7 @@ public class NflPickDto : IEquatable<NflPickDto>
     public string UserName { get; set; } = string.Empty;
     public string Team { get; set; } = string.Empty;
     [JsonConverter(typeof(JsonStringEnumConverter))]
-    public PickType Pick { get; set; }  // Represents PickType enum as int for DTO
+    public PickType Pick { get; set; }
     public int NflWeek { get; set; }
     public int Season { get; set; }
     public DateTimeOffset DateCreated { get; set; } = DateTimeOffset.UtcNow;


### PR DESCRIPTION
## Summary
- `CfbRanking.CapturedAtUtc`: `DateTime` -> `DateTimeOffset` (b2y) — verified zero downstream consumers, zero schema change
- New `isGameFinal`/`isGameLive`/`isGameDecided` helpers in `gameHelpers.ts`, replacing 5+ duplicated "final || in_progress || halftime" checks across ScoresPage/PicksPage/sportAdapter/GameCard
- `PickType` exported from `sportAdapter.ts`, used everywhere instead of inline string-literal unions
- `GameCard.tsx` now takes the canonical `GameStatusValue` instead of raw ESPN strings (`'StatusFinal'`) it could never actually match — `mode: 'score'` is unused app-wide, so this whole path was silently dead before
- `CfbPicks.PickType` and `CfbScores.GameStatus` migrated from raw strings to the existing `PickType`/`TypeName` enums, via a `TolerantEnumConverter` (parses back with a warning-and-fallback instead of throwing on a malformed row) rather than a plain `HasConversion<string>()` — zero data migration needed, verified existing dev data already matches exactly
- Extracted `SpreadOddsFetcher.cs`: the "fetch odds, prefer DraftKings, fall back, parse American spread" logic duplicated between `NFLSpreadJob` and `CfbSpreadJob` is now one shared implementation — all 39 pre-existing job tests pass unchanged
- Downgraded routine "no odds for this game" logging from Error to Warning (CFB hits this far more often than NFL, was noisy) and restored the `eventId` CFB's original log line had

Addresses beads: frizat-bo1, frizat-b2y.

## Test plan
- [x] `dotnet test` — 706/706 passing
- [x] `npm run test -- --run` — 474/474 passing
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm run test:e2e -- --project=chromium` — 88/88 passing
- [x] `/simplify` run — removed a speculative unused `ISpreadEntity` interface, consolidated duplicated status-check logic further
- [x] `/code-review` run — added `TolerantEnumConverter` for graceful degradation on a malformed enum-column row, fixed a log-severity/log-detail regression introduced by the `SpreadOddsFetcher` extraction, verified NFL/CFB pick-type JSON serialization was already consistent (false positive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs