### PR TITLE
Release: existing-user invite fix, job-history visibility, UI polish

### DIFF
--- a/Client.React/e2e/admin.spec.ts
+++ b/Client.React/e2e/admin.spec.ts
@@ -16,15 +16,13 @@ test.describe('Admin pages (administrator role)', () => {
     await expect(page.getByText('NflScoresJob')).toBeVisible({ timeout: 5000 });
   });
 
-  test('Job Manager groups jobs by category and hides background jobs behind a toggle', async ({ page }) => {
+  test('Job Manager groups jobs by category and always shows dynamic (per-league/per-week) jobs alongside fixed ones', async ({ page }) => {
     await adminAuth(page, '/admin/jobManager');
     await waitForSpinner(page);
 
     await expect(page.getByText('NFL Scores', { exact: true })).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('NflScoresJob')).toBeVisible();
-    await expect(page.getByText('Juice Reminder 6-2026')).not.toBeVisible();
-
-    await page.getByLabel(/show background jobs/i).click();
+    await expect(page.getByLabel(/show background jobs/i)).not.toBeVisible();
 
     await expect(page.getByText('Juice Reminder 6-2026')).toBeVisible();
     await expect(page.getByText('Remind league 6 owner to configure Juice for season 2026')).toBeVisible();

--- a/Client.React/src/__tests__/InvitationsPage.test.tsx
+++ b/Client.React/src/__tests__/InvitationsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import AdminInvitationsPage from '../pages/admin/InvitationsPage';
@@ -7,7 +7,8 @@ import type { LeagueInfoDto } from '../types/admin';
 vi.mock('../services/auth', () => ({
   useAuth: () => ({ user: { userId: 'admin-1', name: 'Admin', claims: [{ type: 'role', value: 'Administrator' }] } }),
 }));
-vi.mock('../services/toast', () => ({ useToast: () => ({ push: vi.fn() }) }));
+const toastPush = vi.fn();
+vi.mock('../services/toast', () => ({ useToast: () => ({ push: toastPush }) }));
 
 vi.mock('../api/invitations', () => ({
   getAllInvitations: vi.fn().mockResolvedValue([]),
@@ -51,9 +52,10 @@ function makeInvitation(overrides: Partial<InvitationDto> = {}): InvitationDto {
 }
 
 beforeEach(() => {
+  toastPush.mockClear();
   mockedGetAllLeagues.mockResolvedValue([]);
   mockedGetAllInvitations.mockResolvedValue([]);
-  mockedCreateInvitation.mockResolvedValue(makeInvitation());
+  mockedCreateInvitation.mockResolvedValue({ email: 'newplayer@example.com', outcome: 'NewUserInvitationSent' });
 });
 
 describe('AdminInvitationsPage', () => {
@@ -78,6 +80,23 @@ describe('AdminInvitationsPage', () => {
 
     expect(mockedCreateInvitation).toHaveBeenCalledWith('newplayer@example.com', 'admin-1', null);
     expect(mockedResendInvitation).not.toHaveBeenCalled();
+  });
+
+  it('tells the admin an already-registered invitee will see an in-app accept/decline request, not an email', async () => {
+    // Regression: this admin tool used to always create a registration-email Invitation, even
+    // for an email that already had an account — the invitee got nothing (no email needed, no
+    // banner ever created). The backend now detects this and creates a pending membership
+    // invite instead; the toast must reflect that so the admin isn't misled into thinking an
+    // email went out.
+    mockedCreateInvitation.mockResolvedValue({ email: 'existing@example.com', outcome: 'ExistingUserInvitePending' });
+    render(<AdminInvitationsPage />);
+
+    await userEvent.type(await screen.findByLabelText(/email address/i), 'existing@example.com');
+    await userEvent.click(screen.getByRole('button', { name: /^invite$/i }));
+
+    await waitFor(() =>
+      expect(toastPush).toHaveBeenCalledWith(expect.stringMatching(/already has an account/i), 'success')
+    );
   });
 
   it('resend button re-sends the invitation email for an existing invitation', async () => {

--- a/Client.React/src/__tests__/JobManagerPage.test.tsx
+++ b/Client.React/src/__tests__/JobManagerPage.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import AdminJobManagerPage from '../pages/admin/JobManagerPage';
 import type { JobStatusResponse } from '../types/admin';
@@ -31,23 +30,16 @@ function makeJob(overrides: Partial<JobStatusResponse> = {}): JobStatusResponse 
   };
 }
 
-describe('AdminJobManagerPage — background-job toggle visibility', () => {
+describe('AdminJobManagerPage', () => {
   beforeEach(() => {
     mockedGetAllJobsStatus.mockReset();
   });
 
-  // frizat: CLAUDE.md's "New nav link or conditional UI element" checklist item — this is the
-  // toggle /code-review flagged as having no unit test, only e2e coverage.
-  it('hides the toggle entirely when no job in the batch is dynamic', async () => {
-    mockedGetAllJobsStatus.mockResolvedValue([makeJob({ jobName: 'User Manager', isDynamic: false })]);
-
-    render(<AdminJobManagerPage />);
-
-    expect(await screen.findByText('User Manager')).toBeInTheDocument();
-    expect(screen.queryByLabelText(/show background jobs/i)).not.toBeInTheDocument();
-  });
-
-  it('shows the toggle with a count, hides dynamic jobs by default, and reveals them when toggled on', async () => {
+  // Regression: the previous "Show background jobs" toggle hid every isDynamic job (Juice
+  // Reminder/Lock, per-week NFL/CFB Spreads) behind a default-off switch — reported as "doesn't
+  // do anything" and as hiding jobs an admin needed to see (there's no other way to check a
+  // league's juice-lock reminder is actually scheduled). Every job is now always visible.
+  it('shows every job — dynamic (per-league/per-week) and fixed — with no hide/show toggle', async () => {
     mockedGetAllJobsStatus.mockResolvedValue([
       makeJob({ jobName: 'User Manager', category: 'System', isDynamic: false }),
       makeJob({ jobName: 'Juice Reminder 6-2026', category: 'Juice', isDynamic: true }),
@@ -56,13 +48,19 @@ describe('AdminJobManagerPage — background-job toggle visibility', () => {
     render(<AdminJobManagerPage />);
 
     expect(await screen.findByText('User Manager')).toBeInTheDocument();
-    const toggle = screen.getByLabelText(/show background jobs \(1\)/i);
-    expect(toggle).not.toBeChecked();
-    expect(screen.queryByText('Juice Reminder 6-2026')).not.toBeInTheDocument();
-
-    await userEvent.click(toggle);
-
-    expect(toggle).toBeChecked();
     expect(screen.getByText('Juice Reminder 6-2026')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/show background jobs/i)).not.toBeInTheDocument();
+  });
+
+  it('groups jobs under their category header', async () => {
+    mockedGetAllJobsStatus.mockResolvedValue([
+      makeJob({ jobName: 'User Manager', category: 'System', isDynamic: false }),
+      makeJob({ jobName: 'Juice Reminder 6-2026', category: 'Juice', isDynamic: true }),
+    ]);
+
+    render(<AdminJobManagerPage />);
+
+    expect(await screen.findByText('System', { exact: true })).toBeInTheDocument();
+    expect(screen.getByText('Juice', { exact: true })).toBeInTheDocument();
   });
 });

--- a/Client.React/src/__tests__/JoinLeaguePage.test.tsx
+++ b/Client.React/src/__tests__/JoinLeaguePage.test.tsx
@@ -86,6 +86,41 @@ describe('JoinLeaguePage', () => {
     );
   });
 
+  it('offers a log-in option alongside sign-up when logged out — an already-registered invitee has no other way in', async () => {
+    // Regression: a real invite-link batch (20 sent, 11 joined, 9 didn't) traced to exactly
+    // this gap — an already-registered invitee who wasn't currently logged in on this browser
+    // saw only "Create an account to join." Clicking it hits AuthController.CreateUser's
+    // InviteLinkToken branch, which flat-out rejects an existing email ("User already exists.")
+    // with no path back to actually joining. They need to log in, land back on this page, and
+    // then click Join as an authenticated existing user.
+    vi.mocked(validateInviteLink).mockResolvedValue({
+      token: 'tok123',
+      leagueId: 1,
+      leagueName: 'My NFL League',
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+    });
+    authState.user = null;
+    renderWithToken('tok123');
+    await waitFor(() => screen.getByRole('button', { name: /create an account/i }));
+    expect(screen.getByRole('button', { name: /already have an account.*log in/i })).toBeInTheDocument();
+  });
+
+  it('navigates to login with a returnUrl back to this join page when the log-in option is clicked', async () => {
+    vi.mocked(validateInviteLink).mockResolvedValue({
+      token: 'tok123',
+      leagueId: 1,
+      leagueName: 'My NFL League',
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+    });
+    authState.user = null;
+    renderWithToken('tok123');
+    await waitFor(() => screen.getByRole('button', { name: /already have an account.*log in/i }));
+    await userEvent.click(screen.getByRole('button', { name: /already have an account.*log in/i }));
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/account\/login\?returnUrl=.*join.*tok123/),
+    );
+  });
+
   it('shows Join button when user is logged in and token is valid', async () => {
     vi.mocked(validateInviteLink).mockResolvedValue({
       token: 'tok123',

--- a/Client.React/src/__tests__/url.test.ts
+++ b/Client.React/src/__tests__/url.test.ts
@@ -1,4 +1,4 @@
-import { buildAbsoluteUrl } from '../utils/url';
+import { buildAbsoluteUrl, buildLoginUrl } from '../utils/url';
 
 describe('buildAbsoluteUrl', () => {
   it('joins a leading-slash path onto window.location.origin', () => {
@@ -11,5 +11,15 @@ describe('buildAbsoluteUrl', () => {
 
   it('returns the origin with a trailing slash for an empty path', () => {
     expect(buildAbsoluteUrl('')).toBe(`${window.location.origin}/`);
+  });
+});
+
+describe('buildLoginUrl', () => {
+  it('builds a login path with the return path URL-encoded as returnUrl', () => {
+    expect(buildLoginUrl('/join/tok123')).toBe('/account/login?returnUrl=%2Fjoin%2Ftok123');
+  });
+
+  it('encodes query params in the return path too', () => {
+    expect(buildLoginUrl('/dashboard?tab=1')).toBe('/account/login?returnUrl=%2Fdashboard%3Ftab%3D1');
   });
 });

--- a/Client.React/src/api/invitations.ts
+++ b/Client.React/src/api/invitations.ts
@@ -1,5 +1,6 @@
 import { http } from './http';
 import type { InvitationDto } from '../types/admin';
+import type { LeagueInviteResultDto } from './league';
 
 export async function getAllInvitations() {
   const { data } = await http.get<InvitationDto[]>('/api/invitations/all');
@@ -11,11 +12,12 @@ export async function getInvitationsByUser(userId: string) {
   return data;
 }
 
-// The invitation email is sent server-side (same code path as league-scoped
-// invites) — baseUrl tells the backend which frontend origin to build the
-// registration link against.
+// When leagueId targets an already-registered user, the backend routes them through the same
+// existing-user pending-invite flow as League Portal's "Invite Player" (see
+// InvitationController.Create) instead of sending a registration email — outcome tells the
+// caller which one happened.
 export async function createInvitation(email: string, invitedByUserId: string, leagueId?: number | null) {
-  const { data } = await http.post<InvitationDto>('/api/invitations', undefined, {
+  const { data } = await http.post<LeagueInviteResultDto>('/api/invitations', undefined, {
     params: {
       email,
       invitedByUserId,

--- a/Client.React/src/app/theme.ts
+++ b/Client.React/src/app/theme.ts
@@ -147,6 +147,16 @@ export function createAppTheme(mode: 'light' | 'dark') {
         root: {
           border: isDark ? '1px solid rgba(255,255,255,0.07)' : '1px solid rgba(15, 23, 42, 0.08)',
           transition: 'box-shadow 0.2s ease-in-out',
+          // MUI bakes a translucent-white gradient onto elevated (non-outlined) dark-mode
+          // Paper/Card as a stand-in for a drop shadow — it does NOT apply to
+          // variant="outlined". Pages like RulesPage nest an outer elevated Card around many
+          // inner `Paper variant="outlined"` sections; without this override the outer Card
+          // renders visibly lighter (background.paper + overlay) than every inner section
+          // (flat background.paper), so scrolling repeatedly crosses between two different
+          // shades — reported as "the background alternates" and hard to read. Disabling the
+          // overlay makes every Paper/Card render as one flat background.paper in dark mode,
+          // matching outlined surfaces exactly.
+          backgroundImage: isDark ? 'none' : undefined,
           '&:hover': {
             boxShadow: isDark ? '0 4px 12px rgba(0,0,0,0.3)' : '0 4px 12px rgba(0, 0, 0, 0.05)',
           },

--- a/Client.React/src/pages/JoinLeaguePage.tsx
+++ b/Client.React/src/pages/JoinLeaguePage.tsx
@@ -9,6 +9,7 @@ import Typography from '@mui/material/Typography';
 import { validateInviteLink, joinViaLink, type LeagueInviteLinkDto } from '../api/league';
 import { useAuth } from '../services/auth';
 import { useSession } from '../services/session';
+import { buildLoginUrl } from '../utils/url';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 
 export default function JoinLeaguePage() {
@@ -44,7 +45,7 @@ export default function JoinLeaguePage() {
   // branch rejects an existing email with no fallback). Logging in and returning here lets them
   // hit the normal authenticated Join button below.
   const handleLogIn = () => {
-    navigate(`/account/login?returnUrl=${encodeURIComponent(`/join/${token}`)}`);
+    navigate(buildLoginUrl(`/join/${token}`));
   };
 
   const handleJoin = async () => {

--- a/Client.React/src/pages/JoinLeaguePage.tsx
+++ b/Client.React/src/pages/JoinLeaguePage.tsx
@@ -39,6 +39,14 @@ export default function JoinLeaguePage() {
     navigate(`/account/register?inviteLinkToken=${token}&returnUrl=/join/${token}`);
   };
 
+  // An invitee who already has an account but isn't currently logged in on this browser has no
+  // other way to accept — registering fails outright (AuthController.CreateUser's InviteLinkToken
+  // branch rejects an existing email with no fallback). Logging in and returning here lets them
+  // hit the normal authenticated Join button below.
+  const handleLogIn = () => {
+    navigate(`/account/login?returnUrl=${encodeURIComponent(`/join/${token}`)}`);
+  };
+
   const handleJoin = async () => {
     setJoining(true);
     setError(null);
@@ -121,16 +129,20 @@ export default function JoinLeaguePage() {
               {joining ? <CircularProgress size={22} color="inherit" /> : 'Join League'}
             </Button>
           ) : (
-            <Button
-              variant="contained"
-              color="secondary"
-              size="large"
-              fullWidth
-              onClick={handleSignUp}
-              sx={{ mt: 2 }}
-            >
-              Create an account to join
-            </Button>
+            <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <Button
+                variant="contained"
+                color="secondary"
+                size="large"
+                fullWidth
+                onClick={handleSignUp}
+              >
+                Create an account to join
+              </Button>
+              <Button variant="text" size="small" fullWidth onClick={handleLogIn}>
+                Already have an account? Log in
+              </Button>
+            </Box>
           )}
         </CardContent>
       </Card>

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -751,7 +751,11 @@ function MembersTab({ members, loading, costDto, isAdmin: admin, onRemove, onInv
 
   return (
     <Box>
-      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 2 }} flexWrap="wrap">
+      {/* useFlexGap: Stack's default margin-based spacing only separates items within the same
+          flex line — with flexWrap="wrap" on a narrow (mobile) viewport, buttons that wrap onto
+          their own line end up touching with zero gap. useFlexGap switches to real CSS `gap`,
+          which applies between wrapped lines too. */}
+      <Stack direction="row" spacing={2} useFlexGap alignItems="center" sx={{ mb: 2 }} flexWrap="wrap">
         <Chip label={`${count} member${count !== 1 ? 's' : ''} · $${cost}/season`} color="primary" variant="outlined" />
         <Button startIcon={<PersonAddIcon />} variant="outlined" size="small" onClick={onInvite}>
           Invite Player

--- a/Client.React/src/pages/admin/InvitationsPage.tsx
+++ b/Client.React/src/pages/admin/InvitationsPage.tsx
@@ -30,6 +30,7 @@ import { useAuth } from '../../services/auth';
 import { createInvitation, deleteInvitation, getAllInvitations, resendInvitation } from '../../api/invitations';
 import { getAllLeagues } from '../../api/league';
 import type { InvitationDto, LeagueInfoDto } from '../../types/admin';
+import { extractApiErrorMessage } from '../../utils/apiError';
 
 function getInvitationStatusChip(invitation: InvitationDto): { label: string; color: 'success' | 'warning' | 'error' | 'info' } {
   if (invitation.isUsed) {
@@ -91,13 +92,19 @@ export default function AdminInvitationsPage() {
     setCreating(true);
     try {
       const leagueId = selectedLeagueId !== '' ? selectedLeagueId : null;
-      // Email is sent server-side as part of creating the invitation.
-      await createInvitation(email, user.userId, leagueId);
-      toast.push(`Invitation sent to ${email}`, 'success');
+      // Email is sent server-side as part of creating the invitation — unless the address
+      // already belongs to a registered user, in which case the backend creates a pending
+      // membership invite instead (they'll see an in-app accept/decline banner, not an email).
+      const result = await createInvitation(email, user.userId, leagueId);
+      if (result.outcome === 'ExistingUserInvitePending') {
+        toast.push(`${email} already has an account — they'll see a request to accept or decline in the app.`, 'success');
+      } else {
+        toast.push(`Invitation sent to ${email}`, 'success');
+      }
       await loadInvitations();
       setEmail('');
-    } catch {
-      toast.push('Error creating invitation', 'error');
+    } catch (error) {
+      toast.push(extractApiErrorMessage(error, 'Error creating invitation'), 'error');
     } finally {
       setCreating(false);
     }

--- a/Client.React/src/pages/admin/JobManagerPage.tsx
+++ b/Client.React/src/pages/admin/JobManagerPage.tsx
@@ -3,11 +3,9 @@ import {
   Box,
   Button,
   CircularProgress,
-  FormControlLabel,
   Grid,
   Paper,
   Stack,
-  Switch,
   Table,
   TableBody,
   TableCell,
@@ -29,29 +27,23 @@ export default function AdminJobManagerPage() {
   const [jobs, setJobs] = useState<JobStatusResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [jobRunning, setJobRunning] = useState(false);
-  // Default hidden: the per-league/per-week jobs TimedTriggerScheduler registers dynamically
-  // (Juice Reminder/Lock, NFL/CFB Spreads) can easily outnumber the fixed scheduler/cron jobs,
-  // which is what made this table "hard to read" in the first place.
-  const [showDynamic, setShowDynamic] = useState(false);
   const toast = useToast();
 
-  const visibleJobs = useMemo(
-    () => (showDynamic ? jobs : jobs.filter((j) => !j.isDynamic)),
-    [jobs, showDynamic],
-  );
-  const dynamicJobCount = useMemo(() => jobs.filter((j) => j.isDynamic).length, [jobs]);
-
   // Backend already returns jobs ordered by Category then JobName — group in that order rather
-  // than re-sorting, so category order stays server-controlled in one place.
+  // than re-sorting, so category order stays server-controlled in one place. Every job (fixed
+  // scheduler/cron jobs and the per-league/per-week ones TimedTriggerScheduler registers
+  // dynamically — Juice Reminder/Lock, NFL/CFB Spreads) is always shown: a "hide dynamic jobs"
+  // toggle previously defaulted this list to only fixed jobs, which hid the only place an admin
+  // could confirm a league's juice-lock reminder was actually scheduled.
   const jobsByCategory = useMemo(() => {
     const grouped = new Map<string, JobStatusResponse[]>();
-    for (const job of visibleJobs) {
+    for (const job of jobs) {
       const existing = grouped.get(job.category);
       if (existing) existing.push(job);
       else grouped.set(job.category, [job]);
     }
     return grouped;
-  }, [visibleJobs]);
+  }, [jobs]);
 
   const loadJobs = async () => {
     setLoading(true);
@@ -128,15 +120,7 @@ export default function AdminJobManagerPage() {
       </Paper>
 
       <Paper sx={{ p: 2 }}>
-        <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" alignItems={{ sm: 'center' }} spacing={1} sx={{ mb: 2 }}>
-          <Typography variant="h6">Scheduled Jobs</Typography>
-          {dynamicJobCount > 0 && (
-            <FormControlLabel
-              control={<Switch checked={showDynamic} onChange={(e) => setShowDynamic(e.target.checked)} size="small" />}
-              label={`Show background jobs (${dynamicJobCount})`}
-            />
-          )}
-        </Stack>
+        <Typography variant="h6" sx={{ mb: 2 }}>Scheduled Jobs</Typography>
         {loading ? (
           <Stack alignItems="center">
             <CircularProgress />
@@ -179,7 +163,7 @@ export default function AdminJobManagerPage() {
                   ))}
                 </Fragment>
               ))}
-              {visibleJobs.length === 0 && (
+              {jobs.length === 0 && (
                 <TableRow>
                   <TableCell colSpan={7} align="center">No jobs to show.</TableCell>
                 </TableRow>

--- a/Client.React/src/services/auth.tsx
+++ b/Client.React/src/services/auth.tsx
@@ -3,6 +3,7 @@ import { Navigate, useLocation } from 'react-router-dom';
 import { http } from '../api/http';
 import type { LoginRequest, SignInResultDto, UserInfo } from '../types/auth';
 import { isAdmin } from '../utils/auth';
+import { buildLoginUrl } from '../utils/url';
 
 interface AuthContextValue {
   user: UserInfo | null;
@@ -94,8 +95,7 @@ export function RequireAuth({ children }: { children: React.ReactNode }) {
   }
 
   if (!user) {
-    const returnUrl = encodeURIComponent(location.pathname + location.search);
-    return <Navigate to={`/account/login?returnUrl=${returnUrl}`} replace />;
+    return <Navigate to={buildLoginUrl(location.pathname + location.search)} replace />;
   }
 
   return <>{children}</>;
@@ -110,8 +110,7 @@ export function RequireAdmin({ children }: { children: React.ReactNode }) {
   }
 
   if (!user) {
-    const returnUrl = encodeURIComponent(location.pathname + location.search);
-    return <Navigate to={`/account/login?returnUrl=${returnUrl}`} replace />;
+    return <Navigate to={buildLoginUrl(location.pathname + location.search)} replace />;
   }
 
   if (!isAdmin(user)) {

--- a/Client.React/src/utils/url.ts
+++ b/Client.React/src/utils/url.ts
@@ -1,3 +1,9 @@
 export function buildAbsoluteUrl(path: string): string {
   return new URL(path, window.location.origin).toString();
 }
+
+// Shared by every unauthenticated redirect-to-login site (RequireAuth, RequireAdmin,
+// JoinLeaguePage's log-in option) so the returnUrl param stays consistent everywhere.
+export function buildLoginUrl(returnPath: string): string {
+  return `/account/login?returnUrl=${encodeURIComponent(returnPath)}`;
+}

--- a/Server.UnitTests/EmailProcessTests.cs
+++ b/Server.UnitTests/EmailProcessTests.cs
@@ -2,6 +2,7 @@ using FourPlayWebApp.Server.Controllers;
 using FourPlayWebApp.Server.Data;
 using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models.Account;
 using FourPlayWebApp.Shared.Models.Email;
 using Microsoft.AspNetCore.Http;
@@ -39,7 +40,11 @@ public class EmailProcessTests
         IEmailSender<ApplicationUser> emailSenderApp)
     {
         var invitationService = Substitute.For<IInvitationService>();
-        return new InvitationController(invitationService, emailSenderApp);
+        var userManager = Substitute.For<UserManager<ApplicationUser>>(
+            Substitute.For<IUserStore<ApplicationUser>>(), null, null, null, null, null, null, null, null);
+        return new InvitationController(
+            invitationService, emailSenderApp,
+            userManager, Substitute.For<ILeagueRepository>(), Substitute.For<ILeagueMembershipInviteService>());
     }
 
     private static AuthController BuildAuthController(

--- a/Server.UnitTests/InvitationControllerTests.cs
+++ b/Server.UnitTests/InvitationControllerTests.cs
@@ -107,6 +107,27 @@ public class InvitationControllerTests
     }
 
     [Fact]
+    public async Task Create_NewUser_LeagueDoesNotExist_ReturnsNotFound_WithoutCreatingAnything()
+    {
+        // /code-review's second pass caught that the first fix only guarded the existing-user
+        // branch — a brand-new email with a bad leagueId still fell through to
+        // CreateInvitationAsync, which has the identical FK-violation-mishandled-as-duplicate-
+        // race bug (InvitationService.CreateInvitationAsync's catch re-reads a row that was never
+        // inserted, throwing an unhandled InvalidOperationException — a 500, not even the wrong
+        // 200 the existing-user branch had). The league-existence check now runs before either
+        // branch, so this path never reaches CreateInvitationAsync at all.
+        var (ctrl, invitationService, leagueRepo, userManager, membershipInviteService) = BuildControllerWithDeps();
+        userManager.FindByEmailAsync("newplayer@example.com").Returns((ApplicationUser?)null);
+        leagueRepo.GetLeagueInfoAsync(999).Returns(Task.FromException<LeagueInfo>(new InvalidOperationException("Sequence contains no elements")));
+
+        var result = await ctrl.Create("newplayer@example.com", "admin-1", leagueId: 999);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+        await invitationService.DidNotReceiveWithAnyArgs().CreateInvitationAsync(default!, default!, default, default);
+        await membershipInviteService.DidNotReceiveWithAnyArgs().CreateOrReopenAsync(default, default!, default!);
+    }
+
+    [Fact]
     public async Task Create_NoExistingUser_WithLeagueId_StillCreatesEmailInvitation()
     {
         var (ctrl, invitationService, _, userManager, membershipInviteService) = BuildControllerWithDeps();

--- a/Server.UnitTests/InvitationControllerTests.cs
+++ b/Server.UnitTests/InvitationControllerTests.cs
@@ -15,9 +15,9 @@ namespace FourPlayWebApp.Server.UnitTests;
 public class InvitationControllerTests
 {
     private static (InvitationController ctrl, IInvitationService invitationService, ILeagueRepository leagueRepo, UserManager<ApplicationUser> userManager, ILeagueMembershipInviteService membershipInviteService)
-        BuildControllerWithDeps()
+        BuildControllerWithDeps(IInvitationService? invitationService = null)
     {
-        var invitationService = Substitute.For<IInvitationService>();
+        invitationService ??= Substitute.For<IInvitationService>();
         var leagueRepo = Substitute.For<ILeagueRepository>();
         var store = Substitute.For<IUserStore<ApplicationUser>>();
         var userManager = Substitute.For<UserManager<ApplicationUser>>(
@@ -29,14 +29,6 @@ public class InvitationControllerTests
         return (ctrl, invitationService, leagueRepo, userManager, membershipInviteService);
     }
 
-    private static InvitationController BuildController(IInvitationService invitationService) =>
-        new(
-            invitationService, Substitute.For<IEmailSender<ApplicationUser>>(),
-            Substitute.For<UserManager<ApplicationUser>>(
-                Substitute.For<IUserStore<ApplicationUser>>(), null, null, null, null, null, null, null, null),
-            Substitute.For<ILeagueRepository>(),
-            Substitute.For<ILeagueMembershipInviteService>());
-
     [Fact]
     public async Task Create_PassesBaseUrlThrough_SoTheInvitationServiceCanSendTheEmail()
     {
@@ -44,9 +36,9 @@ public class InvitationControllerTests
         invitationService
             .CreateInvitationAsync("target@example.com", "admin-1", null, "https://ivleague.com")
             .Returns(new Invitation { Id = 1, Email = "target@example.com", InvitationCode = "code-abc" });
-        var controller = BuildController(invitationService);
+        var (ctrl, _, _, _, _) = BuildControllerWithDeps(invitationService);
 
-        await controller.Create("target@example.com", "admin-1", baseUrl: "https://ivleague.com");
+        await ctrl.Create("target@example.com", "admin-1", baseUrl: "https://ivleague.com");
 
         await invitationService.Received(1).CreateInvitationAsync("target@example.com", "admin-1", null, "https://ivleague.com");
     }
@@ -93,7 +85,7 @@ public class InvitationControllerTests
     [Fact]
     public async Task Create_NoExistingUser_WithLeagueId_StillCreatesEmailInvitation()
     {
-        var (ctrl, invitationService, leagueRepo, userManager, membershipInviteService) = BuildControllerWithDeps();
+        var (ctrl, invitationService, _, userManager, membershipInviteService) = BuildControllerWithDeps();
         userManager.FindByEmailAsync("newplayer@example.com").Returns((ApplicationUser?)null);
         invitationService.CreateInvitationAsync("newplayer@example.com", "admin-1", 5, null)
             .Returns(new Invitation { Id = 1, Email = "newplayer@example.com", InvitationCode = "code-abc" });
@@ -112,7 +104,7 @@ public class InvitationControllerTests
     {
         // No league context means there's nothing to build a LeagueMembershipInvite against —
         // this leagueless "just register" invite keeps its pre-existing behavior untouched.
-        var (ctrl, invitationService, leagueRepo, userManager, membershipInviteService) = BuildControllerWithDeps();
+        var (ctrl, invitationService, _, userManager, membershipInviteService) = BuildControllerWithDeps();
         invitationService.CreateInvitationAsync("someone@example.com", "admin-1", null, null)
             .Returns(new Invitation { Id = 1, Email = "someone@example.com", InvitationCode = "code-abc" });
 
@@ -129,9 +121,9 @@ public class InvitationControllerTests
     public async Task Resend_CallsResendInvitationEmailAsync()
     {
         var invitationService = Substitute.For<IInvitationService>();
-        var controller = BuildController(invitationService);
+        var (ctrl, _, _, _, _) = BuildControllerWithDeps(invitationService);
 
-        await controller.Resend(7, "https://ivleague.com");
+        await ctrl.Resend(7, "https://ivleague.com");
 
         await invitationService.Received(1).ResendInvitationEmailAsync(7, "https://ivleague.com");
     }
@@ -140,9 +132,9 @@ public class InvitationControllerTests
     public async Task Delete_CallsDeleteInvitationAsync_ReturnsNoContent()
     {
         var invitationService = Substitute.For<IInvitationService>();
-        var controller = BuildController(invitationService);
+        var (ctrl, _, _, _, _) = BuildControllerWithDeps(invitationService);
 
-        var result = await controller.Delete(7);
+        var result = await ctrl.Delete(7);
 
         await invitationService.Received(1).DeleteInvitationAsync(7);
         Assert.IsType<NoContentResult>(result);

--- a/Server.UnitTests/InvitationControllerTests.cs
+++ b/Server.UnitTests/InvitationControllerTests.cs
@@ -2,6 +2,8 @@ using FourPlayWebApp.Server.Controllers;
 using FourPlayWebApp.Server.Models;
 using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Server.Services.Repositories.Interfaces;
+using FourPlayWebApp.Shared.Models.Data.Dtos;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -12,8 +14,28 @@ namespace FourPlayWebApp.Server.UnitTests;
 
 public class InvitationControllerTests
 {
+    private static (InvitationController ctrl, IInvitationService invitationService, ILeagueRepository leagueRepo, UserManager<ApplicationUser> userManager, ILeagueMembershipInviteService membershipInviteService)
+        BuildControllerWithDeps()
+    {
+        var invitationService = Substitute.For<IInvitationService>();
+        var leagueRepo = Substitute.For<ILeagueRepository>();
+        var store = Substitute.For<IUserStore<ApplicationUser>>();
+        var userManager = Substitute.For<UserManager<ApplicationUser>>(
+            store, null, null, null, null, null, null, null, null);
+        var membershipInviteService = Substitute.For<ILeagueMembershipInviteService>();
+        var ctrl = new InvitationController(
+            invitationService, Substitute.For<IEmailSender<ApplicationUser>>(),
+            userManager, leagueRepo, membershipInviteService);
+        return (ctrl, invitationService, leagueRepo, userManager, membershipInviteService);
+    }
+
     private static InvitationController BuildController(IInvitationService invitationService) =>
-        new(invitationService, Substitute.For<IEmailSender<ApplicationUser>>());
+        new(
+            invitationService, Substitute.For<IEmailSender<ApplicationUser>>(),
+            Substitute.For<UserManager<ApplicationUser>>(
+                Substitute.For<IUserStore<ApplicationUser>>(), null, null, null, null, null, null, null, null),
+            Substitute.For<ILeagueRepository>(),
+            Substitute.For<ILeagueMembershipInviteService>());
 
     [Fact]
     public async Task Create_PassesBaseUrlThrough_SoTheInvitationServiceCanSendTheEmail()
@@ -27,6 +49,80 @@ public class InvitationControllerTests
         await controller.Create("target@example.com", "admin-1", baseUrl: "https://ivleague.com");
 
         await invitationService.Received(1).CreateInvitationAsync("target@example.com", "admin-1", null, "https://ivleague.com");
+    }
+
+    // ── Existing-user detection when a league is specified ──────────────────
+    // Mirrors LeagueController.InviteToLeague: an admin using the global "Manage Invitations"
+    // page to invite someone to a specific league must get the same existing-user treatment a
+    // commissioner's "Invite Player" gets — otherwise an already-registered user (NFL or CFB)
+    // silently gets a registration-style email Invitation instead of the in-app accept/decline
+    // banner, and never sees anything (the bug this test locks in).
+
+    [Fact]
+    public async Task Create_ExistingUser_WithLeagueId_CreatesPendingMembershipInvite_NotAnEmailInvitation()
+    {
+        var (ctrl, invitationService, leagueRepo, userManager, membershipInviteService) = BuildControllerWithDeps();
+        var existingUser = new ApplicationUser { Id = "existing-user-1", Email = "already-registered@example.com" };
+        userManager.FindByEmailAsync("already-registered@example.com").Returns(existingUser);
+        leagueRepo.UserExistsInLeagueAsync("existing-user-1", 5).Returns(false);
+
+        var result = await ctrl.Create("already-registered@example.com", "admin-1", leagueId: 5);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<LeagueInviteResultDto>(ok.Value);
+        Assert.Equal(LeagueInviteOutcome.ExistingUserInvitePending, dto.Outcome);
+        await membershipInviteService.Received(1).CreateOrReopenAsync(5, "existing-user-1", "admin-1");
+        await invitationService.DidNotReceiveWithAnyArgs().CreateInvitationAsync(default!, default!, default, default);
+    }
+
+    [Fact]
+    public async Task Create_ExistingUser_AlreadyMember_ReturnsConflict_WithoutCreatingAnything()
+    {
+        var (ctrl, invitationService, leagueRepo, userManager, membershipInviteService) = BuildControllerWithDeps();
+        var existingUser = new ApplicationUser { Id = "existing-user-1", Email = "already-member@example.com" };
+        userManager.FindByEmailAsync("already-member@example.com").Returns(existingUser);
+        leagueRepo.UserExistsInLeagueAsync("existing-user-1", 5).Returns(true);
+
+        var result = await ctrl.Create("already-member@example.com", "admin-1", leagueId: 5);
+
+        Assert.IsType<ConflictObjectResult>(result.Result);
+        await membershipInviteService.DidNotReceiveWithAnyArgs().CreateOrReopenAsync(default, default!, default!);
+        await invitationService.DidNotReceiveWithAnyArgs().CreateInvitationAsync(default!, default!, default, default);
+    }
+
+    [Fact]
+    public async Task Create_NoExistingUser_WithLeagueId_StillCreatesEmailInvitation()
+    {
+        var (ctrl, invitationService, leagueRepo, userManager, membershipInviteService) = BuildControllerWithDeps();
+        userManager.FindByEmailAsync("newplayer@example.com").Returns((ApplicationUser?)null);
+        invitationService.CreateInvitationAsync("newplayer@example.com", "admin-1", 5, null)
+            .Returns(new Invitation { Id = 1, Email = "newplayer@example.com", InvitationCode = "code-abc" });
+
+        var result = await ctrl.Create("newplayer@example.com", "admin-1", leagueId: 5);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<LeagueInviteResultDto>(ok.Value);
+        Assert.Equal(LeagueInviteOutcome.NewUserInvitationSent, dto.Outcome);
+        await invitationService.Received(1).CreateInvitationAsync("newplayer@example.com", "admin-1", 5, null);
+        await membershipInviteService.DidNotReceiveWithAnyArgs().CreateOrReopenAsync(default, default!, default!);
+    }
+
+    [Fact]
+    public async Task Create_ExistingUser_NoLeagueId_SkipsMembershipCheck_CreatesEmailInvitationAsBefore()
+    {
+        // No league context means there's nothing to build a LeagueMembershipInvite against —
+        // this leagueless "just register" invite keeps its pre-existing behavior untouched.
+        var (ctrl, invitationService, leagueRepo, userManager, membershipInviteService) = BuildControllerWithDeps();
+        invitationService.CreateInvitationAsync("someone@example.com", "admin-1", null, null)
+            .Returns(new Invitation { Id = 1, Email = "someone@example.com", InvitationCode = "code-abc" });
+
+        var result = await ctrl.Create("someone@example.com", "admin-1");
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<LeagueInviteResultDto>(ok.Value);
+        Assert.Equal(LeagueInviteOutcome.NewUserInvitationSent, dto.Outcome);
+        await userManager.DidNotReceiveWithAnyArgs().FindByEmailAsync(default!);
+        await membershipInviteService.DidNotReceiveWithAnyArgs().CreateOrReopenAsync(default, default!, default!);
     }
 
     [Fact]

--- a/Server.UnitTests/InvitationControllerTests.cs
+++ b/Server.UnitTests/InvitationControllerTests.cs
@@ -1,5 +1,6 @@
 using FourPlayWebApp.Server.Controllers;
 using FourPlayWebApp.Server.Models;
+using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
@@ -80,6 +81,29 @@ public class InvitationControllerTests
         Assert.IsType<ConflictObjectResult>(result.Result);
         await membershipInviteService.DidNotReceiveWithAnyArgs().CreateOrReopenAsync(default, default!, default!);
         await invitationService.DidNotReceiveWithAnyArgs().CreateInvitationAsync(default!, default!, default, default);
+    }
+
+    [Fact]
+    public async Task Create_ExistingUser_LeagueDoesNotExist_ReturnsNotFound_WithoutCreatingAnything()
+    {
+        // /code-review caught this: LoadOwnedLeagueAsync (LeagueController's sibling flow)
+        // 404s on a missing league before doing anything else; this branch didn't, so a stale or
+        // crafted leagueId reached CreateOrReopenAsync, which inserts a LeagueMembershipInvite
+        // with a required FK to LeagueInfo, tripped a DbUpdateException that CreateOrReopenAsync's
+        // catch block silently swallows (it exists only for a concurrent-duplicate-insert race),
+        // and this endpoint returned 200 OK with ExistingUserInvitePending even though nothing
+        // was ever persisted — a false success shown to the admin.
+        var (ctrl, invitationService, leagueRepo, userManager, membershipInviteService) = BuildControllerWithDeps();
+        var existingUser = new ApplicationUser { Id = "existing-user-1", Email = "already-registered@example.com" };
+        userManager.FindByEmailAsync("already-registered@example.com").Returns(existingUser);
+        leagueRepo.GetLeagueInfoAsync(999).Returns(Task.FromException<LeagueInfo>(new InvalidOperationException("Sequence contains no elements")));
+
+        var result = await ctrl.Create("already-registered@example.com", "admin-1", leagueId: 999);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+        await membershipInviteService.DidNotReceiveWithAnyArgs().CreateOrReopenAsync(default, default!, default!);
+        await invitationService.DidNotReceiveWithAnyArgs().CreateInvitationAsync(default!, default!, default, default);
+        await leagueRepo.DidNotReceiveWithAnyArgs().UserExistsInLeagueAsync(default!, default);
     }
 
     [Fact]

--- a/Server.UnitTests/JobFailureAlertListenerTests.cs
+++ b/Server.UnitTests/JobFailureAlertListenerTests.cs
@@ -9,9 +9,16 @@ namespace FourPlayWebApp.Server.UnitTests;
 // fires for every job's failure uniformly — including jobs that let an exception propagate
 // rather than catching it themselves, since Quartz's JobRunShell still reports that here as a
 // non-null jobException. One shared mechanism, not a notifier call bolted onto each job.
+//
+// It now also centralizes IJobObserverService start/success/failure recording for EVERY job
+// type — previously only LeagueJuiceLockJob/LeagueJuiceReminderJob called RecordJobStartAsync/
+// RecordJobSuccessAsync/RecordAndRethrowAsync themselves, so every other job (NflScoresJob,
+// CfbRankingCaptureJob, etc.) never appeared in the observer at all and Job Manager's
+// "Last Succeeded"/"Last Failed" columns were permanently blank for them, restart or not.
 public class JobFailureAlertListenerTests
 {
     private readonly IJobFailureNotifier _notifier = Substitute.For<IJobFailureNotifier>();
+    private readonly IJobObserverService _observer = Substitute.For<IJobObserverService>();
     private readonly IJobExecutionContext _context = Substitute.For<IJobExecutionContext>();
     private readonly IJobDetail _jobDetail = Substitute.For<IJobDetail>();
     private readonly ITrigger _trigger = Substitute.For<ITrigger>();
@@ -24,7 +31,15 @@ public class JobFailureAlertListenerTests
         _context.Trigger.Returns(_trigger);
     }
 
-    private JobFailureAlertListener BuildListener() => new(_notifier);
+    private JobFailureAlertListener BuildListener() => new(_notifier, _observer);
+
+    [Fact]
+    public async Task JobToBeExecuted_RecordsStartForEveryJob()
+    {
+        await BuildListener().JobToBeExecuted(_context);
+
+        await _observer.Received(1).RecordJobStartAsync("NflSpreadJob");
+    }
 
     [Fact]
     public async Task JobWasExecuted_WithException_NotifiesWithJobAndTriggerNames()
@@ -37,10 +52,68 @@ public class JobFailureAlertListenerTests
     }
 
     [Fact]
+    public async Task JobWasExecuted_WithException_RecordsFailure_WhenJobDidNotAlreadySelfReport()
+    {
+        var exception = new JobExecutionException("ESPN odds API timed out");
+        _observer.GetJobInfoAsync("NflSpreadJob").Returns(new JobRunInfo("NflSpreadJob") { LastStartedUtc = DateTimeOffset.UtcNow });
+
+        await BuildListener().JobWasExecuted(_context, exception);
+
+        await _observer.Received(1).RecordJobFailureAsync("NflSpreadJob", "ESPN odds API timed out");
+    }
+
+    [Fact]
+    public async Task JobWasExecuted_WithException_SkipsFailureRecording_WhenJobAlreadySelfReportedThisRun()
+    {
+        // Mirrors LeagueJuiceLockJob/LeagueJuiceReminderJob's own catch block calling
+        // RecordAndRethrowAsync before this listener ever sees the exception — LastFailedUtc is
+        // already newer than LastStartedUtc for this run.
+        var started = DateTimeOffset.UtcNow.AddSeconds(-1);
+        _observer.GetJobInfoAsync("NflSpreadJob").Returns(new JobRunInfo("NflSpreadJob") {
+            LastStartedUtc = started,
+            LastFailedUtc = started.AddMilliseconds(500),
+        });
+
+        await BuildListener().JobWasExecuted(_context, new JobExecutionException("boom"));
+
+        await _observer.DidNotReceive().RecordJobFailureAsync(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
     public async Task JobWasExecuted_WithoutException_DoesNotNotify()
     {
         await BuildListener().JobWasExecuted(_context, jobException: null);
 
         await _notifier.DidNotReceive().NotifyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task JobWasExecuted_WithoutException_RecordsSuccess_WhenJobDidNotAlreadySelfReport()
+    {
+        // The typical case for most job types (NflScoresJob, CfbRankingCaptureJob, ...) — they
+        // never call RecordJobSuccessAsync themselves, so without this the observer would never
+        // learn they ran at all.
+        _observer.GetJobInfoAsync("NflSpreadJob").Returns(new JobRunInfo("NflSpreadJob") { LastStartedUtc = DateTimeOffset.UtcNow });
+
+        await BuildListener().JobWasExecuted(_context, jobException: null);
+
+        await _observer.Received(1).RecordJobSuccessAsync("NflSpreadJob", null);
+    }
+
+    [Fact]
+    public async Task JobWasExecuted_WithoutException_SkipsSuccessRecording_WhenJobAlreadySelfReportedThisRun()
+    {
+        // A job like LeagueJuiceLockJob already called RecordJobSuccessAsync itself with a
+        // richer, case-specific message ("League 5 season 2026 already configured — nothing to
+        // lock") — the listener must not clobber that with a generic one.
+        var started = DateTimeOffset.UtcNow.AddSeconds(-1);
+        _observer.GetJobInfoAsync("NflSpreadJob").Returns(new JobRunInfo("NflSpreadJob") {
+            LastStartedUtc = started,
+            LastSucceededUtc = started.AddMilliseconds(500),
+        });
+
+        await BuildListener().JobWasExecuted(_context, jobException: null);
+
+        await _observer.DidNotReceive().RecordJobSuccessAsync(Arg.Any<string>(), Arg.Any<string?>());
     }
 }

--- a/Server.UnitTests/LeagueJuiceLockJobTests.cs
+++ b/Server.UnitTests/LeagueJuiceLockJobTests.cs
@@ -26,6 +26,15 @@ public class LeagueJuiceLockJobTests
         jobData.Put("LeagueId", "1");
         jobData.Put("Season", "2026");
         _context.MergedJobDataMap.Returns(jobData);
+        // /code-review: the job must record under the actual Quartz JobKey ("Juice Lock 1-2026",
+        // per TimedTriggerScheduler/LeagueJuiceScheduleSource's candidate.Identity) — not the
+        // static class name — since JobManagerController correlates observer info by
+        // jobDetail.Key.Name. Recording under nameof(LeagueJuiceLockJob) meant every league's/
+        // season's rich success message clobbered every other's under one shared key, and none
+        // of them were ever visible under the Job Manager row an admin actually looks at.
+        var jobDetail = Substitute.For<IJobDetail>();
+        jobDetail.Key.Returns(new JobKey("Juice Lock 1-2026"));
+        _context.JobDetail.Returns(jobDetail);
         _repo.GetLeagueJuiceMappingAsync(1).Returns(new List<LeagueJuiceMapping>());
     }
 
@@ -77,7 +86,7 @@ public class LeagueJuiceLockJobTests
 
         await BuildJob().Execute(_context);
 
-        await _observer.Received(1).RecordJobSuccessAsync(nameof(LeagueJuiceLockJob), Arg.Any<string>());
+        await _observer.Received(1).RecordJobSuccessAsync("Juice Lock 1-2026", Arg.Any<string>());
     }
 
     // frizat-703.2: an unhandled exception must propagate to Quartz (not be swallowed after
@@ -95,6 +104,6 @@ public class LeagueJuiceLockJobTests
         var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => BuildJob().Execute(_context));
 
         Assert.Same(boom, thrown);
-        await _observer.Received(1).RecordJobFailureAsync(nameof(LeagueJuiceLockJob), "DB unavailable");
+        await _observer.Received(1).RecordJobFailureAsync("Juice Lock 1-2026", "DB unavailable");
     }
 }

--- a/Server.UnitTests/LeagueJuiceReminderJobTests.cs
+++ b/Server.UnitTests/LeagueJuiceReminderJobTests.cs
@@ -35,6 +35,15 @@ public class LeagueJuiceReminderJobTests
         jobData.Put("LeagueId", "1");
         jobData.Put("Season", "2026");
         _context.MergedJobDataMap.Returns(jobData);
+        // /code-review: the job must record under the actual Quartz JobKey ("Juice Reminder
+        // 1-2026", per TimedTriggerScheduler/LeagueJuiceScheduleSource's candidate.Identity) —
+        // not the static class name — since JobManagerController correlates observer info by
+        // jobDetail.Key.Name. Recording under nameof(LeagueJuiceReminderJob) meant every league's/
+        // season's rich success message clobbered every other's under one shared key, and none
+        // of them were ever visible under the Job Manager row an admin actually looks at.
+        var jobDetail = Substitute.For<IJobDetail>();
+        jobDetail.Key.Returns(new JobKey("Juice Reminder 1-2026"));
+        _context.JobDetail.Returns(jobDetail);
 
         _repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, LeagueName = "Test League", OwnerUserId = "owner-1" });
         _repo.GetJuiceRemindersSentAsync().Returns(new HashSet<(int, int)>());
@@ -117,7 +126,7 @@ public class LeagueJuiceReminderJobTests
         await Assert.ThrowsAsync<InvalidOperationException>(() => BuildJob().Execute(_context));
 
         await _emailSender.DidNotReceive().SendEmailAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
-        await _observer.Received(1).RecordJobFailureAsync(nameof(LeagueJuiceReminderJob), Arg.Is<string>(m => m.Contains("no email on file")));
+        await _observer.Received(1).RecordJobFailureAsync("Juice Reminder 1-2026", Arg.Is<string>(m => m.Contains("no email on file")));
     }
 
     [Fact]
@@ -127,7 +136,7 @@ public class LeagueJuiceReminderJobTests
 
         await BuildJob().Execute(_context);
 
-        await _observer.Received(1).RecordJobSuccessAsync(nameof(LeagueJuiceReminderJob), Arg.Any<string>());
+        await _observer.Received(1).RecordJobSuccessAsync("Juice Reminder 1-2026", Arg.Any<string>());
     }
 
     // frizat-703.2: an unhandled exception must propagate to Quartz (not be swallowed after
@@ -145,6 +154,6 @@ public class LeagueJuiceReminderJobTests
         var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => BuildJob().Execute(_context));
 
         Assert.Same(boom, thrown);
-        await _observer.Received(1).RecordJobFailureAsync(nameof(LeagueJuiceReminderJob), "SMTP unavailable");
+        await _observer.Received(1).RecordJobFailureAsync("Juice Reminder 1-2026", "SMTP unavailable");
     }
 }

--- a/Server/Controllers/InvitationController.cs
+++ b/Server/Controllers/InvitationController.cs
@@ -1,6 +1,7 @@
 ﻿using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Models.Mappers;
 using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models.Data.Dtos;
 using FourPlayWebApp.Shared.Models.Email;
 using Microsoft.AspNetCore.Authorization;
@@ -12,7 +13,12 @@ namespace FourPlayWebApp.Server.Controllers;
 [Authorize(Roles = "Administrator")]
 [ApiController]
 [Route("api/invitations")]
-public class InvitationController(IInvitationService invitationService, IEmailSender<ApplicationUser> emailSenderApplication) : ControllerBase {
+public class InvitationController(
+    IInvitationService invitationService,
+    IEmailSender<ApplicationUser> emailSenderApplication,
+    UserManager<ApplicationUser> userManager,
+    ILeagueRepository leagueRepo,
+    ILeagueMembershipInviteService membershipInviteService) : ControllerBase {
     [HttpGet("all")]
     public async Task<ActionResult<List<InvitationDto>>> GetAll()
     {
@@ -28,10 +34,27 @@ public class InvitationController(IInvitationService invitationService, IEmailSe
     }
 
     [HttpPost]
-    public async Task<ActionResult<InvitationDto>> Create([FromQuery] string email, [FromQuery] string invitedByUserId, [FromQuery] int? leagueId = null, [FromQuery] string? baseUrl = null)
+    public async Task<ActionResult<LeagueInviteResultDto>> Create([FromQuery] string email, [FromQuery] string invitedByUserId, [FromQuery] int? leagueId = null, [FromQuery] string? baseUrl = null)
     {
+        // Mirrors LeagueController.InviteToLeague's existing-user check: this admin-facing
+        // "Manage Invitations" tool used to unconditionally create a registration-style email
+        // Invitation, even for an email that already has an account — the invitee never saw an
+        // email (they don't need one) and never got the in-app accept/decline banner either
+        // (no LeagueMembershipInvite was ever created), so they got nothing. Only applies when a
+        // specific league is targeted — a leagueless invite has no league to build a pending
+        // membership invite against, so it keeps its original behavior.
+        if (leagueId is int targetLeagueId) {
+            var existingUser = await userManager.FindByEmailAsync(email);
+            if (existingUser != null) {
+                if (await leagueRepo.UserExistsInLeagueAsync(existingUser.Id, targetLeagueId))
+                    return Conflict($"{email} is already a member of this league.");
+                await membershipInviteService.CreateOrReopenAsync(targetLeagueId, existingUser.Id, invitedByUserId);
+                return Ok(new LeagueInviteResultDto(email, LeagueInviteOutcome.ExistingUserInvitePending));
+            }
+        }
+
         var invitation = await invitationService.CreateInvitationAsync(email, invitedByUserId, leagueId, baseUrl);
-        return CreatedAtAction(nameof(GetAll), new { id = invitation.Id }, invitation.ToDto());
+        return Ok(new LeagueInviteResultDto(invitation.Email, LeagueInviteOutcome.NewUserInvitationSent));
     }
 
     [HttpPost("{id:int}/resend")]

--- a/Server/Controllers/InvitationController.cs
+++ b/Server/Controllers/InvitationController.cs
@@ -50,6 +50,16 @@ public class InvitationController(
         // membershipSvc directly against that controller — deferred here to avoid rewriting those
         // passing tests as a side effect of this bug fix. Keep both branches in sync until then.
         if (leagueId is int targetLeagueId && await userManager.FindByEmailAsync(email) is { } existingUser) {
+            // /code-review: without this, a stale or crafted leagueId reached CreateOrReopenAsync,
+            // which inserts a LeagueMembershipInvite with a required FK to LeagueInfo — a bad
+            // leagueId trips a DbUpdateException that CreateOrReopenAsync's catch block silently
+            // swallows (it exists only for a concurrent-duplicate-insert race), so this endpoint
+            // returned 200 OK as if the invite were created even though nothing was persisted.
+            try {
+                await leagueRepo.GetLeagueInfoAsync(targetLeagueId);
+            } catch (InvalidOperationException) {
+                return NotFound();
+            }
             if (await leagueRepo.UserExistsInLeagueAsync(existingUser.Id, targetLeagueId))
                 return Conflict($"{email} is already a member of this league.");
             await membershipInviteService.CreateOrReopenAsync(targetLeagueId, existingUser.Id, invitedByUserId);

--- a/Server/Controllers/InvitationController.cs
+++ b/Server/Controllers/InvitationController.cs
@@ -43,14 +43,17 @@ public class InvitationController(
         // (no LeagueMembershipInvite was ever created), so they got nothing. Only applies when a
         // specific league is targeted — a leagueless invite has no league to build a pending
         // membership invite against, so it keeps its original behavior.
-        if (leagueId is int targetLeagueId) {
-            var existingUser = await userManager.FindByEmailAsync(email);
-            if (existingUser != null) {
-                if (await leagueRepo.UserExistsInLeagueAsync(existingUser.Id, targetLeagueId))
-                    return Conflict($"{email} is already a member of this league.");
-                await membershipInviteService.CreateOrReopenAsync(targetLeagueId, existingUser.Id, invitedByUserId);
-                return Ok(new LeagueInviteResultDto(email, LeagueInviteOutcome.ExistingUserInvitePending));
-            }
+        // KNOWN DUPLICATION (deliberate, not an oversight): this block is near-identical to
+        // LeagueController.InviteToLeague's existing-user branch. Extracting a shared
+        // ILeagueMembershipInviteService-backed orchestration method is the right long-term fix,
+        // but LeagueController's callers (LeagueOwnershipTests.cs) mock repo/userManager/
+        // membershipSvc directly against that controller — deferred here to avoid rewriting those
+        // passing tests as a side effect of this bug fix. Keep both branches in sync until then.
+        if (leagueId is int targetLeagueId && await userManager.FindByEmailAsync(email) is { } existingUser) {
+            if (await leagueRepo.UserExistsInLeagueAsync(existingUser.Id, targetLeagueId))
+                return Conflict($"{email} is already a member of this league.");
+            await membershipInviteService.CreateOrReopenAsync(targetLeagueId, existingUser.Id, invitedByUserId);
+            return Ok(new LeagueInviteResultDto(email, LeagueInviteOutcome.ExistingUserInvitePending));
         }
 
         var invitation = await invitationService.CreateInvitationAsync(email, invitedByUserId, leagueId, baseUrl);

--- a/Server/Controllers/InvitationController.cs
+++ b/Server/Controllers/InvitationController.cs
@@ -43,27 +43,33 @@ public class InvitationController(
         // (no LeagueMembershipInvite was ever created), so they got nothing. Only applies when a
         // specific league is targeted — a leagueless invite has no league to build a pending
         // membership invite against, so it keeps its original behavior.
-        // KNOWN DUPLICATION (deliberate, not an oversight): this block is near-identical to
-        // LeagueController.InviteToLeague's existing-user branch. Extracting a shared
+        // KNOWN DUPLICATION (deliberate, not an oversight): the existing-user branch below is
+        // near-identical to LeagueController.InviteToLeague's. Extracting a shared
         // ILeagueMembershipInviteService-backed orchestration method is the right long-term fix,
         // but LeagueController's callers (LeagueOwnershipTests.cs) mock repo/userManager/
         // membershipSvc directly against that controller — deferred here to avoid rewriting those
         // passing tests as a side effect of this bug fix. Keep both branches in sync until then.
-        if (leagueId is int targetLeagueId && await userManager.FindByEmailAsync(email) is { } existingUser) {
-            // /code-review: without this, a stale or crafted leagueId reached CreateOrReopenAsync,
-            // which inserts a LeagueMembershipInvite with a required FK to LeagueInfo — a bad
-            // leagueId trips a DbUpdateException that CreateOrReopenAsync's catch block silently
-            // swallows (it exists only for a concurrent-duplicate-insert race), so this endpoint
-            // returned 200 OK as if the invite were created even though nothing was persisted.
+        if (leagueId is int targetLeagueId) {
+            // /code-review: without this, a stale or crafted leagueId reaches either
+            // CreateOrReopenAsync (which inserts a LeagueMembershipInvite with a required FK to
+            // LeagueInfo) or CreateInvitationAsync below (same FK, on Invitation) — a bad leagueId
+            // trips a DbUpdateException that both methods' catch blocks assume only ever means "a
+            // concurrent duplicate insert already happened" and mishandle, so this endpoint would
+            // report success (or crash re-reading a row that was never inserted) instead of a
+            // clean 404. Matches LeagueController.InviteToLeague's LoadOwnedLeagueAsync guard,
+            // which runs unconditionally before either of its branches for the same reason.
             try {
                 await leagueRepo.GetLeagueInfoAsync(targetLeagueId);
             } catch (InvalidOperationException) {
                 return NotFound();
             }
-            if (await leagueRepo.UserExistsInLeagueAsync(existingUser.Id, targetLeagueId))
-                return Conflict($"{email} is already a member of this league.");
-            await membershipInviteService.CreateOrReopenAsync(targetLeagueId, existingUser.Id, invitedByUserId);
-            return Ok(new LeagueInviteResultDto(email, LeagueInviteOutcome.ExistingUserInvitePending));
+
+            if (await userManager.FindByEmailAsync(email) is { } existingUser) {
+                if (await leagueRepo.UserExistsInLeagueAsync(existingUser.Id, targetLeagueId))
+                    return Conflict($"{email} is already a member of this league.");
+                await membershipInviteService.CreateOrReopenAsync(targetLeagueId, existingUser.Id, invitedByUserId);
+                return Ok(new LeagueInviteResultDto(email, LeagueInviteOutcome.ExistingUserInvitePending));
+            }
         }
 
         var invitation = await invitationService.CreateInvitationAsync(email, invitedByUserId, leagueId, baseUrl);

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -946,6 +946,9 @@ public class LeagueController(
         // Unlike a brand-new user (registering IS joining, one step), an existing user gets a
         // pending invite they must explicitly accept — no email; it surfaces as a banner on
         // their next login. See LeagueMembershipInvite.
+        // KNOWN DUPLICATION: InvitationController.Create has a near-identical existing-user
+        // branch (deliberately not extracted into a shared service yet — see its comment). Keep
+        // both in sync.
         var existingUser = await userManager.FindByEmailAsync(dto.Email);
         if (existingUser != null) {
             if (await repo.UserExistsInLeagueAsync(existingUser.Id, leagueId))

--- a/Server/Jobs/JobFailureAlertListener.cs
+++ b/Server/Jobs/JobFailureAlertListener.cs
@@ -4,24 +4,46 @@ using Quartz;
 namespace FourPlayWebApp.Server.Jobs;
 
 // frizat-703.2: registered with q.AddJobListener<JobFailureAlertListener>() and no matcher (see
-// Program.cs), so this fires for every job's failure uniformly — including jobs that let an
-// exception propagate rather than catching it themselves, since Quartz's JobRunShell still
-// reports that here as a non-null jobException. One shared mechanism instead of a notifier call
-// bolted onto each job's own catch block.
-public class JobFailureAlertListener(IJobFailureNotifier notifier) : IJobListener
+// Program.cs), so this fires for every job uniformly — including jobs that let an exception
+// propagate rather than catching it themselves, since Quartz's JobRunShell still reports that
+// here as a non-null jobException. One shared mechanism instead of a notifier call bolted onto
+// each job's own catch block.
+//
+// Also centralizes IJobObserverService start/success/failure recording for EVERY job type.
+// Originally only LeagueJuiceLockJob/LeagueJuiceReminderJob called RecordJobStartAsync/
+// RecordJobSuccessAsync/RecordAndRethrowAsync themselves — every other job (NflScoresJob,
+// CfbRankingCaptureJob, the spread jobs, ...) never appeared in the observer at all, so Job
+// Manager's "Last Succeeded"/"Last Failed" columns were permanently blank for them regardless of
+// whether the job actually ran or restarts happened. A self-reporting job's own richer,
+// case-specific message (e.g. "League 5 season 2026 already configured — nothing to lock") is
+// never clobbered: this only fills in a generic record when the job didn't already report a
+// terminal state (success or failure) for this same run.
+public class JobFailureAlertListener(IJobFailureNotifier notifier, IJobObserverService observer) : IJobListener
 {
     public string Name => nameof(JobFailureAlertListener);
 
     public Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default) =>
-        Task.CompletedTask;
+        observer.RecordJobStartAsync(context.JobDetail.Key.Name);
 
     public Task JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default) =>
         Task.CompletedTask;
 
     public async Task JobWasExecuted(IJobExecutionContext context, JobExecutionException? jobException, CancellationToken cancellationToken = default)
     {
-        if (jobException is null) return;
+        var jobName = context.JobDetail.Key.Name;
+        var info = await observer.GetJobInfoAsync(jobName);
 
-        await notifier.NotifyAsync(context.JobDetail.Key.Name, context.Trigger.Key.Name, jobException.Message, cancellationToken);
+        if (jobException is not null) {
+            if (!SelfReportedThisRun(info, info?.LastFailedUtc))
+                await observer.RecordJobFailureAsync(jobName, jobException.Message);
+            await notifier.NotifyAsync(jobName, context.Trigger.Key.Name, jobException.Message, cancellationToken);
+            return;
+        }
+
+        if (!SelfReportedThisRun(info, info?.LastSucceededUtc))
+            await observer.RecordJobSuccessAsync(jobName);
     }
+
+    private static bool SelfReportedThisRun(JobRunInfo? info, DateTimeOffset? terminalTimeUtc) =>
+        info?.LastStartedUtc is { } started && terminalTimeUtc is { } terminal && terminal > started;
 }

--- a/Server/Jobs/LeagueJuiceLockJob.cs
+++ b/Server/Jobs/LeagueJuiceLockJob.cs
@@ -12,8 +12,10 @@ namespace FourPlayWebApp.Server.Jobs;
 [DisallowConcurrentExecution]
 public class LeagueJuiceLockJob(ILeagueRepository repo, IJobObserverService observer) : IJob {
     public async Task Execute(IJobExecutionContext context) {
+        // RecordJobStartAsync is now centralized in JobFailureAlertListener.JobToBeExecuted
+        // (fires for every job type, not just this one) — calling it again here would
+        // double-count RunCount for the exact same run.
         var jobName = nameof(LeagueJuiceLockJob);
-        await observer.RecordJobStartAsync(jobName);
         try {
             var (leagueId, season) = LeagueJuiceJobData.Parse(context);
 

--- a/Server/Jobs/LeagueJuiceLockJob.cs
+++ b/Server/Jobs/LeagueJuiceLockJob.cs
@@ -15,7 +15,13 @@ public class LeagueJuiceLockJob(ILeagueRepository repo, IJobObserverService obse
         // RecordJobStartAsync is now centralized in JobFailureAlertListener.JobToBeExecuted
         // (fires for every job type, not just this one) — calling it again here would
         // double-count RunCount for the exact same run.
-        var jobName = nameof(LeagueJuiceLockJob);
+        //
+        // /code-review: must be the actual Quartz JobKey ("Juice Lock {leagueId}-{season}", per
+        // TimedTriggerScheduler/LeagueJuiceScheduleSource's candidate.Identity), not the class
+        // name — JobManagerController correlates observer info by jobDetail.Key.Name, so
+        // recording under the class name meant every league/season's message clobbered every
+        // other's under one shared key, invisible under the row an admin actually looks at.
+        var jobName = context.JobDetail.Key.Name;
         try {
             var (leagueId, season) = LeagueJuiceJobData.Parse(context);
 

--- a/Server/Jobs/LeagueJuiceReminderJob.cs
+++ b/Server/Jobs/LeagueJuiceReminderJob.cs
@@ -18,8 +18,10 @@ public class LeagueJuiceReminderJob(
     IJobObserverService observer) : IJob {
 
     public async Task Execute(IJobExecutionContext context) {
+        // RecordJobStartAsync is now centralized in JobFailureAlertListener.JobToBeExecuted
+        // (fires for every job type, not just this one) — calling it again here would
+        // double-count RunCount for the exact same run.
         var jobName = nameof(LeagueJuiceReminderJob);
-        await observer.RecordJobStartAsync(jobName);
         try {
             // /code-review: reading this in a field initializer would throw during job
             // construction — before this try block — bypassing RecordJobFailureAsync entirely and

--- a/Server/Jobs/LeagueJuiceReminderJob.cs
+++ b/Server/Jobs/LeagueJuiceReminderJob.cs
@@ -21,7 +21,13 @@ public class LeagueJuiceReminderJob(
         // RecordJobStartAsync is now centralized in JobFailureAlertListener.JobToBeExecuted
         // (fires for every job type, not just this one) — calling it again here would
         // double-count RunCount for the exact same run.
-        var jobName = nameof(LeagueJuiceReminderJob);
+        //
+        // /code-review: must be the actual Quartz JobKey ("Juice Reminder {leagueId}-{season}",
+        // per TimedTriggerScheduler/LeagueJuiceScheduleSource's candidate.Identity), not the
+        // class name — JobManagerController correlates observer info by jobDetail.Key.Name, so
+        // recording under the class name meant every league/season's message clobbered every
+        // other's under one shared key, invisible under the row an admin actually looks at.
+        var jobName = context.JobDetail.Key.Name;
         try {
             // /code-review: reading this in a field initializer would throw during job
             // construction — before this try block — bypassing RecordJobFailureAsync entirely and

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -325,18 +325,6 @@ builder.Services.AddQuartz(q => {
         .StartAt(DateBuilder.FutureDate(userManagerDelay, IntervalUnit.Second))
     );
 
-    // CFB Slate Seeder — idempotent, runs Monday 5am CST to catch new seasons. Slate-seeding only
-    // — spread-lock trigger scheduling is CfbSpreadSchedulerJob below (frizat-pxy follow-on:
-    // structurally identical to NflSpreadSchedulerJob, its own cadence, not fused into this job).
-    // Registered unconditionally (like UserManagerJob) — it only manages internal slate/date
-    // structure, never pulls live scores or spreads, so it's safe in demo mode.
-    q.ScheduleJob<CfbSlateSeederJob>(trigger => trigger
-        .WithIdentity("CFB Slate Seeder Startup")
-        .WithDescription("Seeds CFB slate dates for the current season")
-        .StartAt(DateBuilder.FutureDate(60, IntervalUnit.Second))
-    );
-    q.ScheduleCstCronJob<CfbSlateSeederJob>("CFB Slate Seeder", "Seeds CFB slate dates for the current season", "0 0 5 ? * MON");
-
     // frizat: every job below this line pulls LIVE data from ESPN and writes it into the same
     // tables DemoDataSeeder owns — NflScoresJob in particular loops currentYear-2..+1, which
     // always includes whatever season the demo seeder fictionally populates. NflScores' unique
@@ -349,6 +337,25 @@ builder.Services.AddQuartz(q => {
     // the seeder — skip all of them (both sports, symmetrically) when seeding demo data.
     if (!seedsDemoData)
     {
+        // CFB Slate Seeder — idempotent, runs Monday 5am CST to catch new seasons. Slate-seeding
+        // only — spread-lock trigger scheduling is CfbSpreadSchedulerJob below (frizat-pxy
+        // follow-on: structurally identical to NflSpreadSchedulerJob, its own cadence, not fused
+        // into this job).
+        // Was previously registered unconditionally (like UserManagerJob), on the theory that it
+        // only manages internal slate/date structure and never pulls live scores/spreads, so it
+        // was "safe" in demo mode. That was wrong: it still seeds the real *current* season's slate
+        // rows, and CfbCurrentSlateService's cross-season date-window resolver picks whichever
+        // season's window is "active" right now — once the real season's window opens, it silently
+        // shadows DemoDataSeeder's frozen demo-season data instead of falling back to it, breaking
+        // every CFB demo/e2e test that runs during that window. Moved inside this guard alongside
+        // its siblings, which exist for exactly this class of problem.
+        q.ScheduleJob<CfbSlateSeederJob>(trigger => trigger
+            .WithIdentity("CFB Slate Seeder Startup")
+            .WithDescription("Seeds CFB slate dates for the current season")
+            .StartAt(DateBuilder.FutureDate(60, IntervalUnit.Second))
+        );
+        q.ScheduleCstCronJob<CfbSlateSeederJob>("CFB Slate Seeder", "Seeds CFB slate dates for the current season", "0 0 5 ? * MON");
+
         // NFL Spreads — frizat-pxy: NflSpreadJob has no fixed trigger of its own anymore.
         // NflSpreadSchedulerJob reads NflSeasonWeekConfig.SpreadLockDatetime and registers a precise
         // one-time trigger per upcoming week, replacing the old Thursday-2pm/Christmas-Eve crons

--- a/Shared/Refit/IInvitationApi.cs
+++ b/Shared/Refit/IInvitationApi.cs
@@ -13,7 +13,7 @@ public interface IInvitationApi
     Task<List<InvitationDto>> GetByUser(string userId);
 
     [Post("/api/invitations")]
-    Task<InvitationDto> Create([Query] string email, [Query] string invitedByUserId);
+    Task<LeagueInviteResultDto> Create([Query] string email, [Query] string invitedByUserId);
 
     [Delete("/api/invitations/{id}")]
     Task Delete(int id);


### PR DESCRIPTION
## Summary

Releasing PR #294 to `main`.

**Existing-user league invites weren't notifying anyone.** Two independent bugs meant an already-registered user invited to a league (NFL or CFB) could get no notification at all — neither an email nor the in-app accept/decline banner:

- **Admin → Manage Invitations page** (`InvitationController.Create`) never checked whether the invited email already had an account. Fixed to mirror the existing-user check `LeagueController.InviteToLeague` already had.
- **Shareable "Invite Link" page** (`JoinLeaguePage`) offered only "Create an account to join" to an unauthenticated visitor — no way to log in, so an already-registered invitee not currently logged in on that browser hit a dead end. Added an "Already have an account? Log in" option that returns to the same join page after login.

**Job history was structurally broken.** Only 2 of 12 job types ever reported to `IJobObserverService`, so Job Manager's "Last Succeeded"/"Last Failed" columns were permanently blank for the rest. Centralized start/success/failure recording in the existing global `JobFailureAlertListener`. Also fixed the two jobs that *were* self-reporting — they were recording under the wrong key (static class name instead of the actual per-league/season Quartz `JobKey`), so their messages were never visible under the row Job Manager actually shows.

**Fixed a CI/demo-mode bug found while landing this PR:** `CfbSlateSeederJob` seeded real-current-season CFB slate data even when `DEMO_MODE=true`, which collided with `CfbCurrentSlateService`'s date-window resolver once the real 2026 season's week-1 window opened — silently shadowing `DemoDataSeeder`'s frozen demo data and breaking the CFB e2e specs. Moved its scheduling inside the existing `if (!seedsDemoData)` guard alongside its siblings.

**UI fixes:**
- Dark-mode background alternating while scrolling on My Leagues/Rules/Invitations/User Management/Job Manager — fixed centrally in `theme.ts`.
- Job Manager's "Show background jobs" toggle removed — it hid dynamic jobs (including Juice Reminder/Lock) by default; everything is always shown now.
- My Leagues' Invite Player/Generate Link/Add User buttons had zero gap on narrow viewports — fixed with `useFlexGap`.

## Test plan

- [x] `dotnet build` — clean (0 errors)
- [x] `dotnet test` — passing (excluding pre-existing sandbox-only failures: live ESPN network tests, Testcontainers/Docker tests)
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm run test -- --run` — passing
- [x] `npm run test:e2e -- --project=chromium` — passing
- [x] CI green on PR #294 (all 7 checks, including Demo backend e2e tests) before merge to `dev`
- [x] `DB Migrate` GitHub Action succeeded on `dev` post-merge
- [x] `/simplify` and `/code-review` run (7 review passes total across the branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2)_