### PR TITLE
Promote dev to main: iOS UX round (Job Manager, pick dialog, week-nav skeleton), CFB admin-access exemption

### DIFF
--- a/Client.React/src/__tests__/sportAccess.test.tsx
+++ b/Client.React/src/__tests__/sportAccess.test.tsx
@@ -9,11 +9,14 @@ import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 import AppLayout from '../layouts/AppLayout';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { isAdmin } from '../utils/auth';
+
+const mockedIsAdmin = vi.mocked(isAdmin);
 
 vi.mock('../services/auth',  () => ({ useAuth: () => ({ user: { userId: 'u1', name: 'Alice', claims: [] } }) }));
 vi.mock('../services/theme', () => ({ useThemeMode: () => ({ mode: 'light', toggleTheme: vi.fn() }) }));
 vi.mock('../services/toast', () => ({ useToast: () => ({ push: vi.fn() }) }));
-vi.mock('../utils/auth',     () => ({ isAdmin: () => false }));
+vi.mock('../utils/auth',     () => ({ isAdmin: vi.fn() }));
 
 // Mutable session state — updated per test
 const sessionState = {
@@ -51,6 +54,7 @@ describe('Sport access control', () => {
     // Reset to defaults
     Object.assign(sessionState, { currentLeague: 1, hasNflAccess: true, hasCfbAccess: true, leaguesLoaded: true, ownedLeagues: [] });
     Object.assign(sportContext, { sport: 'NFL', isCfb: false, isNfl: true });
+    mockedIsAdmin.mockReturnValue(false);
   });
 
   it('NFL-only user on NFL site — no access message, renders nav normally', () => {
@@ -78,6 +82,33 @@ describe('Sport access control', () => {
     Object.assign(sessionState, { hasNflAccess: true, hasCfbAccess: false, currentLeague: null });
     renderLayout('/league/manage');
     expect(screen.queryByText(/No CFB access/i)).not.toBeInTheDocument();
+  });
+
+  // frizat: an admin's own personal league membership is unrelated to whether they should be able
+  // to reach the admin panel or manage the platform on a given sport's site — the block is meant
+  // for regular users who genuinely have nothing to look at, not for admins doing platform work.
+  it('admin with zero CFB access reaches the CFB admin panel directly — no access block at all', () => {
+    mockedIsAdmin.mockReturnValue(true);
+    Object.assign(sportContext, { sport: 'CFB', isCfb: true, isNfl: false });
+    Object.assign(sessionState, { hasNflAccess: true, hasCfbAccess: false, currentLeague: null });
+    renderLayout('/admin/jobManager');
+    expect(screen.queryByText(/No CFB access/i)).not.toBeInTheDocument();
+  });
+
+  it('admin with zero CFB access reaches ordinary sport-specific pages too (Scores), not just admin/League Portal', () => {
+    mockedIsAdmin.mockReturnValue(true);
+    Object.assign(sportContext, { sport: 'CFB', isCfb: true, isNfl: false });
+    Object.assign(sessionState, { hasNflAccess: true, hasCfbAccess: false, currentLeague: null });
+    renderLayout('/scores');
+    expect(screen.queryByText(/No CFB access/i)).not.toBeInTheDocument();
+  });
+
+  it('non-admin with zero CFB access still sees the block on the same admin route — the exemption is admin-only', () => {
+    mockedIsAdmin.mockReturnValue(false);
+    Object.assign(sportContext, { sport: 'CFB', isCfb: true, isNfl: false });
+    Object.assign(sessionState, { hasNflAccess: true, hasCfbAccess: false, currentLeague: null });
+    renderLayout('/admin/jobManager');
+    expect(screen.getByText(/No CFB access/i)).toBeInTheDocument();
   });
 
   it('CFB-only user on NFL site — shows No NFL access with Go to CFB link', () => {

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -105,19 +105,23 @@ export default function AppLayout() {
   const hasCurrent = isCfb ? hasCfbAccess : hasNflAccess;
   const hasOther = isCfb ? hasNflAccess : hasCfbAccess;
   const otherSport = isCfb ? 'NFL' : 'CFB';
-  // frizat: League Portal is exempt — it's the one page that already handles "no leagues yet"
-  // correctly (a "Create League" empty state, since creating a league needs no prior access).
-  // Without this, a user with only NFL leagues could never reach League Portal on the CFB site
-  // to create their first CFB league at all — the "no access" block replaced every routed page,
-  // including the one page designed to get them out of that exact state.
-  //
-  // Admins are exempt everywhere, not just League Portal — an admin's own personal league
-  // membership has nothing to do with whether they should be able to reach the admin panel or
-  // manage the platform on a given sport's site. Requiring them to first self-serve a league of
-  // their own via League Portal, just to unblock the admin pages they actually needed, was a
-  // needless detour that only happened to work by accident.
+  // /code-review: named predicate instead of accreting `&&` clauses on the gate condition itself
+  // — each exemption reason gets its own line here rather than a growing inline expression.
   const isLeaguePortalRoute = location.pathname.startsWith('/league/manage');
-  const noAccessContent = !showAdmin && !isLeaguePortalRoute && leaguesLoaded && currentLeague === null && !hasCurrent ? (
+  const isExemptFromSportAccessGate =
+    // League Portal is the one page that already handles "no leagues yet" correctly (a "Create
+    // League" empty state, since creating a league needs no prior access). Without this, a user
+    // with only NFL leagues could never reach League Portal on the CFB site to create their first
+    // CFB league at all — the "no access" block replaced every routed page, including the one
+    // page designed to get them out of that exact state.
+    isLeaguePortalRoute
+    // Admins are exempt everywhere, not just League Portal — an admin's own personal league
+    // membership has nothing to do with whether they should be able to reach the admin panel or
+    // manage the platform on a given sport's site. Requiring them to first self-serve a league of
+    // their own via League Portal, just to unblock the admin pages they actually needed, was a
+    // needless detour that only happened to work by accident.
+    || showAdmin;
+  const noAccessContent = !isExemptFromSportAccessGate && leaguesLoaded && currentLeague === null && !hasCurrent ? (
     <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '50vh', textAlign: 'center', p: 4 }}>
       <Typography variant="h5" fontWeight={700} gutterBottom>
         No {isCfb ? 'CFB' : 'NFL'} access

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -110,8 +110,14 @@ export default function AppLayout() {
   // Without this, a user with only NFL leagues could never reach League Portal on the CFB site
   // to create their first CFB league at all — the "no access" block replaced every routed page,
   // including the one page designed to get them out of that exact state.
+  //
+  // Admins are exempt everywhere, not just League Portal — an admin's own personal league
+  // membership has nothing to do with whether they should be able to reach the admin panel or
+  // manage the platform on a given sport's site. Requiring them to first self-serve a league of
+  // their own via League Portal, just to unblock the admin pages they actually needed, was a
+  // needless detour that only happened to work by accident.
   const isLeaguePortalRoute = location.pathname.startsWith('/league/manage');
-  const noAccessContent = !isLeaguePortalRoute && leaguesLoaded && currentLeague === null && !hasCurrent ? (
+  const noAccessContent = !showAdmin && !isLeaguePortalRoute && leaguesLoaded && currentLeague === null && !hasCurrent ? (
     <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '50vh', textAlign: 'center', p: 4 }}>
       <Typography variant="h5" fontWeight={700} gutterBottom>
         No {isCfb ? 'CFB' : 'NFL'} access


### PR DESCRIPTION
## Summary

Promotes `dev` → `main`. Includes:

- PR #290 — iOS UX fixes: League Portal spacing, Job Manager grouping/naming/toggle, pick dialog sizing, Previous/Next week-navigation skeleton, orphaned Quartz job cleanup, footer GitHub link removal.
- PR #292 — admins are now exempt from the "No {sport} access" gate on every route (not just League Portal), so an admin with zero CFB leagues of their own can reach `/admin/*` and every other CFB page directly.
- Everything already accumulated on `dev` since the last promotion (PR #289), notably **PR #280 — the League Portal access-gate fix that lets any authenticated user, admin or not, self-serve create a league in a sport they have zero access to.** This is the actual fix for "only admins can create CFB leagues" — `main` has been missing it.

## Why now

Prod (`main`) is currently missing the self-serve CFB/NFL league creation fix entirely — any user (including admins) with zero access to a sport gets walled off from League Portal on that sport's site, with no path to create their first league there. This promotion closes that gap.

## Test plan

Both PRs merged into dev with full green CI (backend/frontend build+test, demo backend e2e, demo replay e2e, Docker build, secret scan) — see PR #290 and PR #292 for the individual test plans.

- [ ] After merge deploys: verify `/api/version` reflects this SHA
- [ ] Live-verify: a non-admin user with zero CFB access can reach `cfb.ivleague.xyz` → My Leagues → Create League → submit successfully
- [ ] Live-verify: an admin with zero CFB access can reach CFB admin pages directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JHKu6p4bRnpVSujaYUEUe