### PR TITLE
PicksPage error state + retract Show Jerseys toggle

### DIFF
--- a/Client.React/src/__tests__/picks.test.tsx
+++ b/Client.React/src/__tests__/picks.test.tsx
@@ -160,6 +160,31 @@ describe('PicksPage', () => {
     expect(screen.getByText(/Picks Remaining \(2\)/i)).toBeInTheDocument();
   });
 
+  // frizat-d2h: toggle removed for now (likely permanent removal pending a copyright review
+  // of the jersey images).
+  it('never shows the Show Jerseys toggle', async () => {
+    await setupDefaults({ week: 2 });
+    await renderPage();
+    expect(screen.queryByRole('button', { name: /show jerseys/i })).toBeNull();
+  });
+
+  // frizat-bqi: PicksPage previously had no error-state handling at all — a failed fetch just
+  // silently stayed blank. Mirrors ScoresPage's existing Alert + Retry pattern.
+  it('shows an error alert with a retry button when the picks query fails', async () => {
+    await setupDefaults();
+    mockedLoadScoresWithRetry.mockRejectedValue(new Error('network down'));
+    renderWithClient(<PicksPage adapter={createNflAdapter()} />);
+
+    const retryButton = await screen.findByRole('button', { name: /retry/i });
+    expect(screen.getByText(/couldn.t load picks/i)).toBeInTheDocument();
+
+    // Recover on retry
+    mockedLoadScoresWithRetry.mockResolvedValue(createScores({ week: 2, postSeason: false, gameStarted: false }));
+    await userEvent.click(retryButton);
+
+    await waitFor(() => expect(screen.getAllByText(/BUF/i).length).toBeGreaterThan(0));
+  });
+
   it('shows picks remaining (1) for postseason week 1 with two existing picks', async () => {
     const existing = [createPick({ team: 'BUF' }), createPick({ team: 'DAL' })];
     await setupDefaults({ week: 1, postSeason: true, existingPicks: existing });

--- a/Client.React/src/components/QueryErrorAlert.tsx
+++ b/Client.React/src/components/QueryErrorAlert.tsx
@@ -1,0 +1,22 @@
+import { Alert, Box, Button } from '@mui/material';
+import PageHeader from './PageHeader';
+
+interface QueryErrorAlertProps {
+  title: string;
+  entityName?: string;
+  onRetry: () => void;
+}
+
+export default function QueryErrorAlert({ title, entityName = title.toLowerCase(), onRetry }: QueryErrorAlertProps) {
+  return (
+    <Box><PageHeader title={title} />
+      <Alert
+        severity="error"
+        sx={{ mt: 4 }}
+        action={<Button color="inherit" size="small" onClick={onRetry}>Retry</Button>}
+      >
+        Couldn&apos;t load {entityName}. Check your connection and try again.
+      </Alert>
+    </Box>
+  );
+}

--- a/Client.React/src/pages/PicksPage.tsx
+++ b/Client.React/src/pages/PicksPage.tsx
@@ -7,11 +7,11 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import CheckroomIcon from '@mui/icons-material/Checkroom';
 import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
 import PageHeader from '../components/PageHeader';
 import WeekYearSelector from '../components/WeekYearSelector';
 import NoLeague from '../components/NoLeague';
+import QueryErrorAlert from '../components/QueryErrorAlert';
 import SpreadRelease from '../components/SpreadRelease';
 import GameCard, { type PickState } from '../components/sports/GameCard';
 import { useSession } from '../services/session';
@@ -45,14 +45,13 @@ export default function PicksPage({ adapter }: PicksPageProps) {
   // Pending (unsubmitted) selections — local state only, never touched by refetches
   const [userPicks, setUserPicks] = useState<Set<string>>(new Set());
   const [storingPicks, setStoringPicks] = useState(false);
-  const [showJerseys, setShowJerseys] = useState(false);
   // The real navigable ceiling, captured only from a current-week load — see the effect below.
   const [currentBounds, setCurrentBounds] = useState<{ maxWeek: number; maxSeason: number } | null>(null);
 
   const isCurrentWeek = weekState === null;
   const enabled = leaguesLoaded && !!currentLeague && !!user?.userId;
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, refetch } = useQuery({
     queryKey: [adapter.sport, 'picks', currentLeague, user?.userId, weekState],
     queryFn: () => weekState
       ? adapter.loadHistoricalGames(currentLeague!, user!.userId, weekState)
@@ -99,14 +98,9 @@ export default function PicksPage({ adapter }: PicksPageProps) {
     if (droppedByLock) toast.push('Selection removed — game already kicked off', 'warning');
   }, [data, games, existingPicks, userPicks, toast]);
 
-  const { data: jerseyCache = {} } = useQuery({
-    queryKey: [adapter.sport, 'jerseys', data?.season, data?.week],
-    queryFn: () => adapter.loadJerseys!(data!.season, data!.week),
-    enabled: !!adapter.loadJerseys && !!data,
-    staleTime: Infinity,
-    retry: false,
-  });
-
+  // frizat-d2h: Show Jerseys toggle removed for now (likely permanent removal pending a
+  // copyright review of the jersey images). adapter.loadJerseys and the underlying
+  // /api/jersey endpoint are left intact for a future re-enable.
   const handleWeekChange = useCallback((newWeek: number, meta?: { isPostSeason?: boolean }) => {
     setWeekState({ season, week: newWeek, isPostSeason: meta?.isPostSeason ?? isPostSeason });
   }, [season, isPostSeason]);
@@ -173,6 +167,9 @@ export default function PicksPage({ adapter }: PicksPageProps) {
   );
 
   if (!currentLeague) return <NoLeague />;
+  if (isError && !data) return (
+    <QueryErrorAlert title="Picks" onRetry={() => void refetch()} />
+  );
   if (!hasOdds && isCurrentWeek) return <SpreadRelease sport={adapter.sport} />;
 
   const hasUnlockedGames = games.some(g => !gameIsLocked(g));
@@ -207,14 +204,6 @@ export default function PicksPage({ adapter }: PicksPageProps) {
       )}
 
       <Grid container spacing={2}>
-        {Object.keys(jerseyCache).length > 0 && (
-          <Grid size={12} sx={{ display: 'flex', justifyContent: 'center' }}>
-            <Button variant="outlined" color="info" startIcon={<CheckroomIcon />} onClick={() => setShowJerseys(p => !p)}>
-              {showJerseys ? 'Show Logos' : 'Show Jerseys'}
-            </Button>
-          </Grid>
-        )}
-
         {hasUnlockedGames && (remainingPicks > 0 || userPicks.size > 0) && (
           <Grid size={12}>
             {remainingPicks > 0 && (
@@ -265,8 +254,6 @@ export default function PicksPage({ adapter }: PicksPageProps) {
                 spreadPostedAt={game.spreadPostedAt}
                 homeRecord={!isPostSeasonSlate ? game.homeRecord : undefined}
                 awayRecord={!isPostSeasonSlate ? game.awayRecord : undefined}
-                homeJerseyUrl={showJerseys ? jerseyCache[game.homeTeam] : undefined}
-                awayJerseyUrl={showJerseys ? jerseyCache[game.awayTeam] : undefined}
                 weatherDisplayValue={game.weather?.displayValue}
                 weatherConditionId={game.weather?.conditionId}
                 weatherTemperatureF={game.weather?.temperatureF}

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  Alert, Badge, Box, Button, CircularProgress, Grid,
+  Badge, Box, Button, CircularProgress, Grid,
   IconButton, Paper, Stack, Typography,
 } from '@mui/material';
 import PersonIcon from '@mui/icons-material/Person';
@@ -11,6 +11,7 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import PageHeader from '../components/PageHeader';
 import WeekYearSelector from '../components/WeekYearSelector';
 import NoLeague from '../components/NoLeague';
+import QueryErrorAlert from '../components/QueryErrorAlert';
 import SpreadRelease from '../components/SpreadRelease';
 import TeamHelmet from '../components/sports/TeamHelmet';
 import UserPicksMatrix from '../components/UserPicksMatrix';
@@ -196,15 +197,7 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
   );
   if (!currentLeague) return <NoLeague />;
   if (isError && !data) return (
-    <Box><PageHeader title="Scores" />
-      <Alert
-        severity="error"
-        sx={{ mt: 4 }}
-        action={<Button color="inherit" size="small" onClick={() => void refetch()}>Retry</Button>}
-      >
-        Couldn&apos;t load scores. Check your connection and try again.
-      </Alert>
-    </Box>
+    <QueryErrorAlert title="Scores" onRetry={() => void refetch()} />
   );
   if (!data?.hasOdds && isCurrentWeek) return <SpreadRelease sport={adapter.sport} />;
   if (!data) return null;


### PR DESCRIPTION
## Summary
- Adds error-state handling to `PicksPage` (Alert + Retry button) for a failed picks fetch, mirroring `ScoresPage`'s existing pattern — closes frizat-bqi
- Extracted the now-duplicated Alert/Retry JSX into a shared `QueryErrorAlert` component used by both `PicksPage` and `ScoresPage`
- Removes the "Show Jerseys" toggle from `PicksPage` (state, query, button, GameCard props) pending a copyright review of the jersey images — closes frizat-d2h. `adapter.loadJerseys` and the `/api/jersey` endpoint are left intact for a future re-enable.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test -- --run` — 476/476 passed
- [x] `npx playwright test --project=chromium` — 88/88 passed
- [x] `/simplify` (4 parallel angles) run and findings applied
- [x] `/code-review` run and findings applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs