### PR TITLE
fix: users with no leagues on a sport couldn't reach League Portal to create one

### DIFF
--- a/Client.React/src/__tests__/sportAccess.test.tsx
+++ b/Client.React/src/__tests__/sportAccess.test.tsx
@@ -35,9 +35,9 @@ vi.mock('../services/session', () => ({ useSession: () => sessionState }));
 const sportContext = { sport: 'NFL', isCfb: false, isNfl: true };
 vi.mock('../services/sport', () => ({ useSportContext: () => sportContext }));
 
-function renderLayout() {
+function renderLayout(initialPath = '/') {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
         <Route path="*" element={<AppLayout />} />
       </Routes>
@@ -66,6 +66,18 @@ describe('Sport access control', () => {
     renderLayout();
     expect(screen.getByText(/No CFB access/i)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Go to NFL/i })).toBeInTheDocument();
+  });
+
+  // frizat: League Portal is how a user gets access to a sport in the first place (self-serve
+  // Create League, frizat-d6l) — the blanket "no access" gate previously replaced every routed
+  // page including this one, so an NFL-only user could never reach League Portal on the CFB
+  // site to create their first CFB league at all. Every other sport-specific page (Picks,
+  // Scores, Leaderboard) still needs the gate, since those genuinely require an existing league.
+  it('NFL-only user on CFB site visiting League Portal — no access block, reaches the page', () => {
+    Object.assign(sportContext, { sport: 'CFB', isCfb: true, isNfl: false });
+    Object.assign(sessionState, { hasNflAccess: true, hasCfbAccess: false, currentLeague: null });
+    renderLayout('/league/manage');
+    expect(screen.queryByText(/No CFB access/i)).not.toBeInTheDocument();
   });
 
   it('CFB-only user on NFL site — shows No NFL access with Go to CFB link', () => {

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { NavLink, Outlet, useNavigate } from 'react-router-dom';
+import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import {
   AppBar,
   Box,
@@ -81,6 +81,7 @@ export default function AppLayout() {
   const { user } = useAuth();
   const { mode, toggleTheme } = useThemeMode();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const getOtherSportUrl = () => {
     const { hostname, port, protocol } = window.location;
@@ -104,7 +105,13 @@ export default function AppLayout() {
   const hasCurrent = isCfb ? hasCfbAccess : hasNflAccess;
   const hasOther = isCfb ? hasNflAccess : hasCfbAccess;
   const otherSport = isCfb ? 'NFL' : 'CFB';
-  const noAccessContent = leaguesLoaded && currentLeague === null && !hasCurrent ? (
+  // frizat: League Portal is exempt — it's the one page that already handles "no leagues yet"
+  // correctly (a "Create League" empty state, since creating a league needs no prior access).
+  // Without this, a user with only NFL leagues could never reach League Portal on the CFB site
+  // to create their first CFB league at all — the "no access" block replaced every routed page,
+  // including the one page designed to get them out of that exact state.
+  const isLeaguePortalRoute = location.pathname.startsWith('/league/manage');
+  const noAccessContent = !isLeaguePortalRoute && leaguesLoaded && currentLeague === null && !hasCurrent ? (
     <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '50vh', textAlign: 'center', p: 4 }}>
       <Typography variant="h5" fontWeight={700} gutterBottom>
         No {isCfb ? 'CFB' : 'NFL'} access


### PR DESCRIPTION
## Summary
- `AppLayout`'s "No {sport} access" gate replaced every routed page (`noAccessContent ?? <Outlet />`) whenever a user had zero leagues on the current sport — including League Portal, the one page that doesn't need existing access (creating a league is how you get access). An NFL-only user visiting the CFB site could never reach League Portal to create their first CFB league.
- League Portal already has a correct "no leagues yet — create one" empty state (frizat-d6l), and its nav link was already kept visible regardless of ownership for exactly this reason — this fix completes that: exempts `/league/manage` from the block. Picks/Scores/Leaderboard keep the gate, since those genuinely need an existing league.

## Test plan
- [x] `npm run test -- --run` — 501 passed, 0 regressions, includes a new regression test proving League Portal is reachable without existing sport access
- [x] Typecheck/lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)