### PR TITLE
fix: league name uniqueness check is now case-insensitive

### DIFF
--- a/Server.UnitTests/LeagueRepositoryTests.cs
+++ b/Server.UnitTests/LeagueRepositoryTests.cs
@@ -452,4 +452,36 @@ public class LeagueRepositoryTests
         var league = await db.LeagueInfo.SingleAsync(l => l.Id == 1);
         Assert.Equal("new-owner", league.OwnerUserId); // not reverted by the stale snapshot
     }
+
+    // ── LeagueExistsAsync ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LeagueExistsAsync_ByNameOnly_IsCaseInsensitive() {
+        var factory = new DbContextFactoryStub(nameof(LeagueExistsAsync_ByNameOnly_IsCaseInsensitive));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueInfo.Add(new LeagueInfo { LeagueName = "Office League", OwnerUserId = "owner-1" });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+
+        Assert.True(await repo.LeagueExistsAsync("office league"));
+        Assert.True(await repo.LeagueExistsAsync("OFFICE LEAGUE"));
+        Assert.False(await repo.LeagueExistsAsync("A Totally Different League"));
+    }
+
+    [Fact]
+    public async Task LeagueExistsAsync_ByNameAndSeason_IsCaseInsensitive() {
+        var factory = new DbContextFactoryStub(nameof(LeagueExistsAsync_ByNameAndSeason_IsCaseInsensitive));
+        var seedDb = factory.CreateDbContext();
+        var league = new LeagueInfo { LeagueName = "Office League", OwnerUserId = "owner-1" };
+        seedDb.LeagueInfo.Add(league);
+        await seedDb.SaveChangesAsync();
+        seedDb.LeagueJuiceMapping.Add(new LeagueJuiceMapping { LeagueId = league.Id, Season = 2026, Juice = 13 });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+
+        Assert.True(await repo.LeagueExistsAsync("office league", 2026));
+        Assert.False(await repo.LeagueExistsAsync("office league", 2025));
+    }
 }

--- a/Server/Services/Repositories/LeagueRepository.cs
+++ b/Server/Services/Repositories/LeagueRepository.cs
@@ -444,13 +444,18 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
 
     public async Task<bool> LeagueExistsAsync(string leagueName, int season) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
+        // Case-insensitive: .ToLower() on both sides translates identically on SQLite (unit
+        // tests) and Npgsql (prod), unlike Npgsql-only EF.Functions.ILike, which would throw on
+        // a SQLite-backed test — see CLAUDE.md's EF Core provider-translation gotcha.
+        var normalized = leagueName.ToLower();
         return await db.LeagueJuiceMapping
-            .AnyAsync(ljm => ljm.League.LeagueName == leagueName && ljm.Season == season);
+            .AnyAsync(ljm => ljm.League.LeagueName.ToLower() == normalized && ljm.Season == season);
     }
     public async Task<bool> LeagueExistsAsync(string leagueName) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
+        var normalized = leagueName.ToLower();
         return await db.LeagueInfo
-            .AnyAsync(ljm => ljm.LeagueName == leagueName);
+            .AnyAsync(ljm => ljm.LeagueName.ToLower() == normalized);
     }
 
     public async Task<bool> UserExistsInLeagueAsync(string userId, int leagueId) {


### PR DESCRIPTION
## Summary
- `LeagueRepository.LeagueExistsAsync` (both overloads) did an exact string comparison, so "Office League" and "office league" could both exist as separate leagues. Both now normalize with `.ToLower()` on each side.
- Used `.ToLower()` deliberately over Npgsql's `EF.Functions.ILike` — this repo's unit tests run against EF Core's InMemory provider, and `ILike` is Npgsql-only and would throw there; `.ToLower()` translates/executes identically on both.
- Confirmed cross-sport uniqueness (NFL and CFB league can't share a name) is intentional and unchanged — `LeagueInfo` is a single shared table for both sports (`LeagueType` is just a column), so that's the correct scope.

## Test plan
- [x] `dotnet test` — 761 passed, 0 regressions, 2 new tests directly proving case-insensitivity for both `LeagueExistsAsync` overloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)