### PR TITLE
Drop redundant NflPicks.NflWeekId FK column (frizat-8a4)

### DIFF
--- a/Server.UnitTests/DemoDataSeederIdempotencyTests.cs
+++ b/Server.UnitTests/DemoDataSeederIdempotencyTests.cs
@@ -142,7 +142,7 @@ public class DemoDataSeederIdempotencyTests : IClassFixture<PostgresSeederFixtur
             {
                 UserId = AdminId, LeagueId = league.Id, Team = "KC",
                 Pick = PickType.Spread, NflWeek = week, Season = DemoSeason,
-                NflWeekId = weekRow.Id, DateCreated = DateTimeOffset.UtcNow,
+                DateCreated = DateTimeOffset.UtcNow,
             });
             await db.SaveChangesAsync();
         }

--- a/Server.UnitTests/PicksTests.cs
+++ b/Server.UnitTests/PicksTests.cs
@@ -345,7 +345,6 @@ public class PicksTests
         {
             LeagueId = LeagueId, UserId = UserId, Team = "BUF",
             Pick = PickType.Spread, NflWeek = Week, Season = Season,
-            NflWeekId = 1
         };
 
         var repo = Substitute.For<ILeagueRepository>();
@@ -424,7 +423,7 @@ public class PicksTests
     private static NflPicks MakeNflPick(string userId, string team) => new()
     {
         LeagueId = LeagueId, UserId = userId, Team = team,
-        Pick = PickType.Spread, NflWeek = Week, Season = Season, NflWeekId = 1,
+        Pick = PickType.Spread, NflWeek = Week, Season = Season,
         User = new ApplicationUser { UserName = userId }
     };
 

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -425,8 +425,7 @@ public class LeagueController(
                 Pick        = pick.Pick,
                 NflWeek     = pick.NflWeek,
                 Season      = pick.Season,
-                DateCreated = pick.DateCreated,
-                NflWeekId   = week.Id
+                DateCreated = pick.DateCreated
             });
         }
 

--- a/Server/Data/Configurations/NflPicksConfiguration.cs
+++ b/Server/Data/Configurations/NflPicksConfiguration.cs
@@ -23,11 +23,6 @@ public class NflPicksConfiguration : IEntityTypeConfiguration<NflPicks>
             .HasForeignKey(e => e.UserId)
             .IsRequired();
 
-        entity.HasOne(e => e.NflWeekInfo)
-            .WithMany(l => l.NflPicks)
-            .HasForeignKey(e => e.NflWeekId)
-            .IsRequired();
-
         entity.HasIndex(x => new { x.UserId, x.LeagueId, x.NflWeek, x.Season, x.Team, x.Pick }).IsUnique();
     }
 }

--- a/Server/Data/Configurations/NflWeeksConfiguration.cs
+++ b/Server/Data/Configurations/NflWeeksConfiguration.cs
@@ -14,10 +14,5 @@ public class NflWeeksConfiguration : IEntityTypeConfiguration<NflWeeks>
             .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
         entity.HasIndex(w => new { w.Season, w.NflWeek }).IsUnique();
-
-        entity.HasMany(e => e.NflPicks)
-            .WithOne(l => l.NflWeekInfo)
-            .HasForeignKey(g => g.NflWeekId)
-            .IsRequired();
     }
 }

--- a/Server/Migrations/20260826012543_DropNflPicksNflWeekIdRedundancy.Designer.cs
+++ b/Server/Migrations/20260826012543_DropNflPicksNflWeekIdRedundancy.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260826012543_DropNflPicksNflWeekIdRedundancy")]
+    partial class DropNflPicksNflWeekIdRedundancy
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/20260826012543_DropNflPicksNflWeekIdRedundancy.cs
+++ b/Server/Migrations/20260826012543_DropNflPicksNflWeekIdRedundancy.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropNflPicksNflWeekIdRedundancy : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_NflPicks_NflWeeks_NflWeekId",
+                table: "NflPicks");
+
+            migrationBuilder.DropIndex(
+                name: "IX_NflPicks_NflWeekId",
+                table: "NflPicks");
+
+            migrationBuilder.DropColumn(
+                name: "NflWeekId",
+                table: "NflPicks");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "NflWeekId",
+                table: "NflPicks",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NflPicks_NflWeekId",
+                table: "NflPicks",
+                column: "NflWeekId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_NflPicks_NflWeeks_NflWeekId",
+                table: "NflPicks",
+                column: "NflWeekId",
+                principalTable: "NflWeeks",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Server/Models/Data/NFLPicks.cs
+++ b/Server/Models/Data/NFLPicks.cs
@@ -16,10 +16,6 @@ public class NflPicks {
     public int NflWeek { get; set; }
     public int Season { get; set; }
     public DateTimeOffset DateCreated { get; set; } = DateTimeOffset.UtcNow;
-    // Navigation property
-    public NflWeeks NflWeekInfo { get; set; }
-    public int NflWeekId { get; set; }
-    // Foreign key to the NFlWeeks table
     public override int GetHashCode() {
         return HashCode.Combine(Team, Pick, Season, NflWeek, UserId, LeagueId);
     }

--- a/Server/Models/Data/NFLWeeks.cs
+++ b/Server/Models/Data/NFLWeeks.cs
@@ -7,5 +7,4 @@ public class NflWeeks {
     public DateTimeOffset StartDate { get; set; }
     public DateTimeOffset EndDate { get; set; }
     public DateTimeOffset DateCreated { get; set; } = DateTimeOffset.UtcNow;
-    public ICollection<NflPicks> NflPicks { get; set; }
 }

--- a/Server/Services/DemoDataSeeder.cs
+++ b/Server/Services/DemoDataSeeder.cs
@@ -409,14 +409,14 @@ public class DemoDataSeeder(
     {
         if (league == null) return;
 
-        var nflWeek = await db.NflWeeks.FirstOrDefaultAsync(w => w.Season == DemoSeason && w.NflWeek == DemoWeek);
-        if (nflWeek == null) return;
+        var nflWeekExists = await db.NflWeeks.AnyAsync(w => w.Season == DemoSeason && w.NflWeek == DemoWeek);
+        if (!nflWeekExists) return;
 
         foreach (var (username, email) in DemoUsers)
         {
             var user = await EnsureDemoUserAsync(username, email, league);
             if (user == null) continue;
-            await SeedPicksForUserAsync(user, league, nflWeek);
+            await SeedPicksForUserAsync(user, league);
         }
     }
 
@@ -442,7 +442,7 @@ public class DemoDataSeeder(
         return user;
     }
 
-    private async Task SeedPicksForUserAsync(ApplicationUser user, LeagueInfo league, NflWeeks nflWeek)
+    private async Task SeedPicksForUserAsync(ApplicationUser user, LeagueInfo league)
     {
         if (!DemoPicksMap.TryGetValue(user.UserName!, out var picks)) return;
 
@@ -462,7 +462,6 @@ public class DemoDataSeeder(
                 Pick = PickType.Spread,
                 NflWeek = DemoWeek,
                 Season = DemoSeason,
-                NflWeekId = nflWeek.Id,
                 DateCreated = DateTimeOffset.UtcNow,
             });
         }
@@ -646,7 +645,6 @@ public class DemoDataSeeder(
             var weekStart = new DateTimeOffset(2025, 9, 4, 0, 0, 0, TimeSpan.Zero).AddDays((week - 1) * 7);
             db.NflWeeks.Add(new NflWeeks { Season = DemoSeason, NflWeek = week, StartDate = weekStart, EndDate = weekStart.AddDays(6) });
             await db.SaveChangesAsync();
-            var nflWeek = await db.NflWeeks.FirstAsync(w => w.Season == DemoSeason && w.NflWeek == week);
 
             // NflSpreads (16 games, all 32 NFL teams, home teams favored)
             foreach (var g in HistGames)
@@ -675,7 +673,7 @@ public class DemoDataSeeder(
                     {
                         UserId = user.Id, LeagueId = league.Id, Team = team,
                         Pick = PickType.Spread, NflWeek = week, Season = DemoSeason,
-                        NflWeekId = nflWeek.Id, DateCreated = DateTimeOffset.UtcNow,
+                        DateCreated = DateTimeOffset.UtcNow,
                     });
                 }
             }
@@ -726,7 +724,6 @@ public class DemoDataSeeder(
         // NflWeeks row
         db.NflWeeks.Add(new NflWeeks { Season = DemoSeason, NflWeek = week, StartDate = startDate, EndDate = endDate });
         await db.SaveChangesAsync();
-        var nflWeek = await db.NflWeeks.FirstAsync(w => w.Season == DemoSeason && w.NflWeek == week);
 
         // Spreads
         foreach (var g in games)
@@ -763,11 +760,11 @@ public class DemoDataSeeder(
             for (int i = 0; i < Math.Min(pattern.Length, games.Length); i++)
             {
                 if (i == 0 && name == "Bob") {
-                    db.NflPicks.Add(new NflPicks { UserId = user.Id, LeagueId = league.Id, Team = games[0].Home, Pick = PickType.Over, NflWeek = week, Season = DemoSeason, NflWeekId = nflWeek.Id, DateCreated = DateTimeOffset.UtcNow });
+                    db.NflPicks.Add(new NflPicks { UserId = user.Id, LeagueId = league.Id, Team = games[0].Home, Pick = PickType.Over, NflWeek = week, Season = DemoSeason, DateCreated = DateTimeOffset.UtcNow });
                     continue;
                 }
                 if (i == 0 && name == "Dana") {
-                    db.NflPicks.Add(new NflPicks { UserId = user.Id, LeagueId = league.Id, Team = games[0].Home, Pick = PickType.Under, NflWeek = week, Season = DemoSeason, NflWeekId = nflWeek.Id, DateCreated = DateTimeOffset.UtcNow });
+                    db.NflPicks.Add(new NflPicks { UserId = user.Id, LeagueId = league.Id, Team = games[0].Home, Pick = PickType.Under, NflWeek = week, Season = DemoSeason, DateCreated = DateTimeOffset.UtcNow });
                     continue;
                 }
                 var team = pattern[i] ? games[i].Home : games[i].Away;
@@ -775,7 +772,7 @@ public class DemoDataSeeder(
                 {
                     UserId = user.Id, LeagueId = league.Id, Team = team,
                     Pick = PickType.Spread, NflWeek = week, Season = DemoSeason,
-                    NflWeekId = nflWeek.Id, DateCreated = DateTimeOffset.UtcNow,
+                    DateCreated = DateTimeOffset.UtcNow,
                 });
             }
         }


### PR DESCRIPTION
## Summary
- Removes `NflPicks.NflWeekId`/`NflWeekInfo` (the FK to `NflWeeks`) — a full call-site audit confirmed it was never read anywhere (no `.Include()`, no query, no join), only ever written to satisfy the FK constraint. `NflWeek` (raw int) is the actual load-bearing key everywhere: the unique index, `Equals`/`GetHashCode`, `GameHelpers.GetRequiredPicks`, every controller/DTO/query.
- Drops the column, FK, and index via migration `20260826012543_DropNflPicksNflWeekIdRedundancy`.
- Cleans up now-dead `NflWeekId` assignments and redundant `NflWeeks` re-fetches in `LeagueController` and `DemoDataSeeder` (one existence check simplified from fetch+null-check to `AnyAsync`).
- Zero behavioral change — confirmed via `dotnet ef migrations has-pending-model-changes` (zero drift after applying) and full test suites.

## Test plan
- [x] Full call-site audit documented (grepped for `NflWeekId`/`NflWeekInfo`/`.Include` across the whole repo before touching anything, per the bead's own design notes)
- [x] Migration applied to local dev Postgres, confirmed column/FK/index gone via `psql \d`
- [x] `dotnet ef migrations has-pending-model-changes` — zero pending changes
- [x] `dotnet test` — 706/706 passed
- [x] `npm run test:e2e:demo` — 46/46 passed (seeder re-verified against the new schema)
- [x] `/simplify` (4 parallel angles) — all clean, no findings
- [x] `/code-review` — no bugs found

Closes frizat-8a4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs