### PR TITLE
Fix background retiling every viewport height on long pages

### DIFF
--- a/.claude/skills/style-guide/SKILL.md
+++ b/.claude/skills/style-guide/SKILL.md
@@ -66,6 +66,45 @@ reads poorly somewhere:
   ```
   See `GameCard.tsx`'s `lockedFillSx` for the live implementation.
 
+## Page background gradient (`global.css` `body`) — three bugs, one subsystem
+
+The site background — two decorative radial highlights plus a `linear-gradient(180deg, var(--bg-1), var(--bg-2))`
+— has caused the "background looks inconsistent while scrolling" report **three separate times**
+(2026-09-02, 09-03, 09-04), each a genuinely different bug in the same area. Read this before
+touching `global.css`'s `body` rule, `theme.ts`'s `MuiPaper`/`MuiCard` overrides, or the
+`--bg-1`/`--bg-2`/`background.paper` color trio, so the next report doesn't require re-deriving
+all three from scratch:
+
+1. **Dark-mode elevation overlay** (theme.ts `MuiPaper` styleOverrides). MUI bakes a translucent
+   white gradient onto elevated (non-`outlined`) dark-mode `Paper`/`Card` as a stand-in for a drop
+   shadow — an outer elevated `Card` wrapping inner `Paper variant="outlined"` sections rendered
+   visibly lighter than them. Fixed via `backgroundImage: isDark ? 'none' : undefined` on
+   `MuiPaper`'s root override (cascades to `Card` too, since `Card` extends `Paper` — don't add a
+   separate `MuiCard` override for this).
+2. **`--bg-2` / `background.paper` color collision.** These are two independently-maintained color
+   systems (`global.css` CSS custom properties vs. `theme.ts`'s MUI palette) with no shared source
+   of truth. They drifted into the exact same hex value once, so cards near the bottom of the page
+   gradient (where it settles at `--bg-2`) became invisible against the page. **Never let `--bg-2`
+   (dark or light) equal `theme.ts`'s `background.paper` for that mode** — keep a visible gap
+   between them, verified by rendering a page long enough to actually reach the gradient's bottom.
+3. **Background retiling every viewport height** (the deep one — root cause of most reports,
+   including making bug 2 look worse than it was). `html, body { height: 100% }` pins `body`'s own
+   box to exactly `100vh` even though real page content scrolls far past that. With no
+   `background-repeat` set (CSS default: `repeat`), every layer — both radial highlights included —
+   retiled every exact `100vh` down the page: a real seam at every tile boundary, invisible on any
+   page shorter than one screen (which is why a quick check on a short page always looked "fixed").
+   Worse on mobile, where a shorter viewport means more tile boundaries fit in a normal scroll, and
+   the two asymmetric radial highlights (anchored top-left vs. top-right) re-draw at each one and
+   visibly drift apart. Fixed by giving `body` a `background-color: var(--bg-2)` base layer (so
+   there's never a gap, seam-free by construction since it matches the gradient's own end color)
+   plus `background-image` holding the gradients with `background-repeat: no-repeat` and
+   `background-size: 100% 100vh`, so they render exactly once at the top as originally intended.
+
+**Before shipping any future fix in this area**: render (screenshot or pixel-sample) a page long
+enough to scroll past one full viewport, in both themes — a short page or a single-viewport
+screenshot cannot catch any of these three. `python3`/`PIL` pixel-sampling a vertical strip outside
+any card, looking for a sudden channel jump, is the fastest way to confirm a seam is really gone.
+
 ## Layout: numeric columns need explicit centering
 
 A fixed-width column showing numbers of varying digit width (e.g. a spread like `-3.5` vs

--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to IV League, most recent first. For admins — see the version 
 
 Format: `## ` release headings and single-line `- ` bullets only — no bold, links, or multi-line/nested bullets. The admin Changelog page renders this with a small hand-rolled parser (`parseChangelog.ts`), not a full Markdown engine; anything outside this subset renders as literal syntax instead of being formatted. A test guards this file against drifting outside the subset.
 
+## 2026-09-04
+
+- Fixed: the page background retiled every screen-height down any page taller than one viewport (Rules, Changelog, and others), creating a visible seam every scroll — root cause of the repeated "background looks inconsistent" reports; fixed once at the CSS source instead of per-page
+
 ## 2026-09-03
 
 - Fixed: CFB Picks and Scores pages showed the raw Vegas spread with no league juice (tease) applied, unlike NFL — both sports now share the same spread-plus-juice calculator

--- a/Client.React/src/app/global.css
+++ b/Client.React/src/app/global.css
@@ -48,18 +48,37 @@ body {
   margin: 0;
   font-family: "Space Grotesk", "Segoe UI", system-ui, sans-serif;
   color: var(--ink-1);
-  background: radial-gradient(80% 50% at 10% -10%, rgba(203, 213, 245, 0.25), transparent 60%),
+  /* `html, body { height: 100% }` above pins body's own box to exactly one viewport tall (100vh)
+     even though its content grows the page far past that — html/body backgrounds are painted
+     across the whole scrollable canvas per spec, but their SIZING/repeat area is still that
+     nominal 100vh box. With no background-repeat set (default: repeat), every layer here —
+     including the two decorative radial highlights — retiled every exact 900px/one-viewport-
+     height down the page: a real, visible seam at every tile boundary on any page taller than
+     one screen (Rules, Changelog, My Leagues, ...). This is the actual root cause behind every
+     "background looks inconsistent while scrolling" report so far, including the elevation-
+     overlay and bg-2/card-color-collision fixes elsewhere in this file/theme.ts — those were
+     each real too, but this is the one that made it happen on every long page, repeatedly.
+     Fix: background-color carries the flat color for anything below the first viewport (it
+     matches --bg-2, the gradient's own bottom stop, so the seam is invisible even where the
+     gradient does end); background-image holds the decorative layers, explicitly sized to one
+     viewport and never repeated, so they only ever render once, at the top, as originally
+     intended — not deliberately tiled and never in any later loop */
+  background-color: var(--bg-2);
+  background-image: radial-gradient(80% 50% at 10% -10%, rgba(203, 213, 245, 0.25), transparent 60%),
     radial-gradient(70% 45% at 90% -20%, rgba(253, 230, 138, 0.1), transparent 55%),
     linear-gradient(180deg, var(--bg-1), var(--bg-2));
+  background-repeat: no-repeat;
+  background-size: 100% 100vh;
   min-height: 100vh;
   -webkit-font-smoothing: antialiased;
   -webkit-touch-callout: none;
   -webkit-tap-highlight-color: transparent;
-  transition: background 0.3s ease, color 0.3s ease;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 [data-theme='dark'] body {
-  background: radial-gradient(80% 50% at 10% -10%, rgba(30, 58, 95, 0.5), transparent 60%),
+  background-color: var(--bg-2);
+  background-image: radial-gradient(80% 50% at 10% -10%, rgba(30, 58, 95, 0.5), transparent 60%),
     radial-gradient(70% 45% at 90% -20%, rgba(253, 230, 138, 0.04), transparent 55%),
     linear-gradient(180deg, var(--bg-1), var(--bg-2));
 }


### PR DESCRIPTION
## Summary

Root-cause fix for the recurring "background looks inconsistent while scrolling" report — this time seen on the Dashboard and (again) the Rules page.

- `html, body { height: 100% }` pins `body`'s own box to exactly one viewport tall, even though page content grows far past that on any page longer than one screen.
- With no `background-repeat` set (default: `repeat`), every layer of `body`'s decorative background — including the two radial highlights — retiled every exact `100vh` down the page.
- Confirmed via headless-browser screenshots + pixel sampling on the Rules page (2965px tall): a real seam at y=900, y=1800, y=2700 — exactly one viewport apart, all the way down. Not reproducible on any page shorter than one screen, which is why it kept resurfacing only on long pages (Rules, Changelog, My Leagues, ...) rather than getting caught by a quick look at a short one — and why the two prior partial fixes (dark-mode Paper/Card elevation overlay from 2026-09-02, the `--bg-2`/card-color collision from 2026-09-03) each helped without actually closing this out.

**Fix**: `background-color` now carries the flat fallback color below the first viewport (matches `--bg-2`, the gradient's own bottom stop, so there's no visible seam even at the gradient's natural edge); `background-image` holds the decorative layers, explicitly sized to one viewport with `background-repeat: no-repeat`, so they render exactly once, at the top, as originally intended.

## Test plan

- [x] Headless-browser screenshots (dark + light, Dashboard + Rules, desktop width) with pixel-level seam detection before/after — confirmed zero seams after the fix, in both themes, on both a short page (Dashboard) and a long one (Rules, ~3000px)
- [x] `npm run test -- --run` (558 tests) — all green
- [x] `Client.React/CHANGELOG.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2)_