### PR TITLE
feat: admin Changelog page

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+Notable changes to IV League, most recent first. For admins — see the version footer for the exact build SHA if you need to correlate with a specific deploy.
+
+Format: `## ` release headings and single-line `- ` bullets only — no bold, links, or multi-line/nested bullets. The admin Changelog page renders this with a small hand-rolled parser (`parseChangelog.ts`), not a full Markdown engine; anything outside this subset renders as literal syntax instead of being formatted. A test guards this file against drifting outside the subset.
+
+## 2026-09-03
+
+- Changed: NFL league platform cost is now $200 base / $20 per head (CFB unchanged at $100 / $10)
+- Removed: the Share button on the Scores page — it only ever linked to the site itself, nothing worth sharing
+- Added: a daily catch-up job for CFB rankings capture, so a missed Monday run or a Tuesday CFP release doesn't leave a week's eligibility data stale
+
+## 2026-09-02
+
+- Fixed: an already-registered user invited to a league (NFL or CFB) wasn't getting an accept/decline notification — both the admin invite page and the shareable invite-link flow were missing the existing-user check
+- Fixed: Job Manager's "Last Succeeded"/"Last Failed" columns were blank for most jobs — only 2 of 12 job types were ever reporting their status
+- Fixed: dark-mode background looked inconsistent while scrolling on My Leagues, Rules, Invitations, User Management, and Job Manager
+- Fixed: the Invite Player / Generate Invite Link / Add User buttons had no visible gap between them on narrow screens
+- Removed: Job Manager's "Show background jobs" toggle — it hid dynamic jobs (including Juice Reminder/Lock) by default

--- a/Client.React/e2e/admin.spec.ts
+++ b/Client.React/e2e/admin.spec.ts
@@ -66,6 +66,19 @@ test.describe('Admin pages (administrator role)', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Changelog
+  // -----------------------------------------------------------------------
+  test('Changelog page renders heading and at least one release', async ({ page }) => {
+    await adminAuth(page, '/admin/changelog');
+    await waitForSpinner(page);
+
+    await expect(page.getByRole('heading', { name: /^changelog$/i })).toBeVisible({ timeout: 5000 });
+    // Bundled from the real CHANGELOG.md at the repo root, not mocked — just assert a release
+    // heading shows up, without pinning to specific entry text that'll churn as the file grows.
+    await expect(page.getByRole('heading', { level: 6 }).first()).toBeVisible({ timeout: 5000 });
+  });
+
+  // -----------------------------------------------------------------------
   // My Leagues — admin-only actions (Create League / Add User / Change Owner)
   // -----------------------------------------------------------------------
   test('My Leagues — Create League button opens Create League dialog', async ({ page }) => {

--- a/Client.React/src/App.tsx
+++ b/Client.React/src/App.tsx
@@ -60,6 +60,7 @@ import AdminJobManagerPage from './pages/admin/JobManagerPage';
 import AdminUserManagementPage from './pages/admin/UserManagementPage';
 import AdminInvitationsPage from './pages/admin/InvitationsPage';
 import AdminLeagueCostsPage from './pages/admin/LeagueCostsPage';
+import AdminChangelogPage from './pages/admin/ChangelogPage';
 import LogoutPage from './pages/LogoutPage';
 import AuthPage from './pages/AuthPage';
 import RulesPage from './pages/RulesPage';
@@ -142,6 +143,15 @@ export default function App() {
           element={
             <RequireAdmin>
               <AdminLeagueCostsPage />
+            </RequireAdmin>
+          }
+        />
+        <Route
+          path="/admin/changelog"
+          caseSensitive={false}
+          element={
+            <RequireAdmin>
+              <AdminChangelogPage />
             </RequireAdmin>
           }
         />

--- a/Client.React/src/__tests__/ChangelogPage.test.tsx
+++ b/Client.React/src/__tests__/ChangelogPage.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+// The real CHANGELOG.md is bundled at build time via Vite's ?raw import — mock it here so these
+// tests don't churn every time someone adds a real entry to the file. vi.mock is hoisted, so the
+// mocked content has to be inlined per-test via vi.doMock + dynamic import rather than a shared
+// module-level page import, since ChangelogPage computes `releases` once at import time.
+const nonEmptyChangelog = `# Changelog
+
+## 2026-09-03
+
+- Changed: NFL pricing
+- Removed: Scores Share button
+
+## 2026-09-02
+
+- Fixed: existing-user invite notifications
+`;
+
+async function renderWithChangelog(raw: string) {
+  vi.resetModules();
+  vi.doMock('../../CHANGELOG.md?raw', () => ({ default: raw }));
+  const { default: AdminChangelogPage } = await import('../pages/admin/ChangelogPage');
+  render(<AdminChangelogPage />);
+}
+
+describe('AdminChangelogPage', () => {
+  it('shows each release heading with its entries', async () => {
+    await renderWithChangelog(nonEmptyChangelog);
+
+    expect(screen.getByText('2026-09-03')).toBeInTheDocument();
+    expect(screen.getByText('Changed: NFL pricing')).toBeInTheDocument();
+    expect(screen.getByText('Removed: Scores Share button')).toBeInTheDocument();
+    expect(screen.getByText('2026-09-02')).toBeInTheDocument();
+    expect(screen.getByText('Fixed: existing-user invite notifications')).toBeInTheDocument();
+  });
+
+  it('renders releases in document order, most recent first', async () => {
+    await renderWithChangelog(nonEmptyChangelog);
+
+    const headings = screen.getAllByRole('heading', { level: 6 }).map((h) => h.textContent);
+    expect(headings).toEqual(['2026-09-03', '2026-09-02']);
+  });
+
+  it('shows an empty state when the changelog has no parseable releases', async () => {
+    await renderWithChangelog('# Changelog\n\nNothing shipped yet.\n');
+
+    expect(screen.getByText(/no entries yet/i)).toBeInTheDocument();
+  });
+});

--- a/Client.React/src/__tests__/changelogFormat.test.ts
+++ b/Client.React/src/__tests__/changelogFormat.test.ts
@@ -1,0 +1,33 @@
+import changelogRaw from '../../CHANGELOG.md?raw';
+import { parseChangelog } from '../utils/parseChangelog';
+
+// Canary against the REAL CHANGELOG.md, not a mock — parseChangelog only understands `## `
+// headings and single-line `- ` bullets (see CHANGELOG.md's own format note). Anything outside
+// that subset silently renders as literal syntax or gets dropped, rather than erroring — this
+// test is what actually catches drift, since parseChangelog.test.ts only exercises synthetic
+// strings and ChangelogPage.test.tsx mocks the file entirely.
+describe('CHANGELOG.md format', () => {
+  const releases = parseChangelog(changelogRaw);
+
+  it('has at least one parsed release', () => {
+    expect(releases.length).toBeGreaterThan(0);
+  });
+
+  it('has no bold, italic, or link syntax in any entry', () => {
+    for (const release of releases) {
+      for (const entry of release.entries) {
+        expect(entry).not.toMatch(/\*\*|\[.*\]\(/);
+      }
+    }
+  });
+
+  it('has no indented continuation lines that would silently drop from a bullet', () => {
+    // A line indented under a `- ` bullet that isn't itself a new bullet/heading is a multi-line
+    // entry the parser doesn't support — it just never becomes part of any entry, so the only way
+    // to catch it is checking the raw text directly.
+    const orphanedContinuation = changelogRaw
+      .split('\n')
+      .some((line) => /^\s+\S/.test(line) && !/^\s*-\s+/.test(line));
+    expect(orphanedContinuation).toBe(false);
+  });
+});

--- a/Client.React/src/__tests__/parseChangelog.test.ts
+++ b/Client.React/src/__tests__/parseChangelog.test.ts
@@ -1,0 +1,69 @@
+import { parseChangelog } from '../utils/parseChangelog';
+
+describe('parseChangelog', () => {
+  it('groups bullet entries under their release heading', () => {
+    const raw = `# Changelog
+
+## 2026-09-03
+
+- Changed: NFL pricing
+- Removed: Scores Share button
+`;
+
+    expect(parseChangelog(raw)).toEqual([
+      { heading: '2026-09-03', entries: ['Changed: NFL pricing', 'Removed: Scores Share button'] },
+    ]);
+  });
+
+  it('returns multiple releases in document order (most recent first, matching the file)', () => {
+    const raw = `# Changelog
+
+## 2026-09-03
+
+- Newest entry
+
+## 2026-09-02
+
+- Older entry
+`;
+
+    expect(parseChangelog(raw)).toEqual([
+      { heading: '2026-09-03', entries: ['Newest entry'] },
+      { heading: '2026-09-02', entries: ['Older entry'] },
+    ]);
+  });
+
+  it('ignores the top-level title and blank lines', () => {
+    const raw = `# Changelog
+
+Some intro text that isn't a bullet.
+
+## 2026-09-03
+
+- Only bullets become entries
+`;
+
+    expect(parseChangelog(raw)).toEqual([
+      { heading: '2026-09-03', entries: ['Only bullets become entries'] },
+    ]);
+  });
+
+  it('returns an empty array for a document with no release headings', () => {
+    expect(parseChangelog('# Changelog\n')).toEqual([]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(parseChangelog('')).toEqual([]);
+  });
+
+  it('skips a release heading with no bullets under it', () => {
+    const raw = `## 2026-09-03
+
+## 2026-09-02
+
+- Has an entry
+`;
+
+    expect(parseChangelog(raw)).toEqual([{ heading: '2026-09-02', entries: ['Has an entry'] }]);
+  });
+});

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -39,6 +39,7 @@ import WorkIcon from '@mui/icons-material/Work';
 import PersonIcon from '@mui/icons-material/Person';
 import MailIcon from '@mui/icons-material/Mail';
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
+import HistoryIcon from '@mui/icons-material/History';
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import { useSession } from '../services/session';
 import { useAuth } from '../services/auth';
@@ -414,6 +415,17 @@ export default function AppLayout() {
                         <AttachMoneyIcon sx={{ fontSize: 20 }} />
                       </ListItemIcon>
                       <ListItemText primary="League Costs" />
+                    </ListItemButton>
+                    <ListItemButton
+                      component={NavLink}
+                      to="/admin/changelog"
+                      sx={adminNavItemSx}
+                      onClick={() => handleNavClick('/admin/changelog')}
+                    >
+                      <ListItemIcon sx={{ minWidth: 36 }}>
+                        <HistoryIcon sx={{ fontSize: 20 }} />
+                      </ListItemIcon>
+                      <ListItemText primary="Changelog" />
                     </ListItemButton>
                   </List>
                 </Collapse>

--- a/Client.React/src/pages/admin/ChangelogPage.tsx
+++ b/Client.React/src/pages/admin/ChangelogPage.tsx
@@ -1,0 +1,44 @@
+import { Box, List, ListItem, ListItemText, Paper, Stack, Typography } from '@mui/material';
+import PageHeader from '../../components/PageHeader';
+import changelogRaw from '../../../CHANGELOG.md?raw';
+import { parseChangelog } from '../../utils/parseChangelog';
+
+// Bundled at build time (Vite ?raw import) — always exactly what shipped in this deploy, no
+// backend endpoint or extra request needed. See Client.React/CHANGELOG.md for the source.
+// Deliberately inside Client.React/ (not the repo root) — that's Vercel's configured build root
+// (vercel.json lives here), and a file outside it isn't guaranteed to be available at build time.
+const releases = parseChangelog(changelogRaw);
+
+export default function AdminChangelogPage() {
+  return (
+    <Box>
+      <PageHeader title="Changelog" />
+
+      {releases.length === 0 && (
+        <Typography color="text.secondary" sx={{ textAlign: 'center', mt: 4 }}>
+          No entries yet.
+        </Typography>
+      )}
+
+      <Stack spacing={3}>
+        {releases.map((release) => (
+          <Paper key={release.heading} sx={{ p: 2 }}>
+            <Typography variant="h6" component="h6" gutterBottom>
+              {release.heading}
+            </Typography>
+            <List dense disablePadding>
+              {release.entries.map((entry, i) => (
+                // Index, not entry text, as the key — a hand-written changelog can plausibly
+                // repeat a bullet's wording within one release; order is stable and entries are
+                // never independently reordered, so index is safe here.
+                <ListItem key={i} disablePadding sx={{ display: 'list-item', listStyleType: 'disc', ml: 3 }}>
+                  <ListItemText primary={entry} />
+                </ListItem>
+              ))}
+            </List>
+          </Paper>
+        ))}
+      </Stack>
+    </Box>
+  );
+}

--- a/Client.React/src/utils/parseChangelog.ts
+++ b/Client.React/src/utils/parseChangelog.ts
@@ -1,0 +1,27 @@
+export interface ChangelogRelease {
+  heading: string;
+  entries: string[];
+}
+
+// Parses the small subset of Markdown CHANGELOG.md actually uses: `## ` release headings and
+// `- ` bullets under them. Not a general Markdown parser — the changelog's own format is
+// something we control, so there's no need for a full CommonMark dependency just to render it.
+export function parseChangelog(raw: string): ChangelogRelease[] {
+  const releases: ChangelogRelease[] = [];
+  let current: ChangelogRelease | null = null;
+
+  for (const line of raw.split('\n')) {
+    const heading = line.match(/^##\s+(.+)/);
+    if (heading) {
+      current = { heading: heading[1].trim(), entries: [] };
+      releases.push(current);
+      continue;
+    }
+    const bullet = line.match(/^-\s+(.+)/);
+    if (bullet && current) {
+      current.entries.push(bullet[1].trim());
+    }
+  }
+
+  return releases.filter((r) => r.entries.length > 0);
+}


### PR DESCRIPTION
## Summary

Adds an admin-only Changelog page at `/admin/changelog`, alongside Job Manager and League Costs.

- `Client.React/CHANGELOG.md` — hand-written release notes, "Keep a Changelog"-ish format (`## ` release headings + `- ` bullets). Lives inside `Client.React/` (not the repo root) — that's Vercel's configured build root (`vercel.json` lives there too), and a file outside it isn't guaranteed to be available at Vercel's build step.
- `parseChangelog.ts` — a small parser for just that subset (headings + single-line bullets), not a full Markdown engine. No markdown dependency exists in this project, and the file's format is entirely self-controlled, so a real parser would be over-engineering for what's rendered.
- `ChangelogPage.tsx` — bundled at build time via a Vite `?raw` import, so there's no backend endpoint and the page always reflects exactly what's deployed.
- A canary test (`changelogFormat.test.ts`) runs the parser against the *real* file and fails if it ever drifts outside the supported subset (bold, links, multi-line bullets), instead of silently rendering broken syntax to an admin.

## Test plan

- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm run test -- --run` — 535/535 passing (parser unit tests, page render tests including an empty-state case, and the real-file canary)
- [x] `npm run test:e2e -- --project=chromium` — full admin.spec.ts suite (10 tests) passing, including the new Changelog smoke test, run twice (once before moving CHANGELOG.md into `Client.React/`, once after)
- [x] `npm run build` — a real production build resolves the `?raw` import cleanly
- [x] `dotnet test` — full backend suite unaffected (no backend files touched)
- [x] `/simplify` — 2-agent parallel review; applied both real findings (React key using bullet text → index-based key; added the canary test + a format-contract note in CHANGELOG.md itself, since nothing previously enforced the parser's supported subset going forward)
- [x] `/code-review` — one real finding (CHANGELOG.md at the repo root sat outside Vercel's build root, risking the whole site's deploy on an unverifiable Vercel project setting) — fixed by moving the file inside `Client.React/` and re-verified via a real `vite build` and a fresh e2e run against the new location; one test-coverage finding (empty-state page test) — fixed; one pre-existing gap (no admin nav items, including this new one, have a role-visibility unit test) — left as-is, out of scope for this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2)_