### PR TITLE
Leaderboard: show "Juice not configured" instead of blank state

### DIFF
--- a/Client.React/e2e/helpers/routes.ts
+++ b/Client.React/e2e/helpers/routes.ts
@@ -377,8 +377,15 @@ export async function setupRoutes(page: Page, options: SetupRoutesOptions = {}):
       return;
     }
 
+    const mockJuiceMapping = { id: 1, leagueId: TEST_LEAGUE_ID, season: TEST_SEASON, juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5 };
+
     if (url.match(/\/api\/league\/\d+\/juice$/) && method === 'GET') {
-      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ id: 1, leagueId: TEST_LEAGUE_ID, season: TEST_SEASON, juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5 }]) });
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([mockJuiceMapping]) });
+      return;
+    }
+
+    if (url.match(/\/api\/league\/\d+\/juice\/\d+$/) && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockJuiceMapping) });
       return;
     }
 

--- a/Client.React/src/__tests__/leaderboard.test.tsx
+++ b/Client.React/src/__tests__/leaderboard.test.tsx
@@ -28,10 +28,24 @@ const sessionState = {
 vi.mock('../services/session', () => ({ useSession: () => sessionState }));
 vi.mock('../services/auth', () => ({ useAuth: () => ({ user: { userId: '123', name: 'TestUser', claims: [] } }) }));
 vi.mock('../api/leaderboard', () => ({ getLeaderboard: vi.fn() }));
+vi.mock('../api/league', () => ({ getLeagueJuiceForSeason: vi.fn() }));
 
 import { getLeaderboard } from '../api/leaderboard';
+import { getLeagueJuiceForSeason } from '../api/league';
 
 const mockedGetLeaderboard = vi.mocked(getLeaderboard);
+const mockedGetLeagueJuiceForSeason = vi.mocked(getLeagueJuiceForSeason);
+
+// frizat-ugs: every existing test in this file exercises a season whose Juice IS configured —
+// default the mock to "configured" globally so only the new not-configured tests need to
+// override it, instead of touching all the pre-existing test bodies below.
+beforeEach(() => {
+  mockedGetLeagueJuiceForSeason.mockReset();
+  mockedGetLeagueJuiceForSeason.mockResolvedValue({
+    id: 1, leagueId: 1, leagueName: 'Demo League', season: 2023,
+    juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, dateCreated: '2023-01-01T00:00:00Z',
+  });
+});
 
 const mockAdapter: SportAdapter = {
   sport: 'nfl',
@@ -143,6 +157,36 @@ describe('LeaderboardPage', () => {
     sessionState.currentLeague = null;
     renderPage();
     await screen.findByText(/League Picker/i);
+  });
+
+  // frizat-ugs: see the juiceConfigured state comment in LeaderboardPage.tsx for the full context.
+  it('shows a "Juice not configured" message instead of the generic empty state when Juice is unconfigured', async () => {
+    mockedGetLeagueJuiceForSeason.mockResolvedValue(null);
+    mockedGetLeaderboard.mockResolvedValue([]);
+
+    renderPage();
+    await screen.findByText(/juice.*not configured/i);
+    expect(screen.queryByText(/no leaderboard data yet/i)).not.toBeInTheDocument();
+  });
+
+  it('keeps the generic "no data yet" message when Juice IS configured but the leaderboard is still empty', async () => {
+    mockedGetLeaderboard.mockResolvedValue([]);
+
+    renderPage();
+    await screen.findByText(/no leaderboard data yet/i);
+    expect(screen.queryByText(/juice.*not configured/i)).not.toBeInTheDocument();
+  });
+
+  // /code-review: the juice-configured lookup is a second await inside the same fetch effect —
+  // without a try/finally around it, a rejected request there (network error, non-401 failure;
+  // http.ts's interceptor only retries on 401) left the page stuck on the spinner forever, since
+  // nothing after the throw ever called setLoading(false).
+  it('still clears the loading spinner when the follow-up Juice-configured check fails', async () => {
+    mockedGetLeaderboard.mockResolvedValue([]);
+    mockedGetLeagueJuiceForSeason.mockRejectedValue(new Error('network down'));
+
+    renderPage();
+    await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument());
   });
 });
 

--- a/Client.React/src/api/league.ts
+++ b/Client.React/src/api/league.ts
@@ -34,6 +34,11 @@ export async function getLeagueJuice(leagueId: number) {
   return data;
 }
 
+export async function getLeagueJuiceForSeason(leagueId: number, season: number) {
+  const { data } = await http.get<LeagueJuiceMappingDto | null>(`/api/league/${leagueId}/juice/${season}`);
+  return data;
+}
+
 export async function getUsers() {
   const { data } = await http.get<UserSummaryDto[]>(`/api/league/users`);
   return data;

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -25,6 +25,7 @@ import ShareableStandingsCard from '../components/ShareableStandingsCard';
 import { useSession } from '../services/session';
 import { useAuth } from '../services/auth';
 import { getLeaderboard } from '../api/leaderboard';
+import { getLeagueJuiceForSeason } from '../api/league';
 import type { LeaderboardDto } from '../types/leaderboard';
 import type { SportAdapter } from '../services/sportAdapter';
 import { stickyColumnSx } from '../utils/tableStyles';
@@ -44,6 +45,14 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
   const cardRef = useRef<HTMLDivElement>(null);
   const [loading, setLoading] = useState(true);
   const [leaderboard, setLeaderboard] = useState<LeaderboardDto[]>([]);
+  // frizat-ugs: LeaderboardService/CfbLeaderboardService both silently return an empty list when
+  // LeagueJuiceMapping has no row for the season — this tracks that distinct state so the empty
+  // leaderboard renders a "not configured" message instead of the generic "no data yet" one.
+  // Checked via a separate GET (getLeagueJuiceForSeason) rather than a flag on the leaderboard
+  // response itself; safe from drift because both paths ultimately key off the exact same
+  // repository call (GetLeagueJuiceMappingAsync(leagueId, season)) — if that lookup's semantics
+  // ever change, both sides change together.
+  const [juiceConfigured, setJuiceConfigured] = useState(true);
   const [season, setSeason] = useState<number | null>(null);
   // Remember the real current-season ceiling separately from `season` (which the selector
   // below can move to a past year) — otherwise re-deriving the selector's upper bound from
@@ -83,12 +92,32 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
     let ignore = false;
     const run = async () => {
       if (hasLoadedOnce.current) setRefreshing(true); else setLoading(true);
-      const data = await getLeaderboard(currentLeague, season);
-      if (ignore) return;
-      setLeaderboard(data ?? []);
-      hasLoadedOnce.current = true;
-      setLoading(false);
-      setRefreshing(false);
+      try {
+        const data = await getLeaderboard(currentLeague, season);
+        if (ignore) return;
+        const entries = data ?? [];
+        // Only worth the extra round-trip when the empty-state message actually needs to
+        // distinguish "not configured" from "no results yet" — most loads have real rows.
+        // Resolved before either setState call so the two never render out of sync with each
+        // other mid-fetch (e.g. a season switch briefly showing the wrong empty-state message).
+        const configured = entries.length === 0
+          ? (await getLeagueJuiceForSeason(currentLeague, season)) != null
+          : true;
+        if (ignore) return;
+        setLeaderboard(entries);
+        setJuiceConfigured(configured);
+      } catch (err) {
+        // /code-review: without a catch here, a rejected getLeaderboard/getLeagueJuiceForSeason
+        // (e.g. a network error — http.ts's interceptor only retries on 401) left the page stuck
+        // on the spinner forever, since nothing after the throw ever cleared loading/refreshing.
+        if (!ignore) console.error('LeaderboardPage: failed to load leaderboard', err);
+      } finally {
+        if (!ignore) {
+          hasLoadedOnce.current = true;
+          setLoading(false);
+          setRefreshing(false);
+        }
+      }
     };
     void run();
     return () => { ignore = true; };
@@ -252,7 +281,9 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
       )}
       {leaderboard.length === 0 && (
         <Typography variant="body2" color="text.secondary" sx={{ mt: 4, textAlign: 'center' }}>
-          No leaderboard data yet for this season.
+          {juiceConfigured
+            ? 'No leaderboard data yet for this season.'
+            : 'Juice not configured for this season — ask your league owner to set it up in the League Portal.'}
         </Typography>
       )}
       {leaderboard.length > 0 && (


### PR DESCRIPTION
## Summary
- `LeaderboardService`/`CfbLeaderboardService` both silently return an empty list when `LeagueJuiceMapping` has no row for the season — a commissioner who forgot to configure Juice for a new season saw the exact same "No leaderboard data yet" message as a season that just hasn't started scoring yet, with zero signal of what was wrong.
- **PR A of 2** for frizat-ugs — the reminder-email + auto-lock Quartz job trio is PR B, coming next.
- Fixed entirely in the frontend: `LeaderboardPage` now checks the already-existing `GET /api/league/{leagueId}/juice/{season}` endpoint (`LeagueController.GetLeagueJuiceForSeason`, already returns `null` when unconfigured) alongside the leaderboard fetch, only when the leaderboard result is empty. **No backend changes needed** — and this covers both NFL and CFB automatically since `LeaderboardPage` is already the shared sport-agnostic page and Juice mappings aren't sport-specific.
- `/code-review` caught a real bug in the first pass: the follow-up fetch had no error handling, so a rejected request (network error, non-401 failure) left the page stuck on the loading spinner forever. Fixed with try/catch/finally, with a regression test locking in that the spinner always clears even when the Juice check itself fails.

## Test plan
- [x] `npm run typecheck` / `npm run lint` clean
- [x] `npm run test -- --run` — 479/479 passed
- [x] `npx playwright test --project=chromium` (mock e2e) — 88/88 passed
- [x] `/simplify` (4 parallel angles) run and findings applied
- [x] `/code-review` run and findings applied (including the loading-spinner-hang fix above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs