### PR TITLE
fix: daily catch-up cron for CFB rankings capture

### DIFF
--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -385,6 +385,14 @@ builder.Services.AddQuartz(q => {
             .StartAt(DateBuilder.FutureDate(60, IntervalUnit.Second))
         );
         q.ScheduleCstCronJob<CfbRankingCaptureJob>("CFB Ranking Capture", "Captures CFB AP rankings as soon as each week's schedule is known", "0 0 5 ? * MON");
+        // Daily catch-up, mirroring the spread schedulers' own daily pass below: a silently-failed
+        // Monday run would otherwise leave IsLeagueEligible stale for a full week until the next
+        // Monday. Also covers CFP committee rankings, which start replacing/supplementing the AP
+        // poll from roughly week 9 on and are released Tuesdays, not Mondays — capturing daily
+        // means we don't have to know exactly which day ESPN's curatedRank field updates on. The
+        // job itself is a cheap no-op once a week's games are all final, so this costs nothing on
+        // the other six days.
+        q.ScheduleCstCronJob<CfbRankingCaptureJob>("CFB Ranking Capture Daily", "Daily catch-up pass for CFB rankings — covers a missed Monday run and CFP Tuesday releases", "0 15 6 * * ?");
 
         // CFB Spreads — mirrors NflSpreadSchedulerJob above exactly: CfbSpreadJob has no fixed trigger
         // of its own; CfbSpreadSchedulerJob reads CfbSeasonWeekConfig.SpreadLockDatetime and registers


### PR DESCRIPTION
## Summary

Follow-up from a live prod check after PR #294/#295 shipped: `CfbRankingCaptureJob` only fired on app startup + a weekly Monday cron (same cadence as `CfbSlateSeederJob`). That leaves two real gaps:

- If the Monday run fails silently (transient ESPN error, etc.), `IsLeagueEligible` data — which determines which games users can even see/pick that week — goes stale for a full week until the next Monday. `NflSpreadSchedulerJob`/`CfbSpreadSchedulerJob` already guard against this exact failure mode with their own daily catch-up crons; the ranking job didn't have one.
- CFP committee rankings start replacing/supplementing the AP poll around week 9 and are released on **Tuesdays**, not Mondays — a Monday-only cron could miss a week of CFP rank movement depending on exactly which day ESPN's `curatedRank` field updates.

## Change

Adds a daily 6:15am CST catch-up pass for `CfbRankingCaptureJob` in `Program.cs`, mirroring the existing daily cadence already used by the spread schedulers. The job already no-ops cheaply once a week's games are all final (`CfbSlateHelpers`/`CfbRankingCaptureJob` skip slates with no scheduled games left), so this costs nothing on the other six days.

## Test plan

- [x] `dotnet build` — clean (0 errors)
- [x] Verified via live Neon query against prod that CFB Week 1 rankings were in fact captured ahead of this Saturday's games (confirms the job's existing logic works correctly; this PR only widens *when* it runs, no logic change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2)_