### PR TITLE
fix(espn): make StatusType.Name/Description required to close a silent-default-to-Final gap

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 - Fixed: the page background retiled every screen-height down any page taller than one viewport (Rules, Changelog, and others), creating a visible seam every scroll — root cause of the repeated "background looks inconsistent" reports; fixed once at the CSS source instead of per-page
 - Fixed: returning to the installed iOS home-screen app from the Safari sheet opened by "Switch to CFB/NFL" could leave the top bar rendered under the Dynamic Island/status bar until the next reload
 - Fixed: a CFB or NFL game with an unusual ESPN status (postponed, delayed, canceled, rain delay, forfeit) could get stuck showing an incorrect status like Final for every other game that week too, since one unrecognized status previously broke parsing for the entire week's scoreboard
+- Fixed: a CFB or NFL game could silently show as Final before it even started if ESPN's response was ever missing the status field outright — that field now fails loudly and falls back to Scheduled instead of defaulting to Final
 
 ## 2026-09-03
 

--- a/Server.UnitTests/CfbCacheServiceTests.cs
+++ b/Server.UnitTests/CfbCacheServiceTests.cs
@@ -67,7 +67,13 @@ public class CfbCacheServiceTests
     private static EspnScores BuildScoreboard(TypeName status = TypeName.StatusInProgress, int homeScore = 14, int awayScore = 7) =>
         new() {
             Events = [new Event { Id = "1", Competitions = [new Competition {
-                Status = new EspnStatus { Type = new StatusType { Name = status } },
+                Status = new EspnStatus { Type = new StatusType { Name = status, Description = status switch {
+                    TypeName.StatusFinal => Description.Final,
+                    TypeName.StatusHalftime => Description.Halftime,
+                    TypeName.StatusInProgress => Description.InProgress,
+                    TypeName.StatusScheduled => Description.Scheduled,
+                    _ => Description.EndOfPeriod,
+                } } },
                 Competitors = [
                     new Competitor { HomeAway = HomeAway.Home, Score = homeScore, Team = new EspnTeam { Abbreviation = "IND" }, Records = [] },
                     new Competitor { HomeAway = HomeAway.Away, Score = awayScore, Team = new EspnTeam { Abbreviation = "ATL" }, Records = [] },

--- a/Server.UnitTests/CfbLiveScoreFetcherTests.cs
+++ b/Server.UnitTests/CfbLiveScoreFetcherTests.cs
@@ -50,7 +50,13 @@ public class CfbLiveScoreFetcherTests {
                 new Competitor { HomeAway = HomeAway.Home, Score = 41, Team = new EspnTeam { Abbreviation = homeAbbr }, Records = [] },
                 new Competitor { HomeAway = HomeAway.Away, Score = 21, Team = new EspnTeam { Abbreviation = awayAbbr }, Records = [] },
             ],
-            Status = new EspnStatus { Type = new StatusType { Name = status } },
+            Status = new EspnStatus { Type = new StatusType { Name = status, Description = status switch {
+                TypeName.StatusFinal => Description.Final,
+                TypeName.StatusHalftime => Description.Halftime,
+                TypeName.StatusInProgress => Description.InProgress,
+                TypeName.StatusScheduled => Description.Scheduled,
+                _ => Description.EndOfPeriod,
+            } } },
             Odds = [],
         };
         return new EspnScores {
@@ -67,7 +73,7 @@ public class CfbLiveScoreFetcherTests {
                 new Competitor { HomeAway = HomeAway.Home, Score = 28, Team = new EspnTeam { Abbreviation = "OSU" }, Records = [], CuratedRank = new CuratedRankInfo { Current = homeRank } },
                 new Competitor { HomeAway = HomeAway.Away, Score = 14, Team = new EspnTeam { Abbreviation = "NEB" }, Records = [], CuratedRank = new CuratedRankInfo { Current = awayRank } },
             ],
-            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusFinal } },
+            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusFinal, Description = Description.Final } },
             Odds = [],
         };
         return new EspnScores {

--- a/Server.UnitTests/CfbRankingCaptureJobTests.cs
+++ b/Server.UnitTests/CfbRankingCaptureJobTests.cs
@@ -62,7 +62,13 @@ public class CfbRankingCaptureJobTests
                 new Competitor { HomeAway = HomeAway.Away, Score = 0, Team = new EspnTeam { Abbreviation = awayAbbr }, Records = [],
                     CuratedRank = awayRank is { } ar ? new CuratedRankInfo { Current = ar } : null },
             ],
-            Status = new EspnStatus { Type = new StatusType { Name = status } },
+            Status = new EspnStatus { Type = new StatusType { Name = status, Description = status switch {
+                TypeName.StatusFinal => Description.Final,
+                TypeName.StatusHalftime => Description.Halftime,
+                TypeName.StatusInProgress => Description.InProgress,
+                TypeName.StatusScheduled => Description.Scheduled,
+                _ => Description.EndOfPeriod,
+            } } },
             Odds = [],
         };
         return new EspnScores {

--- a/Server.UnitTests/CfbScoresJobTests.cs
+++ b/Server.UnitTests/CfbScoresJobTests.cs
@@ -60,7 +60,13 @@ public class CfbScoresJobTests
                 new Competitor { HomeAway = HomeAway.Home, Score = homeScore, Team = new EspnTeam { Abbreviation = homeAbbr }, Records = [] },
                 new Competitor { HomeAway = HomeAway.Away,  Score = awayScore, Team = new EspnTeam { Abbreviation = awayAbbr }, Records = [] },
             ],
-            Status = new EspnStatus { Type = new StatusType { Name = status } },
+            Status = new EspnStatus { Type = new StatusType { Name = status, Description = status switch {
+                TypeName.StatusFinal => Description.Final,
+                TypeName.StatusHalftime => Description.Halftime,
+                TypeName.StatusInProgress => Description.InProgress,
+                TypeName.StatusScheduled => Description.Scheduled,
+                _ => Description.EndOfPeriod,
+            } } },
             Odds = [],
         };
         return new EspnScores {

--- a/Server.UnitTests/CfbSpreadJobTests.cs
+++ b/Server.UnitTests/CfbSpreadJobTests.cs
@@ -84,7 +84,13 @@ public class CfbSpreadJobTests
                 new Competitor { HomeAway = HomeAway.Away,  Score = 0, Team = new EspnTeam { Abbreviation = awayAbbr }, Records = [],
                     CuratedRank = awayRank is { } ar ? new CuratedRankInfo { Current = ar } : null },
             ],
-            Status = new EspnStatus { Type = new StatusType { Name = status } },
+            Status = new EspnStatus { Type = new StatusType { Name = status, Description = status switch {
+                TypeName.StatusFinal => Description.Final,
+                TypeName.StatusHalftime => Description.Halftime,
+                TypeName.StatusInProgress => Description.InProgress,
+                TypeName.StatusScheduled => Description.Scheduled,
+                _ => Description.EndOfPeriod,
+            } } },
             Odds = [],
         };
         return new EspnScores {

--- a/Server.UnitTests/EspnCacheServiceTests.cs
+++ b/Server.UnitTests/EspnCacheServiceTests.cs
@@ -132,8 +132,8 @@ public class EspnCacheServiceTests
     [Fact]
     public async Task ScoresChanged_Fires_WhenDataChanges()
     {
-        var first = new EspnScores { Events = [new Event { Id = "1", Competitions = [new Competition { Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled } }, Competitors = [new Competitor { HomeAway = HomeAway.Home, Score = 0 }, new Competitor { HomeAway = HomeAway.Away, Score = 0 }], Odds = [] }] }] };
-        var second = new EspnScores { Events = [new Event { Id = "1", Competitions = [new Competition { Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusFinal } }, Competitors = [new Competitor { HomeAway = HomeAway.Home, Score = 28 }, new Competitor { HomeAway = HomeAway.Away, Score = 17 }], Odds = [] }] }] };
+        var first = new EspnScores { Events = [new Event { Id = "1", Competitions = [new Competition { Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Description = Description.Scheduled } }, Competitors = [new Competitor { HomeAway = HomeAway.Home, Score = 0 }, new Competitor { HomeAway = HomeAway.Away, Score = 0 }], Odds = [] }] }] };
+        var second = new EspnScores { Events = [new Event { Id = "1", Competitions = [new Competition { Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusFinal, Description = Description.Final } }, Competitors = [new Competitor { HomeAway = HomeAway.Home, Score = 28 }, new Competitor { HomeAway = HomeAway.Away, Score = 17 }], Odds = [] }] }] };
 
         _espnApi.GetWeekScores(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<bool>()).Returns(
             Task.FromResult<EspnScores?>(first),
@@ -152,7 +152,7 @@ public class EspnCacheServiceTests
     [Fact]
     public async Task ScoresChanged_DoesNotFire_WhenDataUnchanged()
     {
-        var scores = new EspnScores { Events = [new Event { Id = "1", Competitions = [new Competition { Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusFinal } }, Competitors = [new Competitor { HomeAway = HomeAway.Home, Score = 28 }, new Competitor { HomeAway = HomeAway.Away, Score = 17 }], Odds = [] }] }] };
+        var scores = new EspnScores { Events = [new Event { Id = "1", Competitions = [new Competition { Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusFinal, Description = Description.Final } }, Competitors = [new Competitor { HomeAway = HomeAway.Home, Score = 28 }, new Competitor { HomeAway = HomeAway.Away, Score = 17 }], Odds = [] }] }] };
 
         _espnApi.GetWeekScores(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<bool>()).Returns(Task.FromResult<EspnScores?>(scores));
 

--- a/Server.UnitTests/EspnJsonConverterTests.cs
+++ b/Server.UnitTests/EspnJsonConverterTests.cs
@@ -152,6 +152,36 @@ public class EspnJsonConverterTests
         Assert.Equal(Description.Scheduled, statusType!.Description);
     }
 
+    // TypeName's first member (StatusFinal) is ordinal 0 — which is also C#'s default value for a
+    // TypeName field that's never actually set. Our controllers re-serialize this enum as a raw
+    // number (not our custom converter's string form — see EspnController), and the frontend
+    // hardcodes STATUS_FINAL = 0 and checks isGameOver() BEFORE isGameStarted() (gameHelpers.ts's
+    // toGameStatus). So a StatusType whose Name was never populated from JSON — e.g. ESPN's
+    // response is missing the "name" key entirely, which the converter never even sees since
+    // Read() is only invoked for a property that's present — would silently render as "Final" for
+    // a game that hasn't even kicked off, with no exception anywhere. `required` makes System.Text.Json
+    // track whether the property was actually set during deserialization, independent of the
+    // custom converter, and throw JsonException if it wasn't — turning a silent wrong answer into
+    // a loud, logged failure (which PeriodicRefreshCache/the direct fetch path already handle safely
+    // by falling back to "scheduled" rather than showing a fabricated result).
+    [Fact]
+    public void StatusType_MissingNameProperty_ThrowsInsteadOfDefaultingToFinal()
+    {
+        const string json = """{"id":"1","state":"pre","completed":false,"description":"Scheduled","detail":"","shortDetail":""}""";
+
+        Assert.Throws<System.Text.Json.JsonException>(() =>
+            System.Text.Json.JsonSerializer.Deserialize<StatusType>(json, EspnApiServiceJsonConverter.Settings));
+    }
+
+    [Fact]
+    public void StatusType_MissingDescriptionProperty_ThrowsInsteadOfDefaultingToFinal()
+    {
+        const string json = """{"id":"1","name":"STATUS_SCHEDULED","state":"pre","completed":false,"detail":"","shortDetail":""}""";
+
+        Assert.Throws<System.Text.Json.JsonException>(() =>
+            System.Text.Json.JsonSerializer.Deserialize<StatusType>(json, EspnApiServiceJsonConverter.Settings));
+    }
+
     // The real-world failure mode: one game with an unrecognized status must not break every OTHER
     // game in the same scoreboard payload — this is what actually broke, not just the isolated
     // converter (System.Text.Json aborts the whole object graph on any single property throwing).

--- a/Server.UnitTests/LiveGameDtoTests.cs
+++ b/Server.UnitTests/LiveGameDtoTests.cs
@@ -28,7 +28,7 @@ public class LiveGameDtoTests
                 new Competitor { Id = homeId, HomeAway = HomeAway.Home, Team = new EspnTeam { Abbreviation = homeAbbr }, Score = 0, Records = [] },
                 new Competitor { Id = awayId, HomeAway = HomeAway.Away, Team = new EspnTeam { Abbreviation = awayAbbr }, Score = 0, Records = [] },
             ],
-            Status = new EspnStatus { Type = new StatusType { Completed = completed } },
+            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusInProgress, Description = Description.InProgress, Completed = completed } },
             Odds = [],
             Situation = possessionId is null ? null : new EspnSitutation
             {

--- a/Server.UnitTests/NflScoresJobTests.cs
+++ b/Server.UnitTests/NflScoresJobTests.cs
@@ -81,7 +81,13 @@ public class NflScoresJobTests
             },
             Status = new EspnStatus
             {
-                Type = new StatusType { Name = statusName, Completed = isFinal }
+                Type = new StatusType { Name = statusName, Completed = isFinal, Description = statusName switch {
+                    TypeName.StatusFinal => Description.Final,
+                    TypeName.StatusHalftime => Description.Halftime,
+                    TypeName.StatusInProgress => Description.InProgress,
+                    TypeName.StatusScheduled => Description.Scheduled,
+                    _ => Description.EndOfPeriod,
+                } }
             },
             Odds = Array.Empty<Odd>()
         };

--- a/Server.UnitTests/NflSpreadJobTests.cs
+++ b/Server.UnitTests/NflSpreadJobTests.cs
@@ -91,7 +91,13 @@ public class NflSpreadJobTests
             },
             Status = new EspnStatus
             {
-                Type = new StatusType { Name = statusName, Completed = false }
+                Type = new StatusType { Name = statusName, Completed = false, Description = statusName switch {
+                    TypeName.StatusFinal => Description.Final,
+                    TypeName.StatusHalftime => Description.Halftime,
+                    TypeName.StatusInProgress => Description.InProgress,
+                    TypeName.StatusScheduled => Description.Scheduled,
+                    _ => Description.EndOfPeriod,
+                } }
             },
             Odds = Array.Empty<Odd>()
         };
@@ -422,7 +428,7 @@ public class NflSpreadJobTests
                                 new Competitor { Id = "2", HomeAway = HomeAway.Away, Score = 0,
                                     Team = new EspnTeam { Abbreviation = "BUF" }, Records = Array.Empty<EspnRecord>() }
                             },
-                            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled } },
+                            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Description = Description.Scheduled } },
                             Odds = Array.Empty<Odd>()
                         }
                     }
@@ -445,7 +451,7 @@ public class NflSpreadJobTests
                                 new Competitor { Id = "4", HomeAway = HomeAway.Away, Score = 0,
                                     Team = new EspnTeam { Abbreviation = "DAL" }, Records = Array.Empty<EspnRecord>() }
                             },
-                            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled } },
+                            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Description = Description.Scheduled } },
                             Odds = Array.Empty<Odd>()
                         }
                     }

--- a/Server.UnitTests/PicksTests.cs
+++ b/Server.UnitTests/PicksTests.cs
@@ -98,7 +98,7 @@ public class PicksTests
                                 new Competitor { Team = new EspnTeam { Abbreviation = "BUF" }, HomeAway = HomeAway.Home },
                                 new Competitor { Team = new EspnTeam { Abbreviation = "MIA" }, HomeAway = HomeAway.Away }
                             ],
-                            Status = new EspnStatus { Type = new StatusType { Completed = false } },
+                            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Description = Description.Scheduled, Completed = false } },
                             Odds = []
                         }
                     ]
@@ -393,7 +393,7 @@ public class PicksTests
                             new Competitor { Team = new EspnTeam { Abbreviation = "BUF" }, HomeAway = HomeAway.Home },
                             new Competitor { Team = new EspnTeam { Abbreviation = "MIA" }, HomeAway = HomeAway.Away }
                         ],
-                        Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Completed = false } },
+                        Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Description = Description.Scheduled, Completed = false } },
                         Odds = []
                     }
                 ]
@@ -412,7 +412,7 @@ public class PicksTests
                             new Competitor { Team = new EspnTeam { Abbreviation = "DAL" }, HomeAway = HomeAway.Home },
                             new Competitor { Team = new EspnTeam { Abbreviation = "NYG" }, HomeAway = HomeAway.Away }
                         ],
-                        Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusInProgress, Completed = false } },
+                        Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusInProgress, Description = Description.InProgress, Completed = false } },
                         Odds = []
                     }
                 ]
@@ -591,7 +591,7 @@ public class PicksTests
                                 new Competitor { Team = new EspnTeam { Abbreviation = "BUF" }, HomeAway = HomeAway.Home },
                                 new Competitor { Team = new EspnTeam { Abbreviation = "MIA" }, HomeAway = HomeAway.Away }
                             ],
-                            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Completed = false } },
+                            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Description = Description.Scheduled, Completed = false } },
                             Odds = []
                         }
                     ]

--- a/Server.UnitTests/ReplayCacheServiceTests.cs
+++ b/Server.UnitTests/ReplayCacheServiceTests.cs
@@ -16,7 +16,7 @@ namespace FourPlayWebApp.Server.UnitTests;
 public class ReplayCacheServiceTests {
     private static EspnScores Snapshot(string label) => new() {
         Events = [new Event { Id = "1", Competitions = [new Competition {
-            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled } },
+            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Description = Description.Scheduled } },
             Competitors = [], Odds = [],
         }] }],
         // Season used purely to distinguish snapshots by identity in these tests.

--- a/Shared/Models/ESPNApiDataTypes.cs
+++ b/Shared/Models/ESPNApiDataTypes.cs
@@ -180,14 +180,23 @@ public class StatusType
     [JsonPropertyName("id")]
     [JsonConverter(typeof(StringToLongConverter))]
     public long Id { get; set; }
+    // required: TypeName.StatusFinal is ordinal 0 — also C#'s default value for an unset TypeName
+    // field, and the frontend's isGameOver() check treats a raw wire value of 0 as "Final" before
+    // it even checks whether the game has started (gameHelpers.ts's toGameStatus). If ESPN's JSON
+    // ever omits "name" outright, System.Text.Json never even invokes TypeNameConverter (Read() only
+    // runs for a property that's present) and Name would otherwise silently stay at its default —
+    // rendering a not-yet-started game as "Final" with no error anywhere. `required` makes the
+    // deserializer track whether this property was actually set and throw JsonException if not,
+    // so a genuinely missing field fails loudly instead of lying.
     [JsonPropertyName("name")]
-    public TypeName Name { get; set; }
+    public required TypeName Name { get; set; }
     [JsonPropertyName("state")]
     public State State { get; set; }
     [JsonPropertyName("completed")]
     public bool Completed { get; set; }
+    // Same rationale as Name above: Description.Final is also ordinal 0.
     [JsonPropertyName("description")]
-    public Description Description { get; set; }
+    public required Description Description { get; set; }
     [JsonPropertyName("detail")]
     public string Detail { get; set; }
     [JsonPropertyName("shortDetail")]


### PR DESCRIPTION
## Summary

Follow-up to #309, which fixed exceptions on unrecognized ESPN status **values**. This fixes a deeper, separate bug: a status field that's genuinely **absent** from ESPN's JSON.

- `TypeName.StatusFinal` and `Description.Final` are both ordinal `0` — the C# default value for an unset field of those enum types
- Our controllers re-serialize these enums as raw numbers, and the frontend's `isGameOver()` (`gameHelpers.ts`'s `toGameStatus`) compares `status.type.name === 0` **before** even checking whether the game has started
- Concretely: if ESPN's JSON for a competition's status ever omits the `"name"` (or `"description"`) key outright, `System.Text.Json` never invokes `TypeNameConverter`/`DescriptionConverter` at all — `Read()` only runs for a property that's actually present — so the property silently stays at its type default, which happens to be exactly "Final." A game that hasn't even kicked off could render as Final with **no exception, no log, nothing to catch it**.
- Fix: `StatusType.Name` and `StatusType.Description` are now `required`, so `System.Text.Json` throws a `JsonException` if either is genuinely missing from the wire payload instead of silently defaulting. That exception is handled safely by existing callers — the direct per-slate fetch (`CfbLiveScoreFetcher`) surfaces it as a failed request, the polling cache (`PeriodicRefreshCache`) logs and keeps its last good value — both fail toward "unknown," never toward a fabricated "Final."
- Test fixture builders across the CFB/NFL test suite previously relied on this same implicit default (setting `Name` without `Description`, or neither) — updated to be honest about both fields so `required` doesn't just push the problem into test fixtures.

## Test plan

- [x] New TDD tests confirming the gap first (`StatusType_MissingNameProperty_ThrowsInsteadOfDefaultingToFinal`, `StatusType_MissingDescriptionProperty_ThrowsInsteadOfDefaultingToFinal`) — verified RED against pre-fix code, GREEN after
- [x] `dotnet test --filter "FullyQualifiedName~EspnJsonConverterTests"` — 22/22 passed
- [x] Full backend suite (`dotnet test --filter "Category!=Contract"`) — 812/815 passed; the 3 failures are pre-existing Docker/Testcontainers-dependent tests that can't run in this sandbox, unrelated to this change
- [x] `npm run typecheck` (frontend, unaffected by this backend-only change) — clean
- [x] `Client.React/CHANGELOG.md` entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2)_