### PR TITLE
fix(espn): fall back to Scheduled for unrecognized ESPN status/description wire values

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -8,6 +8,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 
 - Fixed: the page background retiled every screen-height down any page taller than one viewport (Rules, Changelog, and others), creating a visible seam every scroll — root cause of the repeated "background looks inconsistent" reports; fixed once at the CSS source instead of per-page
 - Fixed: returning to the installed iOS home-screen app from the Safari sheet opened by "Switch to CFB/NFL" could leave the top bar rendered under the Dynamic Island/status bar until the next reload
+- Fixed: a CFB or NFL game with an unusual ESPN status (postponed, delayed, canceled, rain delay, forfeit) could get stuck showing an incorrect status like Final for every other game that week too, since one unrecognized status previously broke parsing for the entire week's scoreboard
 
 ## 2026-09-03
 

--- a/Server.UnitTests/EspnJsonConverterTests.cs
+++ b/Server.UnitTests/EspnJsonConverterTests.cs
@@ -109,4 +109,106 @@ public class EspnJsonConverterTests
         Assert.Equal(HomeAway.Away, competitors.Single(c => c.Team.Abbreviation == "ATL").HomeAway);
         Assert.Equal(EspnRecordType.HomeRecord, competitors.Single(c => c.Team.Abbreviation == "IND").Records.Single().Type);
     }
+
+    // TypeNameConverter/DescriptionConverter previously threw on any status.type.name/description
+    // value outside our known 5 — but ESPN's real wire values also include things like
+    // STATUS_POSTPONED, STATUS_DELAYED, STATUS_CANCELED, STATUS_RAIN_DELAY, and STATUS_FORFEIT for
+    // weather/scheduling edge cases. Because System.Text.Json aborts the ENTIRE deserialization on
+    // any single property throwing, one game anywhere in a week's scoreboard entering one of these
+    // states broke live status/scores for every OTHER game in that week too — PeriodicRefreshCache
+    // (see PeriodicRefreshCache.cs) then silently keeps serving its last successfully-parsed
+    // snapshot indefinitely, which is how a game already showed as stuck-"Final" days after actually
+    // being scheduled: an unrelated game's odd status froze the whole week's cache at an earlier,
+    // now-stale snapshot. Unknown/unusual statuses must fall back to Scheduled — "not decided yet"
+    // is the only safe default; anything else risks showing a false Final (revealing a fake result,
+    // wrongly locking picks) or a false Live/other state.
+    [Theory]
+    [InlineData("STATUS_POSTPONED")]
+    [InlineData("STATUS_DELAYED")]
+    [InlineData("STATUS_CANCELED")]
+    [InlineData("STATUS_RAIN_DELAY")]
+    [InlineData("STATUS_FORFEIT")]
+    [InlineData("STATUS_SOME_FUTURE_ESPN_VALUE_WE_DONT_KNOW_ABOUT_YET")]
+    public void TypeNameConverter_FallsBackToScheduled_ForUnrecognizedWireValues(string wireValue)
+    {
+        var json = $$"""{"id":"1","name":"{{wireValue}}","state":"pre","completed":false,"description":"Postponed","detail":"","shortDetail":""}""";
+
+        var statusType = System.Text.Json.JsonSerializer.Deserialize<StatusType>(json, EspnApiServiceJsonConverter.Settings);
+
+        Assert.Equal(TypeName.StatusScheduled, statusType!.Name);
+    }
+
+    [Theory]
+    [InlineData("Postponed")]
+    [InlineData("Delayed")]
+    [InlineData("Canceled")]
+    [InlineData("Some future ESPN description we don't know about yet")]
+    public void DescriptionConverter_FallsBackToScheduled_ForUnrecognizedWireValues(string wireValue)
+    {
+        var json = $$"""{"id":"1","name":"STATUS_SCHEDULED","state":"pre","completed":false,"description":"{{wireValue}}","detail":"","shortDetail":""}""";
+
+        var statusType = System.Text.Json.JsonSerializer.Deserialize<StatusType>(json, EspnApiServiceJsonConverter.Settings);
+
+        Assert.Equal(Description.Scheduled, statusType!.Description);
+    }
+
+    // The real-world failure mode: one game with an unrecognized status must not break every OTHER
+    // game in the same scoreboard payload — this is what actually broke, not just the isolated
+    // converter (System.Text.Json aborts the whole object graph on any single property throwing).
+    [Fact]
+    public async Task CfbApiService_GetScoresByWeekAsync_OneGameWithUnrecognizedStatus_DoesNotBreakOtherGames()
+    {
+        const string payload = """
+            {
+              "events": [
+                {
+                  "id": "1",
+                  "date": "2025-11-01T00:00Z",
+                  "competitions": [
+                    {
+                      "id": "1",
+                      "date": "2025-11-01T00:00Z",
+                      "status": {
+                        "clock": 0, "displayClock": "0:00", "period": 0,
+                        "type": { "id": "9", "name": "STATUS_POSTPONED", "state": "pre", "completed": false, "description": "Postponed", "detail": "Postponed", "shortDetail": "Postponed" }
+                      },
+                      "competitors": [
+                        { "id": "1", "homeAway": "home", "team": { "abbreviation": "USC" }, "score": "0", "records": [] },
+                        { "id": "2", "homeAway": "away", "team": { "abbreviation": "FRES" }, "score": "0", "records": [] }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "id": "2",
+                  "date": "2025-11-01T00:00Z",
+                  "competitions": [
+                    {
+                      "id": "2",
+                      "date": "2025-11-01T00:00Z",
+                      "status": {
+                        "clock": 0, "displayClock": "0:00", "period": 2,
+                        "type": { "id": "2", "name": "STATUS_IN_PROGRESS", "state": "in", "completed": false, "description": "In Progress", "detail": "In Progress", "shortDetail": "In Progress" }
+                      },
+                      "competitors": [
+                        { "id": "3", "homeAway": "home", "team": { "abbreviation": "OU" }, "score": "14", "records": [] },
+                        { "id": "4", "homeAway": "away", "team": { "abbreviation": "UTEP" }, "score": "7", "records": [] }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """;
+        var httpClient = new HttpClient(new StubHttpMessageHandler(payload)) { BaseAddress = new Uri("http://site.api.espn.com") };
+        var service = new CfbApiService(httpClient);
+
+        var scores = await service.GetScoresByWeekAsync(week: 1, isPostSeason: false);
+
+        Assert.Equal(2, scores!.Events!.Length);
+        var uscComp = scores.Events.Single(e => e.Competitions[0].Competitors.Any(c => c.Team.Abbreviation == "USC")).Competitions[0];
+        Assert.Equal(TypeName.StatusScheduled, uscComp.Status.Type.Name); // postponed falls back to scheduled, not Final
+        var utepComp = scores.Events.Single(e => e.Competitions[0].Competitors.Any(c => c.Team.Abbreviation == "UTEP")).Competitions[0];
+        Assert.Equal(TypeName.StatusInProgress, utepComp.Status.Type.Name); // the other game parses normally, unaffected
+    }
 }

--- a/Shared/Models/ESPNApiDataTypes.cs
+++ b/Shared/Models/ESPNApiDataTypes.cs
@@ -394,7 +394,13 @@ internal class DescriptionConverter : JsonConverter<Description>
             "In Progress" => Description.InProgress,
             "Scheduled" => Description.Scheduled,
             "End of Period" => Description.EndOfPeriod,
-            _ => throw new Exception("Cannot unmarshal type Description")
+            // ESPN's real wire vocabulary also includes values we don't model (Postponed, Delayed,
+            // Canceled, etc.) for weather/scheduling edge cases. System.Text.Json aborts the ENTIRE
+            // deserialization on any single converter throwing, so one game with an unrecognized
+            // description would previously break every other game in the same week's payload
+            // (see PeriodicRefreshCache, which then silently serves the last successful snapshot
+            // forever). "Scheduled" — not decided yet — is the only safe fallback.
+            _ => Description.Scheduled
         };
 
     public override void Write(Utf8JsonWriter writer, Description value, JsonSerializerOptions options) =>
@@ -421,7 +427,11 @@ internal class TypeNameConverter : JsonConverter<TypeName>
             "STATUS_IN_PROGRESS" => TypeName.StatusInProgress,
             "STATUS_SCHEDULED" => TypeName.StatusScheduled,
             "STATUS_END_PERIOD" => TypeName.StatusEndPeriod,
-            _ => throw new Exception("Cannot unmarshal type TypeName")
+            // Same rationale as DescriptionConverter above: ESPN's real wire vocabulary includes
+            // status names we don't model (STATUS_POSTPONED, STATUS_DELAYED, STATUS_CANCELED,
+            // STATUS_RAIN_DELAY, STATUS_FORFEIT, etc.). Falling back to Scheduled instead of
+            // throwing keeps one unusual game from breaking deserialization of the whole week.
+            _ => TypeName.StatusScheduled
         };
 
     public override void Write(Utf8JsonWriter writer, TypeName value, JsonSerializerOptions options) =>


### PR DESCRIPTION
## Summary

- `TypeNameConverter`/`DescriptionConverter` (`Shared/Models/ESPNApiDataTypes.cs`) threw on any `status.type.name`/`status.type.description` value outside our known 5 — but ESPN's real wire vocabulary also includes `STATUS_POSTPONED`, `STATUS_DELAYED`, `STATUS_CANCELED`, `STATUS_RAIN_DELAY`, `STATUS_FORFEIT`, etc. for weather/scheduling edge cases
- Because `System.Text.Json` aborts deserialization of the entire object graph on any single property converter throwing, one game anywhere in a week's CFB or NFL scoreboard entering one of these unusual states broke live status/scores for every OTHER game in that same week's payload
- `PeriodicRefreshCache` then silently kept serving its last successfully-parsed snapshot indefinitely (no escalation) — this is how a game could show a stale/incorrect status (e.g. "Final") for days: an unrelated game's odd status had frozen the whole week's cache at an earlier, now-stale snapshot
- Fix: both converters now fall back to `Scheduled` ("not decided yet" — the only safe default) instead of throwing on an unrecognized value
- Shared infrastructure (`EspnApiServiceJsonConverter.Settings`), so this fix covers both NFL and CFB parsing automatically

Root-caused from a live production report: CFB's USC game was showing "Final" on the prod site while not actually having started.

## Test plan

- [x] New TDD unit tests in `Server.UnitTests/EspnJsonConverterTests.cs`:
  - `TypeNameConverter_FallsBackToScheduled_ForUnrecognizedWireValues` (6 unrecognized status strings)
  - `DescriptionConverter_FallsBackToScheduled_ForUnrecognizedWireValues` (4 unrecognized description strings)
  - `CfbApiService_GetScoresByWeekAsync_OneGameWithUnrecognizedStatus_DoesNotBreakOtherGames` — end-to-end regression proving one bad game's status doesn't break parsing of the rest of the week's payload
- [x] `dotnet test --filter "FullyQualifiedName~EspnJsonConverterTests"` — 20/20 passed
- [x] Full backend suite (`dotnet test --filter "Category!=Contract"`) — 810/813 passed; the 3 failures are pre-existing Docker/Testcontainers-dependent tests that can't run in this sandbox (no Docker daemon), unrelated to this change
- [x] `Client.React/CHANGELOG.md` entry added under `## 2026-09-04`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2)_