### PR TITLE
dev → main: nitpicks (leaderboard/season-floor/PWA/rankings) + background-retiling fix

### DIFF
--- a/.claude/skills/style-guide/SKILL.md
+++ b/.claude/skills/style-guide/SKILL.md
@@ -66,6 +66,45 @@ reads poorly somewhere:
   ```
   See `GameCard.tsx`'s `lockedFillSx` for the live implementation.
 
+## Page background gradient (`global.css` `body`) — three bugs, one subsystem
+
+The site background — two decorative radial highlights plus a `linear-gradient(180deg, var(--bg-1), var(--bg-2))`
+— has caused the "background looks inconsistent while scrolling" report **three separate times**
+(2026-09-02, 09-03, 09-04), each a genuinely different bug in the same area. Read this before
+touching `global.css`'s `body` rule, `theme.ts`'s `MuiPaper`/`MuiCard` overrides, or the
+`--bg-1`/`--bg-2`/`background.paper` color trio, so the next report doesn't require re-deriving
+all three from scratch:
+
+1. **Dark-mode elevation overlay** (theme.ts `MuiPaper` styleOverrides). MUI bakes a translucent
+   white gradient onto elevated (non-`outlined`) dark-mode `Paper`/`Card` as a stand-in for a drop
+   shadow — an outer elevated `Card` wrapping inner `Paper variant="outlined"` sections rendered
+   visibly lighter than them. Fixed via `backgroundImage: isDark ? 'none' : undefined` on
+   `MuiPaper`'s root override (cascades to `Card` too, since `Card` extends `Paper` — don't add a
+   separate `MuiCard` override for this).
+2. **`--bg-2` / `background.paper` color collision.** These are two independently-maintained color
+   systems (`global.css` CSS custom properties vs. `theme.ts`'s MUI palette) with no shared source
+   of truth. They drifted into the exact same hex value once, so cards near the bottom of the page
+   gradient (where it settles at `--bg-2`) became invisible against the page. **Never let `--bg-2`
+   (dark or light) equal `theme.ts`'s `background.paper` for that mode** — keep a visible gap
+   between them, verified by rendering a page long enough to actually reach the gradient's bottom.
+3. **Background retiling every viewport height** (the deep one — root cause of most reports,
+   including making bug 2 look worse than it was). `html, body { height: 100% }` pins `body`'s own
+   box to exactly `100vh` even though real page content scrolls far past that. With no
+   `background-repeat` set (CSS default: `repeat`), every layer — both radial highlights included —
+   retiled every exact `100vh` down the page: a real seam at every tile boundary, invisible on any
+   page shorter than one screen (which is why a quick check on a short page always looked "fixed").
+   Worse on mobile, where a shorter viewport means more tile boundaries fit in a normal scroll, and
+   the two asymmetric radial highlights (anchored top-left vs. top-right) re-draw at each one and
+   visibly drift apart. Fixed by giving `body` a `background-color: var(--bg-2)` base layer (so
+   there's never a gap, seam-free by construction since it matches the gradient's own end color)
+   plus `background-image` holding the gradients with `background-repeat: no-repeat` and
+   `background-size: 100% 100vh`, so they render exactly once at the top as originally intended.
+
+**Before shipping any future fix in this area**: render (screenshot or pixel-sample) a page long
+enough to scroll past one full viewport, in both themes — a short page or a single-viewport
+screenshot cannot catch any of these three. `python3`/`PIL` pixel-sampling a vertical strip outside
+any card, looking for a sudden channel jump, is the fastest way to confirm a seam is really gone.
+
 ## Layout: numeric columns need explicit centering
 
 A fixed-width column showing numbers of varying digit width (e.g. a spread like `-3.5` vs

--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to IV League, most recent first. For admins — see the version 
 
 Format: `## ` release headings and single-line `- ` bullets only — no bold, links, or multi-line/nested bullets. The admin Changelog page renders this with a small hand-rolled parser (`parseChangelog.ts`), not a full Markdown engine; anything outside this subset renders as literal syntax instead of being formatted. A test guards this file against drifting outside the subset.
 
+## 2026-09-04
+
+- Fixed: the page background retiled every screen-height down any page taller than one viewport (Rules, Changelog, and others), creating a visible seam every scroll — root cause of the repeated "background looks inconsistent" reports; fixed once at the CSS source instead of per-page
+
 ## 2026-09-03
 
 - Fixed: CFB Picks and Scores pages showed the raw Vegas spread with no league juice (tease) applied, unlike NFL — both sports now share the same spread-plus-juice calculator

--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -19,6 +19,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 - Fixed: the season selector on Picks, Scores, and Leaderboard offered years before a league had even started (e.g. a brand-new league showing 2020) — it's now bounded by that league's own earliest configured season
 - Fixed: CFB AP Top 25 rankings could be stored more than once per team per week — now one row per team per week, as intended
 - Changed: tapping "Switch to CFB/NFL" from an installed home-screen app now shows it will open in the regular browser, since each sport is a separate installed app on iOS
+- Fixed: in dark mode, cards could blend almost invisibly into the page background near the bottom of a long page (most visible on the Changelog page) because the page background's own color matched card backgrounds exactly — they're now always visibly distinct
 
 ## 2026-09-02
 

--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -15,6 +15,10 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 - Changed: NFL league platform cost is now $200 base / $20 per head (CFB unchanged at $100 / $10)
 - Removed: the Share button on the Scores page — it only ever linked to the site itself, nothing worth sharing
 - Added: a daily catch-up job for CFB rankings capture, so a missed Monday run or a Tuesday CFP release doesn't leave a week's eligibility data stale
+- Fixed: the CFB leaderboard showed every remaining week of an in-progress season as a missed pick instead of stopping at the current week, matching NFL's behavior
+- Fixed: the season selector on Picks, Scores, and Leaderboard offered years before a league had even started (e.g. a brand-new league showing 2020) — it's now bounded by that league's own earliest configured season
+- Fixed: CFB AP Top 25 rankings could be stored more than once per team per week — now one row per team per week, as intended
+- Changed: tapping "Switch to CFB/NFL" from an installed home-screen app now shows it will open in the regular browser, since each sport is a separate installed app on iOS
 
 ## 2026-09-02
 

--- a/Client.React/e2e/helpers/cfbRoutes.ts
+++ b/Client.React/e2e/helpers/cfbRoutes.ts
@@ -227,6 +227,14 @@ export async function setupCfbRoutes(page: Page, options: SetupCfbRoutesOptions 
       return;
     }
 
+    // useLeagueMinSeason (Picks/Scores/Leaderboard season selectors) reads this on every page —
+    // empty history so it falls back to cfbAdapter's own sport-wide minSeason, same as before
+    // that hook existed, rather than falling through to a real (nonexistent-in-CI) backend.
+    if (url.match(/\/api\/league\/\d+\/juice$/) && method === 'GET') {
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+      return;
+    }
+
     // ── Invite link / misc league bits some layouts probe on every page ─────
     if (url.match(/\/api\/league\/\d+\/invite-link$/) && method === 'GET') {
       void route.fulfill({ status: 404 });

--- a/Client.React/e2e/helpers/routes.ts
+++ b/Client.React/e2e/helpers/routes.ts
@@ -402,9 +402,15 @@ export async function setupRoutes(page: Page, options: SetupRoutesOptions = {}):
     }
 
     const mockJuiceMapping = { id: 1, leagueId: TEST_LEAGUE_ID, season: TEST_SEASON, juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5 };
+    // useLeagueMinSeason (Picks/Scores/Leaderboard season selectors) reads this same list
+    // endpoint and floors the selector at the earliest season returned — include one matching
+    // nflAdapter's own sport-wide default (2020) so existing e2e specs that navigate a few
+    // seasons back keep working, on top of the single current-season mapping other tests assert
+    // on (leaguePortal.spec.ts's juice-values test).
+    const mockJuiceMappingHistory = [mockJuiceMapping, { ...mockJuiceMapping, id: 0, season: 2020 }];
 
     if (url.match(/\/api\/league\/\d+\/juice$/) && method === 'GET') {
-      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([mockJuiceMapping]) });
+      void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockJuiceMappingHistory) });
       return;
     }
 

--- a/Client.React/src/__tests__/leaderboard.test.tsx
+++ b/Client.React/src/__tests__/leaderboard.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { alpha, ThemeProvider } from '@mui/material';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import LeaderboardPage from '../pages/LeaderboardPage';
 import { vi } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { createLeaderboardEntry, createLeaderboardWeekResult } from '../test/fixtures';
+import { createLeaderboardEntry, createLeaderboardWeekResult, mockLeagueJuiceEmpty } from '../test/fixtures';
 import type { SportAdapter } from '../services/sportAdapter';
 import { createAppTheme } from '../app/theme';
 
@@ -46,11 +47,7 @@ beforeEach(() => {
     id: 1, leagueId: 1, leagueName: 'Demo League', season: 2023,
     juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, dateCreated: '2023-01-01T00:00:00Z',
   });
-  // Default: no juice-mapping history returned, so useLeagueMinSeason falls back to
-  // adapter.weekSelectorConfig.minSeason — every pre-existing test in this file was written
-  // against that sport-wide default, not any particular league's own history.
-  mockedGetLeagueJuice.mockReset();
-  mockedGetLeagueJuice.mockResolvedValue([]);
+  mockLeagueJuiceEmpty(mockedGetLeagueJuice);
 });
 
 const mockAdapter: SportAdapter = {
@@ -67,16 +64,24 @@ const mockAdapter: SportAdapter = {
 };
 
 function renderPage(mode: 'light' | 'dark' = 'light') {
-  return render(
-    <ThemeProvider theme={createAppTheme(mode)}>
-      <MemoryRouter initialEntries={['/leaderboard']}>
-        <Routes>
-          <Route path="/leaderboard" element={<LeaderboardPage adapter={mockAdapter} />} />
-          <Route path="/leaguepicker" element={<div>League Picker</div>} />
-        </Routes>
-      </MemoryRouter>
-    </ThemeProvider>
-  );
+  // useLeagueMinSeason (via LeaderboardPage) now goes through React Query — a fresh client per
+  // render so cached ['leagueJuice', leagueId] results never leak between tests.
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return {
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={createAppTheme(mode)}>
+          <MemoryRouter initialEntries={['/leaderboard']}>
+            <Routes>
+              <Route path="/leaderboard" element={<LeaderboardPage adapter={mockAdapter} />} />
+              <Route path="/leaguepicker" element={<div>League Picker</div>} />
+            </Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </QueryClientProvider>
+    ),
+    queryClient,
+  };
 }
 
 describe('LeaderboardPage', () => {
@@ -291,7 +296,7 @@ describe('LeaderboardPage — season selector', () => {
     mockedGetLeaderboard.mockResolvedValueOnce([
       createLeaderboardEntry({ userId: '123', userName: 'LeagueOneUser', rank: '1', total: 5, weekResults: [] }),
     ]);
-    const { rerender } = renderPage();
+    const { rerender, queryClient } = renderPage();
     await screen.findByText('LeagueOneUser');
 
     let resolveLeagueTwo!: (value: ReturnType<typeof createLeaderboardEntry>[]) => void;
@@ -299,14 +304,16 @@ describe('LeaderboardPage — season selector', () => {
 
     sessionState.currentLeague = 2;
     rerender(
-      <ThemeProvider theme={createAppTheme('light')}>
-        <MemoryRouter initialEntries={['/leaderboard']}>
-          <Routes>
-            <Route path="/leaderboard" element={<LeaderboardPage adapter={mockAdapter} />} />
-            <Route path="/leaguepicker" element={<div>League Picker</div>} />
-          </Routes>
-        </MemoryRouter>
-      </ThemeProvider>,
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={createAppTheme('light')}>
+          <MemoryRouter initialEntries={['/leaderboard']}>
+            <Routes>
+              <Route path="/leaderboard" element={<LeaderboardPage adapter={mockAdapter} />} />
+              <Route path="/leaguepicker" element={<div>League Picker</div>} />
+            </Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </QueryClientProvider>,
     );
 
     // The old league's data must not still be on screen while the new league loads.
@@ -325,20 +332,22 @@ describe('LeaderboardPage — season selector', () => {
     mockedGetLeaderboard.mockResolvedValueOnce([
       createLeaderboardEntry({ userId: '1', userName: 'LeagueOneUser', rank: '1', total: 1, weekResults: [] }),
     ]);
-    const { rerender } = renderPage();
+    const { rerender, queryClient } = renderPage();
     await screen.findByText('LeagueOneUser');
 
     const rerenderWithLeague = (leagueId: number) => {
       sessionState.currentLeague = leagueId;
       rerender(
-        <ThemeProvider theme={createAppTheme('light')}>
-          <MemoryRouter initialEntries={['/leaderboard']}>
-            <Routes>
-              <Route path="/leaderboard" element={<LeaderboardPage adapter={mockAdapter} />} />
-              <Route path="/leaguepicker" element={<div>League Picker</div>} />
-            </Routes>
-          </MemoryRouter>
-        </ThemeProvider>,
+        <QueryClientProvider client={queryClient}>
+          <ThemeProvider theme={createAppTheme('light')}>
+            <MemoryRouter initialEntries={['/leaderboard']}>
+              <Routes>
+                <Route path="/leaderboard" element={<LeaderboardPage adapter={mockAdapter} />} />
+                <Route path="/leaguepicker" element={<div>League Picker</div>} />
+              </Routes>
+            </MemoryRouter>
+          </ThemeProvider>
+        </QueryClientProvider>,
       );
     };
 

--- a/Client.React/src/__tests__/leaderboard.test.tsx
+++ b/Client.React/src/__tests__/leaderboard.test.tsx
@@ -28,13 +28,14 @@ const sessionState = {
 vi.mock('../services/session', () => ({ useSession: () => sessionState }));
 vi.mock('../services/auth', () => ({ useAuth: () => ({ user: { userId: '123', name: 'TestUser', claims: [] } }) }));
 vi.mock('../api/leaderboard', () => ({ getLeaderboard: vi.fn() }));
-vi.mock('../api/league', () => ({ getLeagueJuiceForSeason: vi.fn() }));
+vi.mock('../api/league', () => ({ getLeagueJuiceForSeason: vi.fn(), getLeagueJuice: vi.fn() }));
 
 import { getLeaderboard } from '../api/leaderboard';
-import { getLeagueJuiceForSeason } from '../api/league';
+import { getLeagueJuiceForSeason, getLeagueJuice } from '../api/league';
 
 const mockedGetLeaderboard = vi.mocked(getLeaderboard);
 const mockedGetLeagueJuiceForSeason = vi.mocked(getLeagueJuiceForSeason);
+const mockedGetLeagueJuice = vi.mocked(getLeagueJuice);
 
 // frizat-ugs: every existing test in this file exercises a season whose Juice IS configured —
 // default the mock to "configured" globally so only the new not-configured tests need to
@@ -45,6 +46,11 @@ beforeEach(() => {
     id: 1, leagueId: 1, leagueName: 'Demo League', season: 2023,
     juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, dateCreated: '2023-01-01T00:00:00Z',
   });
+  // Default: no juice-mapping history returned, so useLeagueMinSeason falls back to
+  // adapter.weekSelectorConfig.minSeason — every pre-existing test in this file was written
+  // against that sport-wide default, not any particular league's own history.
+  mockedGetLeagueJuice.mockReset();
+  mockedGetLeagueJuice.mockResolvedValue([]);
 });
 
 const mockAdapter: SportAdapter = {
@@ -219,7 +225,7 @@ describe('LeaderboardPage — season selector', () => {
     expect(screen.getByText('2021 Season')).toBeInTheDocument();
   });
 
-  it('offers every season from adapter.weekSelectorConfig.minSeason through the current season', async () => {
+  it('offers every season from adapter.weekSelectorConfig.minSeason through the current season, when the league has no juice history', async () => {
     renderPage();
     await screen.findByRole('table');
 
@@ -228,6 +234,26 @@ describe('LeaderboardPage — season selector', () => {
     expect(screen.getByRole('option', { name: '2020 Season' })).toBeInTheDocument(); // mockAdapter.weekSelectorConfig.minSeason
     expect(screen.queryByRole('option', { name: '2019 Season' })).not.toBeInTheDocument();
     expect(screen.queryByRole('option', { name: '2024 Season' })).not.toBeInTheDocument();
+  });
+
+  it('floors the season range at the league\'s own earliest juice-mapping season, not the sport-wide default', async () => {
+    // frizat nitpick: a brand-new league (e.g. "OG FourPlayaz" on NFL, "CFB Beta Testers" on CFB)
+    // showed years before it ever existed, because the selector's floor was a hardcoded per-sport
+    // constant instead of that league's own history. One shared hook (useLeagueMinSeason) fixes
+    // both sports identically.
+    mockedGetLeagueJuice.mockResolvedValue([
+      { id: 1, leagueId: 1, leagueName: 'Demo League', season: 2022, juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, dateCreated: '2022-01-01T00:00:00Z' },
+      { id: 2, leagueId: 1, leagueName: 'Demo League', season: 2023, juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, dateCreated: '2023-01-01T00:00:00Z' },
+    ]);
+
+    renderPage();
+    await screen.findByRole('table');
+
+    await userEvent.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('option', { name: '2023 Season' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: '2022 Season' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: '2021 Season' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: '2020 Season' })).not.toBeInTheDocument(); // sport-wide default, below the league's own floor
   });
 
   it('disables the season selector while a season change is loading, preventing overlapping requests', async () => {

--- a/Client.React/src/__tests__/picks.test.tsx
+++ b/Client.React/src/__tests__/picks.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import PicksPage from '../pages/PicksPage';
 import { createNflAdapter } from '../services/nflAdapter';
-import { createCompetition, createCurrentWeek, createPick, createScores, createSpreadResponse } from '../test/fixtures';
+import { createCompetition, createCurrentWeek, createPick, createScores, createSpreadResponse, mockLeagueJuiceEmpty } from '../test/fixtures';
 import { vi } from 'vitest';
 import type { NflPickDto } from '../types/picks';
 
@@ -54,8 +54,6 @@ const mockedDoOddsExist = vi.mocked(doOddsExist);
 const mockedGetUserPicks = vi.mocked(getUserPicks);
 const mockedSpreadBatch = vi.mocked(spreadBatch);
 const mockedAddPicks = vi.mocked(addPicks);
-// useLeagueMinSeason falls back to adapter.weekSelectorConfig.minSeason when this resolves
-// empty — every pre-existing test in this file was written against that sport-wide default.
 const mockedGetLeagueJuice = vi.mocked(getLeagueJuice);
 const mockedGetAllJerseys = vi.mocked(getAllJerseys);
 const mockedGetNextSpreadJob = vi.mocked(getNextSpreadJob);
@@ -141,8 +139,7 @@ describe('PicksPage', () => {
     mockedAddPicks.mockReset();
     mockedGetAllJerseys.mockReset();
     mockedGetNextSpreadJob.mockReset();
-    mockedGetLeagueJuice.mockReset();
-    mockedGetLeagueJuice.mockResolvedValue([]);
+    mockLeagueJuiceEmpty(mockedGetLeagueJuice);
   });
 
   it('shows no league message when no league selected', async () => {

--- a/Client.React/src/__tests__/picks.test.tsx
+++ b/Client.React/src/__tests__/picks.test.tsx
@@ -37,12 +37,13 @@ vi.mock('../api/league', () => ({
   getUserPicks: vi.fn(),
   spreadBatch: vi.fn(),
   getNflCurrentWeek: vi.fn(),
+  getLeagueJuice: vi.fn(),
 }));
 vi.mock('../api/jersey', () => ({ getAllJerseys: vi.fn() }));
 vi.mock('../services/spreadRelease', () => ({ getNextSpreadJob: vi.fn() }));
 
 import { getScores, loadScoresWithRetry, getWeekScores } from '../api/espn';
-import { addPicks, doOddsExist, getUserPicks, spreadBatch, getNflCurrentWeek } from '../api/league';
+import { addPicks, doOddsExist, getUserPicks, spreadBatch, getNflCurrentWeek, getLeagueJuice } from '../api/league';
 import { getAllJerseys } from '../api/jersey';
 import { getNextSpreadJob } from '../services/spreadRelease';
 
@@ -53,6 +54,9 @@ const mockedDoOddsExist = vi.mocked(doOddsExist);
 const mockedGetUserPicks = vi.mocked(getUserPicks);
 const mockedSpreadBatch = vi.mocked(spreadBatch);
 const mockedAddPicks = vi.mocked(addPicks);
+// useLeagueMinSeason falls back to adapter.weekSelectorConfig.minSeason when this resolves
+// empty — every pre-existing test in this file was written against that sport-wide default.
+const mockedGetLeagueJuice = vi.mocked(getLeagueJuice);
 const mockedGetAllJerseys = vi.mocked(getAllJerseys);
 const mockedGetNextSpreadJob = vi.mocked(getNextSpreadJob);
 const mockedGetNflCurrentWeek = vi.mocked(getNflCurrentWeek);
@@ -137,6 +141,8 @@ describe('PicksPage', () => {
     mockedAddPicks.mockReset();
     mockedGetAllJerseys.mockReset();
     mockedGetNextSpreadJob.mockReset();
+    mockedGetLeagueJuice.mockReset();
+    mockedGetLeagueJuice.mockResolvedValue([]);
   });
 
   it('shows no league message when no league selected', async () => {

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ScoresPage from '../pages/ScoresPage';
 import { createNflAdapter } from '../services/nflAdapter';
 import { createCfbAdapter } from '../services/cfbAdapter';
-import { createCurrentWeek, createPick, createScores, createSpreadResponse, createCompetition } from '../test/fixtures';
+import { createCurrentWeek, createPick, createScores, createSpreadResponse, createCompetition, mockLeagueJuiceEmpty } from '../test/fixtures';
 import { vi } from 'vitest';
 import type { NflPickDto } from '../types/picks';
 
@@ -58,8 +58,6 @@ const mockedGetWeekScores = vi.mocked(getWeekScores);
 const mockedDoOddsExist = vi.mocked(doOddsExist);
 const mockedGetLeaguePicks = vi.mocked(getLeaguePicks);
 const mockedGetNflCurrentWeek = vi.mocked(getNflCurrentWeek);
-// useLeagueMinSeason falls back to adapter.weekSelectorConfig.minSeason when this resolves
-// empty — every pre-existing test in this file was written against that sport-wide default.
 const mockedGetLeagueJuice = vi.mocked(getLeagueJuice);
 const mockedGetCfbSlates = vi.mocked(getCfbSlates);
 const mockedGetCfbSpreads = vi.mocked(getCfbSpreads);
@@ -102,7 +100,7 @@ const setupDefaults = async (options?: {
   mockedDoOddsExist.mockResolvedValue(options?.oddsExist ?? true);
   mockedGetLeaguePicks.mockResolvedValue(options?.picks ?? []);
   mockedSpreadBatch.mockResolvedValue({ responses: SPREAD_RESPONSES });
-  mockedGetLeagueJuice.mockResolvedValue([]);
+  mockLeagueJuiceEmpty(mockedGetLeagueJuice);
 };
 
 const renderWithClient = (ui: React.ReactElement, client?: QueryClient) => {
@@ -123,7 +121,6 @@ describe('ScoresPage', () => {
   beforeEach(() => {
     sessionState.currentLeague = 1;
     vi.clearAllMocks();
-    mockedGetLeagueJuice.mockResolvedValue([]);
   });
 
   it('shows no league message when no league selected', async () => {

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -38,6 +38,7 @@ vi.mock('../api/espn', () => ({
 vi.mock('../api/league', () => ({
   doOddsExist: vi.fn(), getLeaguePicks: vi.fn(), spreadBatch: vi.fn(),
   addPicks: vi.fn(), getUserPicks: vi.fn(), getNflCurrentWeek: vi.fn(),
+  getLeagueJuice: vi.fn(),
 }));
 vi.mock('../api/cfb', () => ({
   getCfbCurrentSlate: vi.fn(), getCfbSlates: vi.fn(), getCfbSpreads: vi.fn(),
@@ -49,7 +50,7 @@ const toastPush = vi.fn();
 vi.mock('../services/toast', () => ({ useToast: () => ({ push: toastPush }) }));
 
 import { getLiveGames, getWeekScores, getCfbScoresForSlate, getCfbLiveGames } from '../api/espn';
-import { doOddsExist, getLeaguePicks, spreadBatch, getNflCurrentWeek } from '../api/league';
+import { doOddsExist, getLeaguePicks, spreadBatch, getNflCurrentWeek, getLeagueJuice } from '../api/league';
 import { getCfbCurrentSlate, getCfbSlates, getCfbSpreads, getCfbScores, getCfbAllPicks } from '../api/cfb';
 
 const mockedGetLiveGames = vi.mocked(getLiveGames);
@@ -57,6 +58,9 @@ const mockedGetWeekScores = vi.mocked(getWeekScores);
 const mockedDoOddsExist = vi.mocked(doOddsExist);
 const mockedGetLeaguePicks = vi.mocked(getLeaguePicks);
 const mockedGetNflCurrentWeek = vi.mocked(getNflCurrentWeek);
+// useLeagueMinSeason falls back to adapter.weekSelectorConfig.minSeason when this resolves
+// empty — every pre-existing test in this file was written against that sport-wide default.
+const mockedGetLeagueJuice = vi.mocked(getLeagueJuice);
 const mockedGetCfbSlates = vi.mocked(getCfbSlates);
 const mockedGetCfbSpreads = vi.mocked(getCfbSpreads);
 const mockedGetCfbScores = vi.mocked(getCfbScores);
@@ -98,6 +102,7 @@ const setupDefaults = async (options?: {
   mockedDoOddsExist.mockResolvedValue(options?.oddsExist ?? true);
   mockedGetLeaguePicks.mockResolvedValue(options?.picks ?? []);
   mockedSpreadBatch.mockResolvedValue({ responses: SPREAD_RESPONSES });
+  mockedGetLeagueJuice.mockResolvedValue([]);
 };
 
 const renderWithClient = (ui: React.ReactElement, client?: QueryClient) => {
@@ -118,6 +123,7 @@ describe('ScoresPage', () => {
   beforeEach(() => {
     sessionState.currentLeague = 1;
     vi.clearAllMocks();
+    mockedGetLeagueJuice.mockResolvedValue([]);
   });
 
   it('shows no league message when no league selected', async () => {

--- a/Client.React/src/__tests__/sharedPickLayout.test.tsx
+++ b/Client.React/src/__tests__/sharedPickLayout.test.tsx
@@ -40,7 +40,7 @@ import { getWeekScores } from '../api/espn';
 import { doOddsExist, getUserPicks, spreadBatch, getNflCurrentWeek, getLeagueJuice } from '../api/league';
 import { getAllJerseys } from '../api/jersey';
 import { getNextSpreadJob } from '../services/spreadRelease';
-import { createCompetition, createScores, createSpreadResponse } from '../test/fixtures';
+import { createCompetition, createScores, createSpreadResponse, mockLeagueJuiceEmpty } from '../test/fixtures';
 
 describe('NFL PicksPage — GameCard layout regression', () => {
   beforeEach(() => {
@@ -62,7 +62,7 @@ describe('NFL PicksPage — GameCard layout regression', () => {
     }});
     vi.mocked(getAllJerseys).mockResolvedValue({});
     vi.mocked(getNextSpreadJob).mockResolvedValue(null);
-    vi.mocked(getLeagueJuice).mockResolvedValue([]);
+    mockLeagueJuiceEmpty(vi.mocked(getLeagueJuice));
   });
 
   it('renders Pick buttons (GameCard pick mode)', async () => {
@@ -107,7 +107,7 @@ describe('CFB PicksPage (via adapter) — GameCard layout regression', () => {
     vi.mocked(getCfbLiveGames).mockResolvedValue([]);
     vi.mocked(getCfbScores).mockResolvedValue([]);
     vi.mocked(getCfbUserPicks).mockResolvedValue([]);
-    vi.mocked(getLeagueJuice).mockResolvedValue([]);
+    mockLeagueJuiceEmpty(vi.mocked(getLeagueJuice));
   });
 
   it('renders Pick buttons (GameCard pick mode)', async () => {

--- a/Client.React/src/__tests__/sharedPickLayout.test.tsx
+++ b/Client.React/src/__tests__/sharedPickLayout.test.tsx
@@ -32,12 +32,12 @@ vi.mock('../components/sports/TeamHelmet', () => ({
 vi.mock('../components/WeatherIcon', () => ({ default: () => null }));
 
 // ─── NFL regression ──────────────────────────────────────────────────────────
-vi.mock('../api/league', () => ({ addPicks: vi.fn(), doOddsExist: vi.fn(), getUserPicks: vi.fn(), spreadBatch: vi.fn(), getNflCurrentWeek: vi.fn() }));
+vi.mock('../api/league', () => ({ addPicks: vi.fn(), doOddsExist: vi.fn(), getUserPicks: vi.fn(), spreadBatch: vi.fn(), getNflCurrentWeek: vi.fn(), getLeagueJuice: vi.fn() }));
 vi.mock('../api/jersey', () => ({ getAllJerseys: vi.fn() }));
 vi.mock('../services/spreadRelease', () => ({ getNextSpreadJob: vi.fn() }));
 
 import { getWeekScores } from '../api/espn';
-import { doOddsExist, getUserPicks, spreadBatch, getNflCurrentWeek } from '../api/league';
+import { doOddsExist, getUserPicks, spreadBatch, getNflCurrentWeek, getLeagueJuice } from '../api/league';
 import { getAllJerseys } from '../api/jersey';
 import { getNextSpreadJob } from '../services/spreadRelease';
 import { createCompetition, createScores, createSpreadResponse } from '../test/fixtures';
@@ -62,6 +62,7 @@ describe('NFL PicksPage — GameCard layout regression', () => {
     }});
     vi.mocked(getAllJerseys).mockResolvedValue({});
     vi.mocked(getNextSpreadJob).mockResolvedValue(null);
+    vi.mocked(getLeagueJuice).mockResolvedValue([]);
   });
 
   it('renders Pick buttons (GameCard pick mode)', async () => {
@@ -106,6 +107,7 @@ describe('CFB PicksPage (via adapter) — GameCard layout regression', () => {
     vi.mocked(getCfbLiveGames).mockResolvedValue([]);
     vi.mocked(getCfbScores).mockResolvedValue([]);
     vi.mocked(getCfbUserPicks).mockResolvedValue([]);
+    vi.mocked(getLeagueJuice).mockResolvedValue([]);
   });
 
   it('renders Pick buttons (GameCard pick mode)', async () => {

--- a/Client.React/src/__tests__/sportAccess.test.tsx
+++ b/Client.React/src/__tests__/sportAccess.test.tsx
@@ -185,4 +185,49 @@ describe('Sport access control', () => {
       expect(screen.queryByRole('link', { name: /switch to nfl/i })).not.toBeInTheDocument();
     });
   });
+
+  // frizat nitpick: tapping "Switch to CFB" from an installed iOS PWA silently drops the user
+  // into Safari, out of standalone mode — a platform constraint (each sport is a separate origin,
+  // so a separate installed PWA) that no routing change can fix. The controls just say so up
+  // front now, so it isn't a surprise.
+  describe('Switch-sport copy inside an installed standalone PWA', () => {
+    let originalMatchMedia: typeof window.matchMedia;
+
+    beforeEach(() => {
+      originalMatchMedia = window.matchMedia;
+      window.matchMedia = ((query: string) => ({
+        matches: query === '(display-mode: standalone)',
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      })) as typeof window.matchMedia;
+    });
+
+    afterEach(() => {
+      window.matchMedia = originalMatchMedia;
+    });
+
+    it('flags the toolbar quick-switch link as opening in the browser', () => {
+      renderLayout();
+      expect(screen.getByRole('link', { name: /switch to cfb site \(opens in your browser\)/i })).toBeInTheDocument();
+    });
+
+    it('adds an explanatory caption under the empty-state "Go to {sport} site" button', () => {
+      Object.assign(sportContext, { sport: 'CFB', isCfb: true, isNfl: false });
+      Object.assign(sessionState, { hasNflAccess: true, hasCfbAccess: false, currentLeague: null });
+      renderLayout();
+      expect(screen.getByRole('link', { name: /go to nfl/i })).toBeInTheDocument();
+      expect(screen.getByText(/opens in your browser/i)).toBeInTheDocument();
+    });
+
+    it('does not flag the toolbar quick-switch link when not running as a standalone PWA', () => {
+      window.matchMedia = originalMatchMedia;
+      renderLayout();
+      expect(screen.getByRole('link', { name: /^switch to cfb site$/i })).toBeInTheDocument();
+    });
+  });
 });

--- a/Client.React/src/__tests__/useLeagueMinSeason.test.tsx
+++ b/Client.React/src/__tests__/useLeagueMinSeason.test.tsx
@@ -1,0 +1,70 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+
+vi.mock('../api/league', () => ({ getLeagueJuice: vi.fn() }));
+
+import { getLeagueJuice } from '../api/league';
+import { useLeagueMinSeason } from '../utils/useLeagueMinSeason';
+import type { LeagueJuiceMappingDto } from '../types/admin';
+
+const mockedGetLeagueJuice = vi.mocked(getLeagueJuice);
+
+function makeJuiceMapping(season: number): LeagueJuiceMappingDto {
+  return {
+    id: season, leagueId: 1, leagueName: 'Demo League', season,
+    juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, dateCreated: `${season}-01-01T00:00:00Z`,
+  };
+}
+
+describe('useLeagueMinSeason', () => {
+  beforeEach(() => {
+    mockedGetLeagueJuice.mockReset();
+  });
+
+  it('resolves to the league\'s own earliest juice-mapping season', async () => {
+    mockedGetLeagueJuice.mockResolvedValue([makeJuiceMapping(2023), makeJuiceMapping(2022), makeJuiceMapping(2024)]);
+
+    const { result } = renderHook(() => useLeagueMinSeason(1, 2020));
+
+    await waitFor(() => expect(result.current).toBe(2022));
+  });
+
+  it('falls back to fallbackMinSeason when the league has no juice mapping yet', async () => {
+    mockedGetLeagueJuice.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useLeagueMinSeason(1, 2020));
+
+    await waitFor(() => expect(mockedGetLeagueJuice).toHaveBeenCalledWith(1));
+    expect(result.current).toBe(2020);
+  });
+
+  it('falls back to fallbackMinSeason when the fetch fails', async () => {
+    mockedGetLeagueJuice.mockRejectedValue(new Error('network error'));
+
+    const { result } = renderHook(() => useLeagueMinSeason(1, 2020));
+
+    await waitFor(() => expect(mockedGetLeagueJuice).toHaveBeenCalledWith(1));
+    expect(result.current).toBe(2020);
+  });
+
+  it('returns fallbackMinSeason immediately when there is no league selected, without fetching', () => {
+    const { result } = renderHook(() => useLeagueMinSeason(null, 2020));
+
+    expect(result.current).toBe(2020);
+    expect(mockedGetLeagueJuice).not.toHaveBeenCalled();
+  });
+
+  it('re-fetches when the league changes', async () => {
+    mockedGetLeagueJuice.mockImplementation((leagueId: number) =>
+      Promise.resolve(leagueId === 1 ? [makeJuiceMapping(2022)] : [makeJuiceMapping(2025)])
+    );
+
+    const { result, rerender } = renderHook(({ leagueId }) => useLeagueMinSeason(leagueId, 2020), {
+      initialProps: { leagueId: 1 },
+    });
+    await waitFor(() => expect(result.current).toBe(2022));
+
+    rerender({ leagueId: 2 });
+    await waitFor(() => expect(result.current).toBe(2025));
+  });
+});

--- a/Client.React/src/__tests__/useLeagueMinSeason.test.tsx
+++ b/Client.React/src/__tests__/useLeagueMinSeason.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { vi } from 'vitest';
 
 vi.mock('../api/league', () => ({ getLeagueJuice: vi.fn() }));
@@ -16,6 +17,16 @@ function makeJuiceMapping(season: number): LeagueJuiceMappingDto {
   };
 }
 
+// A fresh QueryClient per render — the hook's cache key is ['leagueJuice', leagueId], so a
+// shared client across tests using the same leagueId would return a stale cached result instead
+// of the test's own mock. retry: false keeps a rejected fetch settling immediately.
+function renderWithClient(leagueId: number | null, fallbackMinSeason: number) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return renderHook(() => useLeagueMinSeason(leagueId, fallbackMinSeason), {
+    wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>,
+  });
+}
+
 describe('useLeagueMinSeason', () => {
   beforeEach(() => {
     mockedGetLeagueJuice.mockReset();
@@ -24,7 +35,7 @@ describe('useLeagueMinSeason', () => {
   it('resolves to the league\'s own earliest juice-mapping season', async () => {
     mockedGetLeagueJuice.mockResolvedValue([makeJuiceMapping(2023), makeJuiceMapping(2022), makeJuiceMapping(2024)]);
 
-    const { result } = renderHook(() => useLeagueMinSeason(1, 2020));
+    const { result } = renderWithClient(1, 2020);
 
     await waitFor(() => expect(result.current).toBe(2022));
   });
@@ -32,7 +43,7 @@ describe('useLeagueMinSeason', () => {
   it('falls back to fallbackMinSeason when the league has no juice mapping yet', async () => {
     mockedGetLeagueJuice.mockResolvedValue([]);
 
-    const { result } = renderHook(() => useLeagueMinSeason(1, 2020));
+    const { result } = renderWithClient(1, 2020);
 
     await waitFor(() => expect(mockedGetLeagueJuice).toHaveBeenCalledWith(1));
     expect(result.current).toBe(2020);
@@ -41,14 +52,14 @@ describe('useLeagueMinSeason', () => {
   it('falls back to fallbackMinSeason when the fetch fails', async () => {
     mockedGetLeagueJuice.mockRejectedValue(new Error('network error'));
 
-    const { result } = renderHook(() => useLeagueMinSeason(1, 2020));
+    const { result } = renderWithClient(1, 2020);
 
     await waitFor(() => expect(mockedGetLeagueJuice).toHaveBeenCalledWith(1));
     expect(result.current).toBe(2020);
   });
 
   it('returns fallbackMinSeason immediately when there is no league selected, without fetching', () => {
-    const { result } = renderHook(() => useLeagueMinSeason(null, 2020));
+    const { result } = renderWithClient(null, 2020);
 
     expect(result.current).toBe(2020);
     expect(mockedGetLeagueJuice).not.toHaveBeenCalled();
@@ -58,10 +69,14 @@ describe('useLeagueMinSeason', () => {
     mockedGetLeagueJuice.mockImplementation((leagueId: number) =>
       Promise.resolve(leagueId === 1 ? [makeJuiceMapping(2022)] : [makeJuiceMapping(2025)])
     );
-
-    const { result, rerender } = renderHook(({ leagueId }) => useLeagueMinSeason(leagueId, 2020), {
-      initialProps: { leagueId: 1 },
-    });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result, rerender } = renderHook(
+      ({ leagueId }) => useLeagueMinSeason(leagueId, 2020),
+      {
+        initialProps: { leagueId: 1 },
+        wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>,
+      },
+    );
     await waitFor(() => expect(result.current).toBe(2022));
 
     rerender({ leagueId: 2 });

--- a/Client.React/src/app/global.css
+++ b/Client.React/src/app/global.css
@@ -16,7 +16,16 @@
 
 [data-theme='dark'] {
   --bg-1: #0f1729;
-  --bg-2: #1a2440;
+  /* Was #1a2440 — byte-for-byte identical to theme.ts's dark-mode background.paper. On a page
+     long enough to scroll well past the first viewport (e.g. the ever-growing Changelog), the
+     bottom of this gradient reached that exact color, so every Paper/Card down there visually
+     vanished into the page background — reported as "the background color is bad" (same
+     complaint category as the elevation-overlay bug fixed in theme.ts's MuiPaper override, but a
+     different cause: this is a page-background/surface color collision, not an elevation
+     artifact). Darkened just enough to stay clearly distinct from background.paper everywhere
+     in the gradient, while still lighter than --bg-1 so the top-to-bottom brightening look
+     survives. */
+  --bg-2: #121a2f;
   --bg-3: #1e3a5f;
   --ink-1: #e2e8f0;
   --ink-2: #94a3b8;

--- a/Client.React/src/app/global.css
+++ b/Client.React/src/app/global.css
@@ -48,18 +48,37 @@ body {
   margin: 0;
   font-family: "Space Grotesk", "Segoe UI", system-ui, sans-serif;
   color: var(--ink-1);
-  background: radial-gradient(80% 50% at 10% -10%, rgba(203, 213, 245, 0.25), transparent 60%),
+  /* `html, body { height: 100% }` above pins body's own box to exactly one viewport tall (100vh)
+     even though its content grows the page far past that — html/body backgrounds are painted
+     across the whole scrollable canvas per spec, but their SIZING/repeat area is still that
+     nominal 100vh box. With no background-repeat set (default: repeat), every layer here —
+     including the two decorative radial highlights — retiled every exact 900px/one-viewport-
+     height down the page: a real, visible seam at every tile boundary on any page taller than
+     one screen (Rules, Changelog, My Leagues, ...). This is the actual root cause behind every
+     "background looks inconsistent while scrolling" report so far, including the elevation-
+     overlay and bg-2/card-color-collision fixes elsewhere in this file/theme.ts — those were
+     each real too, but this is the one that made it happen on every long page, repeatedly.
+     Fix: background-color carries the flat color for anything below the first viewport (it
+     matches --bg-2, the gradient's own bottom stop, so the seam is invisible even where the
+     gradient does end); background-image holds the decorative layers, explicitly sized to one
+     viewport and never repeated, so they only ever render once, at the top, as originally
+     intended — not deliberately tiled and never in any later loop */
+  background-color: var(--bg-2);
+  background-image: radial-gradient(80% 50% at 10% -10%, rgba(203, 213, 245, 0.25), transparent 60%),
     radial-gradient(70% 45% at 90% -20%, rgba(253, 230, 138, 0.1), transparent 55%),
     linear-gradient(180deg, var(--bg-1), var(--bg-2));
+  background-repeat: no-repeat;
+  background-size: 100% 100vh;
   min-height: 100vh;
   -webkit-font-smoothing: antialiased;
   -webkit-touch-callout: none;
   -webkit-tap-highlight-color: transparent;
-  transition: background 0.3s ease, color 0.3s ease;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 [data-theme='dark'] body {
-  background: radial-gradient(80% 50% at 10% -10%, rgba(30, 58, 95, 0.5), transparent 60%),
+  background-color: var(--bg-2);
+  background-image: radial-gradient(80% 50% at 10% -10%, rgba(30, 58, 95, 0.5), transparent 60%),
     radial-gradient(70% 45% at 90% -20%, rgba(253, 230, 138, 0.04), transparent 55%),
     linear-gradient(180deg, var(--bg-1), var(--bg-2));
 }

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -23,6 +23,7 @@ import {
 } from '@mui/material';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import MenuIcon from '@mui/icons-material/Menu';
@@ -46,6 +47,7 @@ import { useAuth } from '../services/auth';
 import { useSportContext } from '../services/sport';
 import { useThemeMode } from '../services/theme';
 import { isAdmin } from '../utils/auth';
+import { isStandalonePwa } from '../utils/pwa';
 import PendingInviteBanner from '../components/PendingInviteBanner';
 import VersionFooter from '../components/VersionFooter';
 
@@ -91,6 +93,13 @@ export default function AppLayout() {
     return `${protocol}//${otherHost}${portSuffix}`;
   };
 
+  // NFL and CFB are separate origins, so each is its own installed PWA — a cross-origin link
+  // from one always drops a standalone-mode install into the regular browser (see utils/pwa.ts).
+  // Not fixable via routing; the switch-sport controls below just say so up front instead of
+  // surprising the user with an unexpected app-to-browser jump.
+  const [inStandalonePwa] = useState(isStandalonePwa);
+  const otherSportOpensInBrowser = inStandalonePwa ? ' (opens in your browser)' : '';
+
   const handleNavClick = (to: string) => {
     if (isMobile) setOpen(false);
     navigate(to);
@@ -135,6 +144,11 @@ export default function AppLayout() {
           <Button variant="contained" href={getOtherSportUrl()}>
             Go to {isCfb ? 'NFL' : 'CFB'} site
           </Button>
+          {inStandalonePwa && (
+            <Typography variant="caption" color="text.secondary" sx={{ mt: 1 }}>
+              Opens in your browser — this installed app can only show {isCfb ? 'CFB' : 'NFL'}.
+            </Typography>
+          )}
         </>
       ) : (
         <Typography color="text.secondary">
@@ -177,9 +191,12 @@ export default function AppLayout() {
               <Chip
                 component="a"
                 href={getOtherSportUrl()}
-                icon={<SwapHorizIcon />}
+                // A distinct "leaves the app" icon when installed standalone — always visible,
+                // unlike a hover title/tooltip, which a one-tap mobile navigation never shows.
+                icon={inStandalonePwa ? <OpenInNewIcon /> : <SwapHorizIcon />}
                 label={otherSport}
-                aria-label={`Switch to ${otherSport} site`}
+                title={inStandalonePwa ? 'Opens in your browser, outside this installed app' : undefined}
+                aria-label={`Switch to ${otherSport} site${otherSportOpensInBrowser}`}
                 clickable
                 variant="outlined"
                 sx={{

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -97,7 +97,7 @@ export default function AppLayout() {
   // from one always drops a standalone-mode install into the regular browser (see utils/pwa.ts).
   // Not fixable via routing; the switch-sport controls below just say so up front instead of
   // surprising the user with an unexpected app-to-browser jump.
-  const [inStandalonePwa] = useState(isStandalonePwa);
+  const inStandalonePwa = isStandalonePwa();
   const otherSportOpensInBrowser = inStandalonePwa ? ' (opens in your browser)' : '';
 
   const handleNavClick = (to: string) => {

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -31,6 +31,7 @@ import type { SportAdapter } from '../services/sportAdapter';
 import { stickyColumnSx } from '../utils/tableStyles';
 import { useShareLink } from '../utils/useShareLink';
 import { useShareImage } from '../utils/useShareImage';
+import { useLeagueMinSeason } from '../utils/useLeagueMinSeason';
 
 interface LeaderboardPageProps {
   adapter: SportAdapter;
@@ -123,10 +124,12 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
     return () => { ignore = true; };
   }, [currentLeague, season]);
 
+  const leagueMinSeason = useLeagueMinSeason(currentLeague, adapter.weekSelectorConfig.minSeason);
+
   const seasonOptions = useMemo(() => {
     if (maxSeason == null) return [];
-    return buildDescendingSeasonRange(adapter.weekSelectorConfig.minSeason, maxSeason);
-  }, [maxSeason, adapter.weekSelectorConfig.minSeason]);
+    return buildDescendingSeasonRange(leagueMinSeason, maxSeason);
+  }, [maxSeason, leagueMinSeason]);
 
   const maxWeek = useMemo(() => {
     if (leaderboard.length === 0) return 0;

--- a/Client.React/src/pages/PicksPage.tsx
+++ b/Client.React/src/pages/PicksPage.tsx
@@ -20,6 +20,7 @@ import type { SportAdapter, GameView, PickType, WeekState } from '../services/sp
 import { sortGamesByTimeThenRank } from '../services/sportAdapter';
 import { useToast } from '../services/toast';
 import { isGameDecided } from '../utils/gameHelpers';
+import { useLeagueMinSeason } from '../utils/useLeagueMinSeason';
 
 // Pick key: "gameId|team|pickType" — stable across NFL and CFB
 function pickKey(gameId: string, team: string, pickType: string) {
@@ -81,6 +82,7 @@ export default function PicksPage({ adapter }: PicksPageProps) {
   const isPostSeason = weekState?.isPostSeason ?? data?.isPostSeason ?? false;
   const maxWeek = currentBounds?.maxWeek ?? adapter.weekSelectorConfig.maxRegularSeasonWeek;
   const maxSeason = currentBounds?.maxSeason ?? new Date().getFullYear();
+  const minSeason = useLeagueMinSeason(currentLeague, adapter.weekSelectorConfig.minSeason);
 
   const existingPicks = useMemo(
     () => new Set((data?.userPicks ?? []).map(p => pickKey(p.gameId, p.team, p.pickType))),
@@ -203,6 +205,7 @@ export default function PicksPage({ adapter }: PicksPageProps) {
           {...adapter.weekSelectorConfig}
           maxRegularSeasonWeek={maxWeek}
           maxSeason={maxSeason}
+          minSeason={minSeason}
           isCurrent={isCurrentWeek}
         />
         {!isCurrentWeek && (

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -23,6 +23,7 @@ import { useAuth } from '../services/auth';
 import { isGameDecided, isGameFinal, isGameLive, spreadLabel } from '../utils/gameHelpers';
 import type { SportAdapter, GameView, WeekState, PickType } from '../services/sportAdapter';
 import { sortGamesByTimeThenRank } from '../services/sportAdapter';
+import { useLeagueMinSeason } from '../utils/useLeagueMinSeason';
 
 // ─── Icon + color helpers (use pre-computed adapter fields) ──────────────────
 
@@ -123,6 +124,7 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
 
   const maxWeek = currentWeekSnapshot?.maxWeek ?? adapter.weekSelectorConfig.maxRegularSeasonWeek;
   const maxSeason = currentWeekSnapshot?.maxSeason ?? new Date().getFullYear();
+  const minSeason = useLeagueMinSeason(currentLeague, adapter.weekSelectorConfig.minSeason);
 
   // Selecting the week that IS the current week (from the dropdown, not the "Current Week"
   // button) routes back to the live query instead of a one-off historical fetch — the historical
@@ -241,6 +243,7 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
           {...adapter.weekSelectorConfig}
           maxRegularSeasonWeek={maxWeek}
           maxSeason={maxSeason}
+          minSeason={minSeason}
           isCurrent={isCurrentWeek}
         />
         {!isCurrentWeek && (

--- a/Client.React/src/test/fixtures.ts
+++ b/Client.React/src/test/fixtures.ts
@@ -1,5 +1,18 @@
+import type { Mock } from 'vitest';
 import type { Competition, EspnScores, Event } from '../types/espn';
 import type { NflPickDto, PickType, SpreadCalculationResponse, SpreadResponse } from '../types/picks';
+
+/**
+ * Resets a mocked `getLeagueJuice` and resolves it to no juice-mapping history, so
+ * `useLeagueMinSeason` falls back to the adapter's sport-wide `weekSelectorConfig.minSeason` —
+ * the default every pre-existing Picks/Scores/Leaderboard test was written against before that
+ * hook existed. Call from a `beforeEach` alongside the file's own mock resets; override with a
+ * real resolved value only in a test that specifically exercises the per-league floor.
+ */
+export function mockLeagueJuiceEmpty(mockedGetLeagueJuice: Mock) {
+  mockedGetLeagueJuice.mockReset();
+  mockedGetLeagueJuice.mockResolvedValue([]);
+}
 
 interface LiveStatusOptions {
   name: 'status_in_progress' | 'status_halftime';

--- a/Client.React/src/utils/pwa.ts
+++ b/Client.React/src/utils/pwa.ts
@@ -1,0 +1,13 @@
+/**
+ * Detects an installed, standalone-mode PWA (iOS "Add to Home Screen", or any platform's
+ * equivalent). NFL (ivleague.xyz) and CFB (cfb.ivleague.xyz) are separate origins, so each is
+ * its own installed PWA with its own scope — a cross-origin link between them always breaks out
+ * of standalone mode into the regular browser, on every platform. That's a platform constraint
+ * (manifest scope is origin-bound), not something a link/route change here can fix — the only
+ * thing AppLayout's "Switch to CFB/NFL" control can do is warn the user before it happens.
+ */
+export function isStandalonePwa(): boolean {
+  if (window.matchMedia?.('(display-mode: standalone)').matches) return true;
+  // iOS Safari's legacy, non-standard signal — not covered by the media query above.
+  return (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
+}

--- a/Client.React/src/utils/useLeagueMinSeason.ts
+++ b/Client.React/src/utils/useLeagueMinSeason.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { getLeagueJuice } from '../api/league';
+
+/**
+ * The earliest season a league actually has data for, per the shared source of truth
+ * (LeagueJuiceMapping) — not the sport-wide adapter default. NFL's minSeason=2020 and CFB's
+ * minSeason=2025 are hardcoded floors covering every league on that sport, so a brand-new
+ * league's season selector was offering years before that league (or CFB itself) existed
+ * (e.g. "OG FourPlayaz" showing 2020-2024, "CFB Beta Testers" showing 2025). One shared hook —
+ * not a per-sport fix — since the bug and the fix are identical for NFL and CFB.
+ * Falls back to `fallbackMinSeason` while loading or when the league has no juice mapping yet.
+ */
+export function useLeagueMinSeason(leagueId: number | null, fallbackMinSeason: number): number {
+  const [minSeason, setMinSeason] = useState(fallbackMinSeason);
+
+  useEffect(() => {
+    if (leagueId == null) { setMinSeason(fallbackMinSeason); return; }
+    let ignore = false;
+    void getLeagueJuice(leagueId)
+      .then((mappings) => {
+        if (ignore) return;
+        setMinSeason(mappings.length > 0 ? Math.min(...mappings.map((m) => m.season)) : fallbackMinSeason);
+      })
+      .catch(() => { if (!ignore) setMinSeason(fallbackMinSeason); });
+    return () => { ignore = true; };
+  }, [leagueId, fallbackMinSeason]);
+
+  return minSeason;
+}

--- a/Client.React/src/utils/useLeagueMinSeason.ts
+++ b/Client.React/src/utils/useLeagueMinSeason.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { getLeagueJuice } from '../api/league';
 
 /**
@@ -9,21 +9,18 @@ import { getLeagueJuice } from '../api/league';
  * (e.g. "OG FourPlayaz" showing 2020-2024, "CFB Beta Testers" showing 2025). One shared hook —
  * not a per-sport fix — since the bug and the fix are identical for NFL and CFB.
  * Falls back to `fallbackMinSeason` while loading or when the league has no juice mapping yet.
+ *
+ * Backed by the app's shared React Query cache (not a local useEffect/fetch) so visiting
+ * Picks, Scores, and Leaderboard for the same league in one session shares a single request
+ * instead of each page independently re-fetching the same rarely-changing data.
  */
 export function useLeagueMinSeason(leagueId: number | null, fallbackMinSeason: number): number {
-  const [minSeason, setMinSeason] = useState(fallbackMinSeason);
+  const { data } = useQuery({
+    queryKey: ['leagueJuice', leagueId],
+    queryFn: () => getLeagueJuice(leagueId!),
+    enabled: leagueId != null,
+  });
 
-  useEffect(() => {
-    if (leagueId == null) { setMinSeason(fallbackMinSeason); return; }
-    let ignore = false;
-    void getLeagueJuice(leagueId)
-      .then((mappings) => {
-        if (ignore) return;
-        setMinSeason(mappings.length > 0 ? Math.min(...mappings.map((m) => m.season)) : fallbackMinSeason);
-      })
-      .catch(() => { if (!ignore) setMinSeason(fallbackMinSeason); });
-    return () => { ignore = true; };
-  }, [leagueId, fallbackMinSeason]);
-
-  return minSeason;
+  if (!data || data.length === 0) return fallbackMinSeason;
+  return Math.min(...data.map((m) => m.season));
 }

--- a/Server.UnitTests/CfbPicksControllerTests.cs
+++ b/Server.UnitTests/CfbPicksControllerTests.cs
@@ -408,9 +408,8 @@ public class CfbPicksControllerTests
     public async Task GetSpreads_IncludesTeamRanksInResponse()
     {
         // Rank is read back from CfbRanking via GetLatestRankingsForWeekAsync
-        // (CfbRankingCaptureJob/CfbSpreadJob already capture it there) — "most recent capture
-        // wins" is resolved by that repository method's own join, not here; see
-        // CfbRepositoryTests for that behavior.
+        // (CfbRankingCaptureJob/CfbSpreadJob already capture it there, upserting one row per
+        // team/week) — not resolved here; see CfbRepositoryTests for the upsert behavior.
         var spread = MakeSpread(DateTimeOffset.UtcNow.AddHours(2), "ORE", "OSU");
         _cfbRepo.GetSpreadsForSlateAsync(1).Returns([spread]);
         _cfbRepo.GetSlateByIdAsync(1).Returns(MakeSlate(espnWeekNumber: 3));

--- a/Server.UnitTests/CfbRankingCaptureJobTests.cs
+++ b/Server.UnitTests/CfbRankingCaptureJobTests.cs
@@ -83,8 +83,10 @@ public class CfbRankingCaptureJobTests
     }
 
     [Fact]
-    public async Task Execute_PersistsRankingForBothRankedCompetitors()
+    public async Task Execute_PersistsRankingOnlyForTheRankedCompetitor_NotTheUnrankedOne()
     {
+        // "Rankings" now means one row per (season, week, ranked team) — CuratedRank=99 (ESPN's
+        // unranked sentinel) is not a rank, so it's never persisted at all, not even as a row.
         var slate = BuildSlate();
         _repo.GetSlatesForSeasonAsync(2026).Returns([slate]);
         _fetcher.FetchForSlateAsync(slate).Returns(BuildScoreboard(homeRank: 3, awayRank: 99));
@@ -95,8 +97,9 @@ public class CfbRankingCaptureJobTests
         await BuildJob().Execute(_context);
 
         var rankings = saved!.ToList();
-        Assert.Contains(rankings, r => r.TeamAbbreviation == "ORE" && r.CuratedRank == 3);
-        Assert.Contains(rankings, r => r.TeamAbbreviation == "OSU" && r.CuratedRank == 99);
+        Assert.Single(rankings);
+        Assert.Equal("ORE", rankings[0].TeamAbbreviation);
+        Assert.Equal(3, rankings[0].CuratedRank);
     }
 
     [Fact]

--- a/Server.UnitTests/CfbRepositoryTests.cs
+++ b/Server.UnitTests/CfbRepositoryTests.cs
@@ -183,23 +183,30 @@ public class CfbRepositoryTests
     }
 
     [Fact]
-    public async Task GetLatestRankingsForWeekAsync_ResolvesToTheMostRecentlyCapturedRank()
+    public async Task AddRankingsAsync_UpsertsInPlace_WhenTheSameTeamWeekIsCapturedAgain()
     {
-        // CfbRanking is append-only — CfbRankingCaptureJob's earlier run and CfbSpreadJob's later
-        // run both capture the same team-week. The join in GetLatestRankingsForWeekAsync should
-        // resolve to the later (most recent) capture, not the first or an arbitrary one.
-        var factory = new DbContextFactoryStub(nameof(GetLatestRankingsForWeekAsync_ResolvesToTheMostRecentlyCapturedRank));
+        // CfbRankingCaptureJob's earlier run and CfbSpreadJob's later run both capture the same
+        // team-week. AddRankingsAsync must overwrite the existing row (rank doesn't change once
+        // captured for a week) rather than appending a second row and violating the unique index
+        // on (Season, EspnWeekNumber, TeamAbbreviation).
+        var factory = new DbContextFactoryStub(nameof(AddRankingsAsync_UpsertsInPlace_WhenTheSameTeamWeekIsCapturedAgain));
         var repo = new CfbRepository(factory);
         var earlier = new DateTimeOffset(2026, 8, 25, 9, 0, 0, TimeSpan.Zero);
         var later = new DateTimeOffset(2026, 8, 27, 9, 0, 0, TimeSpan.Zero);
 
         await repo.AddRankingsAsync([
             new CfbRanking { Season = 2026, EspnWeekNumber = 1, EspnEventId = 1, TeamAbbreviation = "ALA", CuratedRank = 5, CapturedAtUtc = earlier },
-            new CfbRanking { Season = 2026, EspnWeekNumber = 1, EspnEventId = 1, TeamAbbreviation = "ALA", CuratedRank = 3, CapturedAtUtc = later },
+        ]);
+        await repo.AddRankingsAsync([
+            new CfbRanking { Season = 2026, EspnWeekNumber = 1, EspnEventId = 2, TeamAbbreviation = "ALA", CuratedRank = 3, CapturedAtUtc = later },
         ]);
 
-        var result = await repo.GetLatestRankingsForWeekAsync(2026, 1);
+        var all = await factory.CreateDbContext().CfbRankings.Where(r => r.TeamAbbreviation == "ALA").ToListAsync();
+        Assert.Single(all);
+        Assert.Equal(3, all[0].CuratedRank);
+        Assert.Equal(2, all[0].EspnEventId);
 
+        var result = await repo.GetLatestRankingsForWeekAsync(2026, 1);
         Assert.Equal(3, result["ALA"]);
     }
 

--- a/Server.UnitTests/CfbSpreadJobTests.cs
+++ b/Server.UnitTests/CfbSpreadJobTests.cs
@@ -255,8 +255,10 @@ public class CfbSpreadJobTests
     }
 
     [Fact]
-    public async Task Execute_PersistsRankingForBothCompetitors()
+    public async Task Execute_PersistsRankingOnlyForTheRankedCompetitor()
     {
+        // "Rankings" now means one row per (season, week, ranked team) — CuratedRank=99 (ESPN's
+        // unranked sentinel) is not a rank, so it's never persisted at all, not even as a row.
         SetCurrentSlate(BuildSlate());
         _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>()).Returns(BuildScoreboard(homeAbbr: "ORE", awayAbbr: "OSU", homeRank: 3, awayRank: 99));
         _oddsService.GetCfbEventsWithOddsAsync(401677183, 100).Returns(BuildOdds());
@@ -267,10 +269,10 @@ public class CfbSpreadJobTests
         await BuildJob().Execute(_context);
 
         var rankings = saved!.ToList();
-        Assert.Equal(2, rankings.Count);
-        Assert.Contains(rankings, r => r.TeamAbbreviation == "ORE" && r.CuratedRank == 3);
-        Assert.Contains(rankings, r => r.TeamAbbreviation == "OSU" && r.CuratedRank == 99);
-        Assert.All(rankings, r => Assert.Equal(401677183, r.EspnEventId));
+        Assert.Single(rankings);
+        Assert.Equal("ORE", rankings[0].TeamAbbreviation);
+        Assert.Equal(3, rankings[0].CuratedRank);
+        Assert.Equal(401677183, rankings[0].EspnEventId);
     }
 
     [Fact]
@@ -283,7 +285,7 @@ public class CfbSpreadJobTests
 
         await BuildJob().Execute(_context);
 
-        await _repo.Received(1).AddRankingsAsync(Arg.Is<IEnumerable<CfbRanking>>(r => r.Count() == 2));
+        await _repo.Received(1).AddRankingsAsync(Arg.Is<IEnumerable<CfbRanking>>(r => r.Count() == 1));
     }
 
     // -----------------------------------------------------------------------

--- a/Server.UnitTests/LeaderboardTests.cs
+++ b/Server.UnitTests/LeaderboardTests.cs
@@ -332,7 +332,19 @@ public class LeaderboardServiceTests {
 
     // ─── CFB Leaderboard Tests ────────────────────────────────────────────────
 
-    private static (ILeagueRepository repo, ICfbRepository cfbRepo, ICfbPicksRepository picksRepo)
+    // Defaults to "current slate = slate 20 of season 2025" — past every SlateNumber any existing
+    // single-slate test uses, so the new current-slate clamp (frizat: leaderboard nitpicks) is a
+    // no-op for all of them unless a test overrides currentSlateService itself.
+    private static ICfbCurrentSlateService BuildCurrentSlateService(int? season = 2025, int slateNumber = 20) {
+        var svc = Substitute.For<ICfbCurrentSlateService>();
+        svc.GetCurrentSlateAsync().Returns(season is int s
+            ? new CfbSlateInfo(999, s, slateNumber, "Stub", "RegularSeason",
+                DateOnly.FromDateTime(DateTime.Today), DateOnly.FromDateTime(DateTime.Today), null, DateTime.UtcNow)
+            : null);
+        return svc;
+    }
+
+    private static (ILeagueRepository repo, ICfbRepository cfbRepo, ICfbPicksRepository picksRepo, ICfbCurrentSlateService currentSlateService)
         BuildCfbMocks(string userId, int leagueId = 1, int slateId = 1, int slateNumber = 1) {
         var user = new ApplicationUser { Id = userId, UserName = "Alice" };
         var leagueInfo = new LeagueInfo { Id = leagueId, LeagueName = "CFB Test", OwnerUserId = userId };
@@ -358,15 +370,15 @@ public class LeaderboardServiceTests {
             new CfbPicks { UserId = userId, LeagueId = leagueId, CfbSlateId = slateId, Team = "IU", PickType = PickType.Spread, Season = 2025 }
         ]);
 
-        return (leagueRepo, cfbRepo, picksRepo);
+        return (leagueRepo, cfbRepo, picksRepo, BuildCurrentSlateService());
     }
 
     [Fact]
     public async Task CfbBuildLeaderboard_ReturnsWon_WhenAllPicksBeatSpread() {
         var userId = Guid.NewGuid().ToString();
         // slateNumber=19 = CFP National Championship → requires 1 pick, so 1 winning pick → Won
-        var (leagueRepo, cfbRepo, picksRepo) = BuildCfbMocks(userId, slateNumber: 19);
-        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo);
+        var (leagueRepo, cfbRepo, picksRepo, currentSlateService) = BuildCfbMocks(userId, slateNumber: 19);
+        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo, currentSlateService);
 
         var result = await service.BuildLeaderboard(1, 2025);
 
@@ -377,14 +389,14 @@ public class LeaderboardServiceTests {
     [Fact]
     public async Task CfbBuildLeaderboard_ReturnsLost_WhenPickLosesSpread() {
         var userId = Guid.NewGuid().ToString();
-        var (leagueRepo, cfbRepo, picksRepo) = BuildCfbMocks(userId);
+        var (leagueRepo, cfbRepo, picksRepo, currentSlateService) = BuildCfbMocks(userId);
 
         // Override scores: IU loses badly — 7 to 35, so IU 7 + (-7+5) = 5; 5 - 35 = -30 < 0 → loss
         cfbRepo.GetScoresForSlateAsync(1).Returns((IEnumerable<CfbScores>)[
             new CfbScores { Id = 1, CfbSlateId = 1, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 7, AwayTeamScore = 35, GameStatus = TypeName.StatusFinal }
         ]);
 
-        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo);
+        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo, currentSlateService);
         var result = await service.BuildLeaderboard(1, 2025);
 
         Assert.Equal(WeekResult.Lost, result[0].WeekResults[0].WeekResult);
@@ -393,7 +405,7 @@ public class LeaderboardServiceTests {
     [Fact]
     public async Task CfbBuildLeaderboard_ReturnsMissingPicks_WhenUserHasFewerPicksThanGames() {
         var userId = Guid.NewGuid().ToString();
-        var (leagueRepo, cfbRepo, picksRepo) = BuildCfbMocks(userId);
+        var (leagueRepo, cfbRepo, picksRepo, currentSlateService) = BuildCfbMocks(userId);
 
         // Add a second game that the user did NOT pick
         cfbRepo.GetSpreadsForSlateAsync(1).Returns((IEnumerable<CfbSpreads>)[
@@ -401,13 +413,89 @@ public class LeaderboardServiceTests {
             new CfbSpreads { Id = 2, CfbSlateId = 1, HomeTeam = "MIC", AwayTeam = "PSU", HomeTeamSpread = -3, AwayTeamSpread = 3, OverUnder = 47, IsLeagueEligible = true },
         ]);
 
-        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo);
+        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo, currentSlateService);
         var result = await service.BuildLeaderboard(1, 2025);
 
         Assert.Equal(WeekResult.MissingPicks, result[0].WeekResults[0].WeekResult);
     }
 
-    private static (ILeagueRepository repo, ICfbRepository cfbRepo, ICfbPicksRepository picksRepo)
+    // ─── CFB Leaderboard — clamp to current slate (frizat: "shows week 18 and all missed picks"
+    // even for slates that haven't happened yet — CfbSlates is fully seeded ahead of time for the
+    // whole season, unlike NFL's NflScores which only exist once a game is final) ────────────────
+
+    [Fact]
+    public async Task CfbBuildLeaderboard_ExcludesSlatesAfterTheCurrentOne() {
+        var userId = Guid.NewGuid().ToString();
+        var (leagueRepo, cfbRepo, picksRepo, _) = BuildCfbMocks(userId, slateNumber: 1);
+        var futureSlate = new CfbSlates { Id = 2, Season = 2025, SlateNumber = 2, SlateType = "RegularSeason", Label = "Week 2", StartDate = DateOnly.FromDateTime(DateTime.Today.AddDays(7)), EndDate = DateOnly.FromDateTime(DateTime.Today.AddDays(13)) };
+        cfbRepo.GetSlatesForSeasonAsync(2025).Returns([
+            new CfbSlates { Id = 1, Season = 2025, SlateNumber = 1, SlateType = "RegularSeason", Label = "Week 1", StartDate = DateOnly.FromDateTime(DateTime.Today), EndDate = DateOnly.FromDateTime(DateTime.Today.AddDays(6)) },
+            futureSlate,
+        ]);
+        // Current slate is still slate 1 — slate 2 hasn't happened yet.
+        var currentSlateService = BuildCurrentSlateService(season: 2025, slateNumber: 1);
+
+        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo, currentSlateService);
+        var result = await service.BuildLeaderboard(1, 2025);
+
+        Assert.Single(result[0].WeekResults); // only slate 1, slate 2 excluded
+        Assert.Equal(1, result[0].WeekResults[0].Week);
+    }
+
+    [Fact]
+    public async Task CfbBuildLeaderboard_DoesNotClamp_ForAFullyCompletedPastSeason() {
+        var userId = Guid.NewGuid().ToString();
+        var (leagueRepo, cfbRepo, picksRepo, _) = BuildCfbMocks(userId, slateNumber: 1);
+        cfbRepo.GetSlatesForSeasonAsync(2025).Returns([
+            new CfbSlates { Id = 1, Season = 2025, SlateNumber = 1, SlateType = "RegularSeason", Label = "Week 1", StartDate = DateOnly.FromDateTime(DateTime.Today), EndDate = DateOnly.FromDateTime(DateTime.Today.AddDays(6)) },
+            new CfbSlates { Id = 2, Season = 2025, SlateNumber = 2, SlateType = "RegularSeason", Label = "Week 2", StartDate = DateOnly.FromDateTime(DateTime.Today.AddDays(7)), EndDate = DateOnly.FromDateTime(DateTime.Today.AddDays(13)) },
+        ]);
+        cfbRepo.GetSpreadsForSlateAsync(2).Returns((IEnumerable<CfbSpreads>)[]);
+        cfbRepo.GetScoresForSlateAsync(2).Returns((IEnumerable<CfbScores>)[]);
+        picksRepo.GetUserPicksAsync(1, 2, userId).Returns((IEnumerable<CfbPicks>)[]);
+        // "Now" is season 2026 — 2025 is fully in the past, so every one of its slates should
+        // still show, not be clamped to whatever slate 2025 last resolved to.
+        var currentSlateService = BuildCurrentSlateService(season: 2026, slateNumber: 1);
+
+        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo, currentSlateService);
+        var result = await service.BuildLeaderboard(1, 2025);
+
+        Assert.Equal(2, result[0].WeekResults.Length);
+    }
+
+    [Fact]
+    public async Task CfbBuildLeaderboard_ReturnsEmpty_ForASeasonThatHasNotStartedYet() {
+        var userId = Guid.NewGuid().ToString();
+        var (leagueRepo, cfbRepo, picksRepo, _) = BuildCfbMocks(userId, slateNumber: 1);
+        // "Now" is season 2025 — 2026 hasn't started, so nothing should show for it yet.
+        var currentSlateService = BuildCurrentSlateService(season: 2025, slateNumber: 1);
+        leagueRepo.GetLeagueJuiceMappingAsync(1, 2026).Returns(new LeagueJuiceMapping { Id = 2, LeagueId = 1, Season = 2026, Juice = 5, JuiceDivisional = 10, JuiceConference = 6, WeeklyCost = 5 });
+        cfbRepo.GetSlatesForSeasonAsync(2026).Returns([
+            new CfbSlates { Id = 3, Season = 2026, SlateNumber = 1, SlateType = "RegularSeason", Label = "Week 1", StartDate = DateOnly.FromDateTime(DateTime.Today), EndDate = DateOnly.FromDateTime(DateTime.Today.AddDays(6)) },
+        ]);
+
+        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo, currentSlateService);
+        var result = await service.BuildLeaderboard(1, 2026);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task CfbBuildLeaderboard_DoesNotClamp_WhenCurrentSlateCannotBeResolved() {
+        // Fail open, same philosophy as the rest of this codebase's "no data yet" handling —
+        // a null current slate (e.g. pre-launch, no slates seeded anywhere) must not hide every
+        // real slate that DOES exist for the requested season.
+        var userId = Guid.NewGuid().ToString();
+        var (leagueRepo, cfbRepo, picksRepo, _) = BuildCfbMocks(userId, slateNumber: 1);
+        var currentSlateService = BuildCurrentSlateService(season: null);
+
+        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo, currentSlateService);
+        var result = await service.BuildLeaderboard(1, 2025);
+
+        Assert.Single(result[0].WeekResults);
+    }
+
+    private static (ILeagueRepository repo, ICfbRepository cfbRepo, ICfbPicksRepository picksRepo, ICfbCurrentSlateService currentSlateService)
         BuildCfbMultiUserMocks(IReadOnlyList<string> winnerIds, IReadOnlyList<string> loserIds,
             int slateNumber = 19, int weeklyCost = 5) {
         // winnerIds pick IU (home, spread=-7): 28-7+juice-14>0 always (decisive win at any juice≥0).
@@ -454,7 +542,7 @@ public class LeaderboardServiceTests {
                 new CfbPicks { CfbSlateId = slateId, Team = "OSU", PickType = PickType.Spread, Season = 2025 }
             ]);
 
-        return (leagueRepo, cfbRepo, picksRepo);
+        return (leagueRepo, cfbRepo, picksRepo, BuildCurrentSlateService(slateNumber: slateNumber));
     }
 
     // Slates 18 (Semifinals) and 19 (Championship) must both use JuiceConference, not 0.
@@ -465,7 +553,7 @@ public class LeaderboardServiceTests {
     [InlineData(19)]
     public async Task CfbBuildLeaderboard_SemiAndChampionshipUseConferenceTease(int slateNumber) {
         var userId = Guid.NewGuid().ToString();
-        var (leagueRepo, cfbRepo, picksRepo) = BuildCfbMocks(userId, slateNumber: slateNumber);
+        var (leagueRepo, cfbRepo, picksRepo, currentSlateService) = BuildCfbMocks(userId, slateNumber: slateNumber);
 
         cfbRepo.GetSpreadsForSlateAsync(1).Returns((IEnumerable<CfbSpreads>)[
             new CfbSpreads { Id = 1, CfbSlateId = 1, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -10, AwayTeamSpread = 10, OverUnder = 50, IsLeagueEligible = true }
@@ -474,7 +562,7 @@ public class LeaderboardServiceTests {
             new CfbScores { Id = 1, CfbSlateId = 1, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 20, GameStatus = TypeName.StatusFinal }
         ]);
 
-        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo);
+        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo, currentSlateService);
         var result = await service.BuildLeaderboard(1, 2025);
 
         // 28 + (-10) + JuiceConference(6) - 20 = 4 > 0 → Won
@@ -489,9 +577,9 @@ public class LeaderboardServiceTests {
         int winnerCount, int loserCount, int weeklyCost, long expectedWinnerScore, long expectedLoserScore) {
         var winnerIds = Enumerable.Range(0, winnerCount).Select(_ => Guid.NewGuid().ToString()).ToList();
         var loserIds  = Enumerable.Range(0, loserCount).Select(_ => Guid.NewGuid().ToString()).ToList();
-        var (leagueRepo, cfbRepo, picksRepo) = BuildCfbMultiUserMocks(winnerIds, loserIds, weeklyCost: weeklyCost);
+        var (leagueRepo, cfbRepo, picksRepo, currentSlateService) = BuildCfbMultiUserMocks(winnerIds, loserIds, weeklyCost: weeklyCost);
 
-        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo);
+        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo, currentSlateService);
         var result = await service.BuildLeaderboard(1, 2025);
 
         Assert.Equal(winnerCount + loserCount, result.Count);
@@ -507,7 +595,8 @@ public class LeaderboardServiceTests {
         var leagueRepo = Substitute.For<ILeagueRepository>();
         var cfbRepo = Substitute.For<ICfbRepository>();
         var picksRepo = Substitute.For<ICfbPicksRepository>();
-        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo);
+        var currentSlateService = Substitute.For<ICfbCurrentSlateService>();
+        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo, currentSlateService);
 
         var result = await service.BuildLeaderboard(0, 2025);
 

--- a/Server/Data/Configurations/CfbRankingConfiguration.cs
+++ b/Server/Data/Configurations/CfbRankingConfiguration.cs
@@ -9,6 +9,6 @@ public class CfbRankingConfiguration : IEntityTypeConfiguration<CfbRanking>
     public void Configure(EntityTypeBuilder<CfbRanking> entity)
     {
         entity.HasKey(e => e.Id);
-        entity.HasIndex(e => new { e.Season, e.EspnWeekNumber, e.EspnEventId, e.TeamAbbreviation });
+        entity.HasIndex(e => new { e.Season, e.EspnWeekNumber, e.TeamAbbreviation }).IsUnique();
     }
 }

--- a/Server/Jobs/CfbRankingCaptureJob.cs
+++ b/Server/Jobs/CfbRankingCaptureJob.cs
@@ -14,9 +14,9 @@ namespace FourPlayWebApp.Server.Jobs;
 // Waiting until lock time meant eligibility data was only as fresh as the latest lock.
 //
 // CfbSpreadJob keeps its own (later) ranking capture too — it's "free" (rides along with the odds
-// fetch already being made) and adds real audit value (did a team's rank move between
-// schedule-known and spread-locked). CfbRanking is append-only by design, so two captures over the
-// week is more complete history, not redundant noise.
+// fetch already being made) and lets a rank move between schedule-known and spread-locked time
+// win: AddRankingsAsync upserts one row per (Season, EspnWeekNumber, TeamAbbreviation), so the
+// later capture simply overwrites the earlier one rather than appending a second row.
 [DisallowConcurrentExecution]
 public class CfbRankingCaptureJob(ICfbLiveScoreFetcher fetcher, ICfbRepository repo, TimeProvider timeProvider) : IJob {
     private static int Season => DateTime.UtcNow.Month >= 8 ? DateTime.UtcNow.Year : DateTime.UtcNow.Year - 1;

--- a/Server/Jobs/CfbRankingExtractor.cs
+++ b/Server/Jobs/CfbRankingExtractor.cs
@@ -17,7 +17,7 @@ internal static class CfbRankingExtractor {
 
             var eventId = int.Parse(evt.Id);
             rankings.AddRange(comp.Competitors
-                .Where(c => c.CuratedRank is not null)
+                .Where(c => CfbSlateHelpers.RankOf(c) is not null)
                 .Select(c => new CfbRanking {
                     Season           = slate.Season,
                     EspnWeekNumber   = slate.EspnWeekNumber ?? 0,

--- a/Server/Migrations/20260903230821_RankingUniquePerTeamWeek.Designer.cs
+++ b/Server/Migrations/20260903230821_RankingUniquePerTeamWeek.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260903230821_RankingUniquePerTeamWeek")]
+    partial class RankingUniquePerTeamWeek
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/20260903230821_RankingUniquePerTeamWeek.cs
+++ b/Server/Migrations/20260903230821_RankingUniquePerTeamWeek.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class RankingUniquePerTeamWeek : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // CfbRanking used to be append-only (one row per capture, including ESPN's 99
+            // "unranked" sentinel). Before the new unique index below can be created, prod data
+            // must be cleaned up: drop the unranked noise, then dedupe down to one row per
+            // (Season, EspnWeekNumber, TeamAbbreviation) — keeping the most recently captured row.
+            migrationBuilder.Sql(@"
+                DELETE FROM ""CfbRankings"" WHERE ""CuratedRank"" NOT BETWEEN 1 AND 25;
+
+                DELETE FROM ""CfbRankings"" a
+                USING ""CfbRankings"" b
+                WHERE a.""Season"" = b.""Season""
+                  AND a.""EspnWeekNumber"" = b.""EspnWeekNumber""
+                  AND a.""TeamAbbreviation"" = b.""TeamAbbreviation""
+                  AND (a.""CapturedAtUtc"" < b.""CapturedAtUtc""
+                       OR (a.""CapturedAtUtc"" = b.""CapturedAtUtc"" AND a.""Id"" < b.""Id""));
+            ");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CfbRankings_Season_EspnWeekNumber_EspnEventId_TeamAbbreviat~",
+                table: "CfbRankings");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CfbRankings_Season_EspnWeekNumber_TeamAbbreviation",
+                table: "CfbRankings",
+                columns: new[] { "Season", "EspnWeekNumber", "TeamAbbreviation" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CfbRankings_Season_EspnWeekNumber_TeamAbbreviation",
+                table: "CfbRankings");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CfbRankings_Season_EspnWeekNumber_EspnEventId_TeamAbbreviat~",
+                table: "CfbRankings",
+                columns: new[] { "Season", "EspnWeekNumber", "EspnEventId", "TeamAbbreviation" });
+        }
+    }
+}

--- a/Server/Migrations/20260903230821_RankingUniquePerTeamWeek.cs
+++ b/Server/Migrations/20260903230821_RankingUniquePerTeamWeek.cs
@@ -17,13 +17,17 @@ namespace FourPlayWebApp.Server.Migrations
             migrationBuilder.Sql(@"
                 DELETE FROM ""CfbRankings"" WHERE ""CuratedRank"" NOT BETWEEN 1 AND 25;
 
-                DELETE FROM ""CfbRankings"" a
-                USING ""CfbRankings"" b
-                WHERE a.""Season"" = b.""Season""
-                  AND a.""EspnWeekNumber"" = b.""EspnWeekNumber""
-                  AND a.""TeamAbbreviation"" = b.""TeamAbbreviation""
-                  AND (a.""CapturedAtUtc"" < b.""CapturedAtUtc""
-                       OR (a.""CapturedAtUtc"" = b.""CapturedAtUtc"" AND a.""Id"" < b.""Id""));
+                DELETE FROM ""CfbRankings""
+                WHERE ""Id"" IN (
+                    SELECT ""Id"" FROM (
+                        SELECT ""Id"", ROW_NUMBER() OVER (
+                            PARTITION BY ""Season"", ""EspnWeekNumber"", ""TeamAbbreviation""
+                            ORDER BY ""CapturedAtUtc"" DESC, ""Id"" DESC
+                        ) AS rn
+                        FROM ""CfbRankings""
+                    ) ranked
+                    WHERE rn > 1
+                );
             ");
 
             migrationBuilder.DropIndex(

--- a/Server/Models/Data/CfbRanking.cs
+++ b/Server/Models/Data/CfbRanking.cs
@@ -1,8 +1,10 @@
 namespace FourPlayWebApp.Server.Models.Data;
 
-// Append-only audit trail of AP Top 25 rank at the moment CfbSpreadJob fetched a week's scoreboard —
-// written for every competitor, ranked or not, so the full weekly rank picture is preserved even
-// for teams that never became league-eligible (frizat-9m0). ESPN uses 99 for unranked.
+// One row per (Season, EspnWeekNumber, TeamAbbreviation) — AP Top 25 rank does not change once
+// captured for a given week, so later captures (CfbRankingCaptureJob, then CfbSpreadJob riding
+// along with its odds fetch) upsert this row rather than appending a new one. Only genuinely
+// ranked teams (1-25) get a row at all; ESPN's 99 "unranked" sentinel is filtered out before it
+// ever reaches this table (see CfbRankingExtractor / CfbSlateHelpers.RankOf).
 public class CfbRanking {
     public int Id { get; set; }
     public int Season { get; set; }

--- a/Server/Services/CfbLeaderboardService.cs
+++ b/Server/Services/CfbLeaderboardService.cs
@@ -22,10 +22,17 @@ public class CfbLeaderboardService(
         if (leagueId == 0) return leaderboard;
 
         try {
-            var leagueUsers = await leagueRepository.GetLeagueUserMappingsAsync(leagueId);
-            var juiceMapping = await leagueRepository.GetLeagueJuiceMappingAsync(leagueId, season);
-            var slates = (await cfbRepository.GetSlatesForSeasonAsync(season))
-                .OrderBy(s => s.SlateNumber).ToList();
+            // Four independent lookups (no data dependency between them, each on its own
+            // DbContext via the repository pattern) — kick them all off before awaiting instead
+            // of paying for four sequential round-trips.
+            var leagueUsersTask = leagueRepository.GetLeagueUserMappingsAsync(leagueId);
+            var juiceMappingTask = leagueRepository.GetLeagueJuiceMappingAsync(leagueId, season);
+            var slatesTask = cfbRepository.GetSlatesForSeasonAsync(season);
+            var currentSlateTask = currentSlateService.GetCurrentSlateAsync();
+
+            var leagueUsers = await leagueUsersTask;
+            var juiceMapping = await juiceMappingTask;
+            var slates = (await slatesTask).OrderBy(s => s.SlateNumber).ToList();
 
             // CfbSlates is fully seeded for the whole season up front (CfbSlateSeederJob), unlike
             // NFL's NflScores rows, which only exist once a game is FINAL — so NFL's leaderboard
@@ -33,7 +40,7 @@ public class CfbLeaderboardService(
             // showing every future slate as a missed week. Uses the same shared "what's current"
             // resolver NflCurrentWeekService/CfbCurrentSlateService both already go through
             // (SeasonWindowResolver), not a CFB-only reimplementation.
-            var currentSlate = await currentSlateService.GetCurrentSlateAsync();
+            var currentSlate = await currentSlateTask;
             if (currentSlate is not null) {
                 if (currentSlate.Season == season)
                     slates = slates.Where(s => s.SlateNumber <= currentSlate.SlateNumber).ToList();

--- a/Server/Services/CfbLeaderboardService.cs
+++ b/Server/Services/CfbLeaderboardService.cs
@@ -13,7 +13,8 @@ public class CfbLeaderboardService(
     ILogger<CfbLeaderboardService> logger,
     ILeagueRepository leagueRepository,
     ICfbRepository cfbRepository,
-    ICfbPicksRepository cfbPicksRepository)
+    ICfbPicksRepository cfbPicksRepository,
+    ICfbCurrentSlateService currentSlateService)
     : ICfbLeaderboardService {
 
     public async Task<List<LeaderboardModel>> BuildLeaderboard(int leagueId, int season) {
@@ -25,6 +26,21 @@ public class CfbLeaderboardService(
             var juiceMapping = await leagueRepository.GetLeagueJuiceMappingAsync(leagueId, season);
             var slates = (await cfbRepository.GetSlatesForSeasonAsync(season))
                 .OrderBy(s => s.SlateNumber).ToList();
+
+            // CfbSlates is fully seeded for the whole season up front (CfbSlateSeederJob), unlike
+            // NFL's NflScores rows, which only exist once a game is FINAL — so NFL's leaderboard
+            // naturally stops at "now" for free, while CFB needs this explicit clamp to avoid
+            // showing every future slate as a missed week. Uses the same shared "what's current"
+            // resolver NflCurrentWeekService/CfbCurrentSlateService both already go through
+            // (SeasonWindowResolver), not a CFB-only reimplementation.
+            var currentSlate = await currentSlateService.GetCurrentSlateAsync();
+            if (currentSlate is not null) {
+                if (currentSlate.Season == season)
+                    slates = slates.Where(s => s.SlateNumber <= currentSlate.SlateNumber).ToList();
+                else if (season > currentSlate.Season)
+                    slates = []; // that season hasn't started yet
+                // season < currentSlate.Season: a fully completed past season — show it all.
+            }
 
             if (juiceMapping is null || leagueUsers.Count == 0 || slates.Count == 0)
                 return leaderboard;

--- a/Server/Services/Repositories/CfbRepository.cs
+++ b/Server/Services/Repositories/CfbRepository.cs
@@ -96,34 +96,37 @@ public class CfbRepository(IDbContextFactory<ApplicationDbContext> dbFactory) : 
         return await db.CfbSpreads.Where(s => s.CfbSlateId == cfbSlateId).ToListAsync();
     }
 
+    // Rank doesn't change once captured for a week, so a later capture (CfbRankingCaptureJob,
+    // then CfbSpreadJob riding along with its odds fetch) overwrites the same row rather than
+    // appending a new one — enforced by the unique index on (Season, EspnWeekNumber, TeamAbbreviation).
     public async Task AddRankingsAsync(IEnumerable<CfbRanking> rankings) {
         await using var db = await dbFactory.CreateDbContextAsync();
-        db.CfbRankings.AddRange(rankings);
+        var rankingList = rankings.ToList();
+        if (rankingList.Count == 0) return;
+
+        var seasons = rankingList.Select(r => r.Season).ToHashSet();
+        var weeks = rankingList.Select(r => r.EspnWeekNumber).ToHashSet();
+        var existingMap = await db.CfbRankings
+            .Where(r => seasons.Contains(r.Season) && weeks.Contains(r.EspnWeekNumber))
+            .ToDictionaryAsync(r => (r.Season, r.EspnWeekNumber, r.TeamAbbreviation));
+
+        foreach (var ranking in rankingList) {
+            if (!existingMap.TryGetValue((ranking.Season, ranking.EspnWeekNumber, ranking.TeamAbbreviation), out var existing))
+                db.CfbRankings.Add(ranking);
+            else {
+                existing.CuratedRank   = ranking.CuratedRank;
+                existing.EspnEventId   = ranking.EspnEventId;
+                existing.CapturedAtUtc = ranking.CapturedAtUtc;
+            }
+        }
         await db.SaveChangesAsync();
     }
 
-    // CfbRanking is append-only (CfbRankingCaptureJob's earlier run and CfbSpreadJob's later run
-    // both capture the same team-week), so "the" rank for a team is its most recently captured
-    // row. Resolved with a join against each team's own max(CapturedAtUtc) rather than pulling
-    // every capture into memory and reducing there.
     public async Task<Dictionary<string, int>> GetLatestRankingsForWeekAsync(int season, int espnWeekNumber) {
         await using var db = await dbFactory.CreateDbContextAsync();
-        var weekRankings = db.CfbRankings.Where(r => r.Season == season && r.EspnWeekNumber == espnWeekNumber);
-        var latestPerTeam = weekRankings
-            .GroupBy(r => r.TeamAbbreviation)
-            .Select(g => new { TeamAbbreviation = g.Key, CapturedAtUtc = g.Max(r => r.CapturedAtUtc) });
-
-        var latest = await weekRankings
-            .Join(latestPerTeam,
-                r => new { r.TeamAbbreviation, r.CapturedAtUtc },
-                l => new { l.TeamAbbreviation, l.CapturedAtUtc },
-                (r, l) => r)
-            .ToListAsync();
-
-        // GroupBy defends against a duplicate-timestamp tie (two captures for the same team in
-        // the same instant) matching more than one row in the join above — ToDictionary would
-        // otherwise throw on the duplicate key.
-        return latest.GroupBy(r => r.TeamAbbreviation).ToDictionary(g => g.Key, g => g.First().CuratedRank);
+        return await db.CfbRankings
+            .Where(r => r.Season == season && r.EspnWeekNumber == espnWeekNumber)
+            .ToDictionaryAsync(r => r.TeamAbbreviation, r => r.CuratedRank);
     }
 
     public async Task<IEnumerable<CfbScores>> GetScoresForSlateAsync(int cfbSlateId) {

--- a/Server/Services/Repositories/CfbRepository.cs
+++ b/Server/Services/Repositories/CfbRepository.cs
@@ -62,14 +62,11 @@ public class CfbRepository(IDbContextFactory<ApplicationDbContext> dbFactory) : 
         await using var db = await dbFactory.CreateDbContextAsync();
         var spreadList = spreads.ToList();
         var slateIds = spreadList.Select(s => s.CfbSlateId).ToHashSet();
-        var existingMap = await db.CfbSpreads
-            .Where(s => slateIds.Contains(s.CfbSlateId))
-            .ToDictionaryAsync(s => (s.CfbSlateId, s.HomeTeam));
-
-        foreach (var spread in spreadList) {
-            if (!existingMap.TryGetValue((spread.CfbSlateId, spread.HomeTeam), out var existing))
-                db.CfbSpreads.Add(spread);
-            else {
+        await UpsertByKeyAsync(
+            db.CfbSpreads, spreadList,
+            s => (s.CfbSlateId, s.HomeTeam),
+            db.CfbSpreads.Where(s => slateIds.Contains(s.CfbSlateId)),
+            (existing, spread) => {
                 existing.AwayTeam         = spread.AwayTeam;
                 existing.HomeTeamSpread   = spread.HomeTeamSpread;
                 existing.AwayTeamSpread   = spread.AwayTeamSpread;
@@ -77,8 +74,7 @@ public class CfbRepository(IDbContextFactory<ApplicationDbContext> dbFactory) : 
                 existing.GameTime         = spread.GameTime;
                 existing.IsLeagueEligible = spread.IsLeagueEligible;
                 // DateCreated intentionally NOT overwritten — preserves when the line was first posted.
-            }
-        }
+            });
         await db.SaveChangesAsync();
     }
 
@@ -104,21 +100,19 @@ public class CfbRepository(IDbContextFactory<ApplicationDbContext> dbFactory) : 
         var rankingList = rankings.ToList();
         if (rankingList.Count == 0) return;
 
-        var seasons = rankingList.Select(r => r.Season).ToHashSet();
+        // Every caller (CfbRankingCaptureJob's whole-season sweep, CfbSpreadJob's single-slate
+        // capture) only ever produces rankings for one season per call — no need for a HashSet.
+        var season = rankingList[0].Season;
         var weeks = rankingList.Select(r => r.EspnWeekNumber).ToHashSet();
-        var existingMap = await db.CfbRankings
-            .Where(r => seasons.Contains(r.Season) && weeks.Contains(r.EspnWeekNumber))
-            .ToDictionaryAsync(r => (r.Season, r.EspnWeekNumber, r.TeamAbbreviation));
-
-        foreach (var ranking in rankingList) {
-            if (!existingMap.TryGetValue((ranking.Season, ranking.EspnWeekNumber, ranking.TeamAbbreviation), out var existing))
-                db.CfbRankings.Add(ranking);
-            else {
+        await UpsertByKeyAsync(
+            db.CfbRankings, rankingList,
+            r => (r.Season, r.EspnWeekNumber, r.TeamAbbreviation),
+            db.CfbRankings.Where(r => r.Season == season && weeks.Contains(r.EspnWeekNumber)),
+            (existing, ranking) => {
                 existing.CuratedRank   = ranking.CuratedRank;
                 existing.EspnEventId   = ranking.EspnEventId;
                 existing.CapturedAtUtc = ranking.CapturedAtUtc;
-            }
-        }
+            });
         await db.SaveChangesAsync();
     }
 
@@ -159,22 +153,39 @@ public class CfbRepository(IDbContextFactory<ApplicationDbContext> dbFactory) : 
         await using var db = await dbFactory.CreateDbContextAsync();
         var scoreList = scores.ToList();
         var slateIds = scoreList.Select(s => s.CfbSlateId).ToHashSet();
-        var existingMap = await db.CfbScores
-            .Where(s => slateIds.Contains(s.CfbSlateId))
-            .ToDictionaryAsync(s => (s.CfbSlateId, s.HomeTeam));
-
-        foreach (var score in scoreList) {
-            if (!existingMap.TryGetValue((score.CfbSlateId, score.HomeTeam), out var existing))
-                db.CfbScores.Add(score);
-            else {
+        await UpsertByKeyAsync(
+            db.CfbScores, scoreList,
+            s => (s.CfbSlateId, s.HomeTeam),
+            db.CfbScores.Where(s => slateIds.Contains(s.CfbSlateId)),
+            (existing, score) => {
                 existing.HomeTeamScore       = score.HomeTeamScore;
                 existing.AwayTeamScore       = score.AwayTeamScore;
                 existing.GameStatus          = score.GameStatus;
                 existing.WeatherDisplayValue = score.WeatherDisplayValue;
                 existing.WeatherConditionId  = score.WeatherConditionId;
                 existing.WeatherTemperatureF = score.WeatherTemperatureF;
-            }
-        }
+            });
         await db.SaveChangesAsync();
+    }
+
+    // Shared "insert new / update in place" upsert behind UpsertAsync, UpsertCfbScoresAsync, and
+    // AddRankingsAsync — they differ only in entity type, composite key, the pre-filtered
+    // existing-rows query (each caller narrows it to just the rows that could possibly collide),
+    // and which fields carry over on update.
+    private static async Task UpsertByKeyAsync<TEntity, TKey>(
+        DbSet<TEntity> dbSet,
+        List<TEntity> items,
+        Func<TEntity, TKey> keySelector,
+        IQueryable<TEntity> existingRows,
+        Action<TEntity, TEntity> applyUpdate)
+        where TEntity : class
+        where TKey : notnull {
+        var existingMap = await existingRows.ToDictionaryAsync(keySelector);
+        foreach (var item in items) {
+            if (!existingMap.TryGetValue(keySelector(item), out var existing))
+                dbSet.Add(item);
+            else
+                applyUpdate(existing, item);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Cutting `dev` → `main`. Two PRs already merged and confirmed healthy on Railway dev:

**PR #305** — CFB leaderboard clamp, season-selector floor, ranking dedupe, PWA copy, theme fix
- CFB leaderboard now clamps to the current slate instead of showing every remaining week as a missed pick
- Season selector on Picks/Scores/Leaderboard now bounded by each league's own earliest configured season (shared `useLeagueMinSeason` hook, both sports)
- CFB AP Top 25 rankings: one upserted row per team per week instead of an unbounded append-only log (includes prod data cleanup migration)
- "Switch to CFB/NFL" now signals it'll open the browser when running as an installed PWA
- Dark-mode `--bg-2`/card-color collision fix (superseded in scope by PR #306 below, but still correct on its own)

**PR #306** — background retiling every viewport height, root-caused
- `body`'s background (two decorative gradients + linear gradient) was retiling every exact `100vh` down any page taller than one screen, with no `background-repeat` ever set — a real seam at every tile boundary, on every long page (Rules, Changelog, My Leagues, ...)
- Fixed at the CSS source: `background-color` fallback + `background-image` sized to one viewport with `background-repeat: no-repeat`
- `style-guide` skill updated to document all three related-but-distinct background bugs found this week, so this doesn't need re-diagnosing next time

## Test plan

- [x] Both PRs individually: full backend + frontend test suites green, `/simplify`, independent code review, CI green on merge
- [x] Railway dev deploy confirmed SUCCESS for both merges
- [x] Background fix verified via headless-browser screenshot + pixel-level seam detection, both themes, short and long pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2)_