### PR TITLE
Recover safe-area insets after returning from a modal Safari sheet

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -7,6 +7,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 ## 2026-09-04
 
 - Fixed: the page background retiled every screen-height down any page taller than one viewport (Rules, Changelog, and others), creating a visible seam every scroll — root cause of the repeated "background looks inconsistent" reports; fixed once at the CSS source instead of per-page
+- Fixed: returning to the installed iOS home-screen app from the Safari sheet opened by "Switch to CFB/NFL" could leave the top bar rendered under the Dynamic Island/status bar until the next reload
 
 ## 2026-09-03
 

--- a/Client.React/src/__tests__/useSafeAreaRefresh.test.tsx
+++ b/Client.React/src/__tests__/useSafeAreaRefresh.test.tsx
@@ -1,0 +1,68 @@
+import { renderHook } from '@testing-library/react';
+import { useSafeAreaRefresh } from '../utils/useSafeAreaRefresh';
+
+function setVisibilityState(state: DocumentVisibilityState) {
+  Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+}
+
+describe('useSafeAreaRefresh', () => {
+  afterEach(() => {
+    setVisibilityState('visible');
+    document.documentElement.style.display = '';
+  });
+
+  it('forces a reflow (display toggled off, then restored) when the document becomes visible', () => {
+    setVisibilityState('visible');
+    renderHook(() => useSafeAreaRefresh());
+
+    const seen: string[] = [];
+    const originalDescriptor = Object.getOwnPropertyDescriptor(document.documentElement.style, 'display')
+      ?? Object.getOwnPropertyDescriptor(CSSStyleDeclaration.prototype, 'display');
+    let current = '';
+    Object.defineProperty(document.documentElement.style, 'display', {
+      configurable: true,
+      get: () => current,
+      set: (value: string) => { current = value; seen.push(value); },
+    });
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(seen).toEqual(['none', '']);
+
+    if (originalDescriptor) {
+      Object.defineProperty(document.documentElement.style, 'display', originalDescriptor);
+    }
+  });
+
+  it('does nothing when the document is not visible', () => {
+    setVisibilityState('hidden');
+    renderHook(() => useSafeAreaRefresh());
+
+    const seen: string[] = [];
+    const originalDescriptor = Object.getOwnPropertyDescriptor(document.documentElement.style, 'display')
+      ?? Object.getOwnPropertyDescriptor(CSSStyleDeclaration.prototype, 'display');
+    let current = '';
+    Object.defineProperty(document.documentElement.style, 'display', {
+      configurable: true,
+      get: () => current,
+      set: (value: string) => { current = value; seen.push(value); },
+    });
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(seen).toEqual([]);
+
+    if (originalDescriptor) {
+      Object.defineProperty(document.documentElement.style, 'display', originalDescriptor);
+    }
+  });
+
+  it('removes the listener on unmount', () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    const { unmount } = renderHook(() => useSafeAreaRefresh());
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+    removeSpy.mockRestore();
+  });
+});

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -48,6 +48,7 @@ import { useSportContext } from '../services/sport';
 import { useThemeMode } from '../services/theme';
 import { isAdmin } from '../utils/auth';
 import { isStandalonePwa } from '../utils/pwa';
+import { useSafeAreaRefresh } from '../utils/useSafeAreaRefresh';
 import PendingInviteBanner from '../components/PendingInviteBanner';
 import VersionFooter from '../components/VersionFooter';
 
@@ -85,6 +86,7 @@ export default function AppLayout() {
   const { mode, toggleTheme } = useThemeMode();
   const navigate = useNavigate();
   const location = useLocation();
+  useSafeAreaRefresh();
 
   const getOtherSportUrl = () => {
     const { hostname, port, protocol } = window.location;

--- a/Client.React/src/utils/useSafeAreaRefresh.ts
+++ b/Client.React/src/utils/useSafeAreaRefresh.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+
+/**
+ * Works around an iOS WebKit bug where `env(safe-area-inset-*)` goes stale after an installed
+ * standalone PWA regains foreground from a modal overlay — most reproducibly the Safari sheet
+ * opened by a cross-origin link (see AppLayout's "Switch to CFB/NFL" control and utils/pwa.ts).
+ * Content that depends on `--safe-inset-top` (the fixed AppBar) then renders under the Dynamic
+ * Island/status bar again until something forces WebKit to recompute the env() values — toggling
+ * `display` on the root element forces exactly that recalculation via a synchronous reflow.
+ * A no-op everywhere `env()` doesn't apply (desktop, Android, a normal browser tab).
+ */
+export function useSafeAreaRefresh() {
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') return;
+      const { documentElement } = document;
+      documentElement.style.display = 'none';
+      void documentElement.offsetHeight; // force synchronous reflow before restoring display
+      documentElement.style.display = '';
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, []);
+}


### PR DESCRIPTION
## Summary

Follow-up to the PWA switch-sport copy fix — reported: after tapping "Switch to CFB/NFL" on iOS, dismissing the resulting Safari sheet ("X out") leaves the installed webapp's top bar rendered under the Dynamic Island/status bar.

- iOS WebKit can leave `env(safe-area-inset-*)` stale after a standalone PWA regains foreground from a modal overlay (here, the Safari sheet that a cross-origin link always opens from standalone mode — a platform constraint, see `utils/pwa.ts`). The fixed AppBar, which depends on `--safe-inset-top`, then renders under the Dynamic Island/status bar until the next reload.
- Fix: force a synchronous reflow on `visibilitychange` when the document becomes visible again, which nudges WebKit into recomputing the `env()` values. No-op everywhere `env()` doesn't apply (desktop, Android, a normal browser tab).

**Caveat**: I can't independently verify this against real iOS hardware from this environment. This is the standard, commonly-documented mitigation for this exact class of WebKit safe-area staleness bug, but it needs confirmation on a real device before considering it fully closed.

## Test plan

- [x] New `useSafeAreaRefresh` hook + Vitest unit tests (reflow forced on visible, not forced on hidden, listener cleanup on unmount)
- [x] `npm run test -- --run` (561 tests), `npm run typecheck`, `npm run lint` — all green
- [x] `Client.React/CHANGELOG.md` updated
- [ ] Real-device verification on iOS (can't be done from this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2)_