### PR TITLE
Promote dev to main: case-insensitive league name uniqueness

### DIFF
--- a/Server.UnitTests/LeagueRepositoryTests.cs
+++ b/Server.UnitTests/LeagueRepositoryTests.cs
@@ -452,4 +452,36 @@ public class LeagueRepositoryTests
         var league = await db.LeagueInfo.SingleAsync(l => l.Id == 1);
         Assert.Equal("new-owner", league.OwnerUserId); // not reverted by the stale snapshot
     }
+
+    // ── LeagueExistsAsync ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LeagueExistsAsync_ByNameOnly_IsCaseInsensitive() {
+        var factory = new DbContextFactoryStub(nameof(LeagueExistsAsync_ByNameOnly_IsCaseInsensitive));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueInfo.Add(new LeagueInfo { LeagueName = "Office League", OwnerUserId = "owner-1" });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+
+        Assert.True(await repo.LeagueExistsAsync("office league"));
+        Assert.True(await repo.LeagueExistsAsync("OFFICE LEAGUE"));
+        Assert.False(await repo.LeagueExistsAsync("A Totally Different League"));
+    }
+
+    [Fact]
+    public async Task LeagueExistsAsync_ByNameAndSeason_IsCaseInsensitive() {
+        var factory = new DbContextFactoryStub(nameof(LeagueExistsAsync_ByNameAndSeason_IsCaseInsensitive));
+        var seedDb = factory.CreateDbContext();
+        var league = new LeagueInfo { LeagueName = "Office League", OwnerUserId = "owner-1" };
+        seedDb.LeagueInfo.Add(league);
+        await seedDb.SaveChangesAsync();
+        seedDb.LeagueJuiceMapping.Add(new LeagueJuiceMapping { LeagueId = league.Id, Season = 2026, Juice = 13 });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+
+        Assert.True(await repo.LeagueExistsAsync("office league", 2026));
+        Assert.False(await repo.LeagueExistsAsync("office league", 2025));
+    }
 }

--- a/Server/Services/Repositories/LeagueRepository.cs
+++ b/Server/Services/Repositories/LeagueRepository.cs
@@ -444,13 +444,18 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
 
     public async Task<bool> LeagueExistsAsync(string leagueName, int season) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
+        // Case-insensitive: .ToLower() on both sides translates identically on SQLite (unit
+        // tests) and Npgsql (prod), unlike Npgsql-only EF.Functions.ILike, which would throw on
+        // a SQLite-backed test — see CLAUDE.md's EF Core provider-translation gotcha.
+        var normalized = leagueName.ToLower();
         return await db.LeagueJuiceMapping
-            .AnyAsync(ljm => ljm.League.LeagueName == leagueName && ljm.Season == season);
+            .AnyAsync(ljm => ljm.League.LeagueName.ToLower() == normalized && ljm.Season == season);
     }
     public async Task<bool> LeagueExistsAsync(string leagueName) {
         await using var db = await dbContextFactory.CreateDbContextAsync();
+        var normalized = leagueName.ToLower();
         return await db.LeagueInfo
-            .AnyAsync(ljm => ljm.LeagueName == leagueName);
+            .AnyAsync(ljm => ljm.LeagueName.ToLower() == normalized);
     }
 
     public async Task<bool> UserExistsInLeagueAsync(string userId, int leagueId) {


### PR DESCRIPTION
## Summary
- Promotes `dev` → `main` for production release.
- Includes: case-insensitive league name uniqueness check (PR #282) — "Office League" and "office league" now correctly collide instead of allowing duplicate leagues that only differ by case.

## Test plan
- [x] CI passed on PR #282 (dev)
- [x] Unit tests added: `LeagueExistsAsync_ByNameOnly_IsCaseInsensitive`, `LeagueExistsAsync_ByNameAndSeason_IsCaseInsensitive`
- [ ] Confirm Railway prod deploy reaches SUCCESS with correct SHA via `/api/version` on ivleague.xyz and cfb.ivleague.xyz

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JHKu6p4bRnpVSujaYUEUe