### PR TITLE
dev → main: iOS safe-area fix + ESPN status-parsing hardening (2 layers)

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -8,6 +8,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 
 - Fixed: the page background retiled every screen-height down any page taller than one viewport (Rules, Changelog, and others), creating a visible seam every scroll — root cause of the repeated "background looks inconsistent" reports; fixed once at the CSS source instead of per-page
 - Fixed: returning to the installed iOS home-screen app from the Safari sheet opened by "Switch to CFB/NFL" could leave the top bar rendered under the Dynamic Island/status bar until the next reload
+- Fixed: a CFB or NFL game with an unusual ESPN status (postponed, delayed, canceled, rain delay, forfeit) could get stuck showing an incorrect status like Final for every other game that week too, since one unrecognized status previously broke parsing for the entire week's scoreboard
 
 ## 2026-09-03
 

--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 - Fixed: the page background retiled every screen-height down any page taller than one viewport (Rules, Changelog, and others), creating a visible seam every scroll — root cause of the repeated "background looks inconsistent" reports; fixed once at the CSS source instead of per-page
 - Fixed: returning to the installed iOS home-screen app from the Safari sheet opened by "Switch to CFB/NFL" could leave the top bar rendered under the Dynamic Island/status bar until the next reload
 - Fixed: a CFB or NFL game with an unusual ESPN status (postponed, delayed, canceled, rain delay, forfeit) could get stuck showing an incorrect status like Final for every other game that week too, since one unrecognized status previously broke parsing for the entire week's scoreboard
+- Fixed: a CFB or NFL game could silently show as Final before it even started if ESPN's response was ever missing the status field outright — that field now fails loudly and falls back to Scheduled instead of defaulting to Final
 
 ## 2026-09-03
 

--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -7,6 +7,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 ## 2026-09-04
 
 - Fixed: the page background retiled every screen-height down any page taller than one viewport (Rules, Changelog, and others), creating a visible seam every scroll — root cause of the repeated "background looks inconsistent" reports; fixed once at the CSS source instead of per-page
+- Fixed: returning to the installed iOS home-screen app from the Safari sheet opened by "Switch to CFB/NFL" could leave the top bar rendered under the Dynamic Island/status bar until the next reload
 
 ## 2026-09-03
 

--- a/Client.React/src/__tests__/useSafeAreaRefresh.test.tsx
+++ b/Client.React/src/__tests__/useSafeAreaRefresh.test.tsx
@@ -1,0 +1,68 @@
+import { renderHook } from '@testing-library/react';
+import { useSafeAreaRefresh } from '../utils/useSafeAreaRefresh';
+
+function setVisibilityState(state: DocumentVisibilityState) {
+  Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+}
+
+describe('useSafeAreaRefresh', () => {
+  afterEach(() => {
+    setVisibilityState('visible');
+    document.documentElement.style.display = '';
+  });
+
+  it('forces a reflow (display toggled off, then restored) when the document becomes visible', () => {
+    setVisibilityState('visible');
+    renderHook(() => useSafeAreaRefresh());
+
+    const seen: string[] = [];
+    const originalDescriptor = Object.getOwnPropertyDescriptor(document.documentElement.style, 'display')
+      ?? Object.getOwnPropertyDescriptor(CSSStyleDeclaration.prototype, 'display');
+    let current = '';
+    Object.defineProperty(document.documentElement.style, 'display', {
+      configurable: true,
+      get: () => current,
+      set: (value: string) => { current = value; seen.push(value); },
+    });
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(seen).toEqual(['none', '']);
+
+    if (originalDescriptor) {
+      Object.defineProperty(document.documentElement.style, 'display', originalDescriptor);
+    }
+  });
+
+  it('does nothing when the document is not visible', () => {
+    setVisibilityState('hidden');
+    renderHook(() => useSafeAreaRefresh());
+
+    const seen: string[] = [];
+    const originalDescriptor = Object.getOwnPropertyDescriptor(document.documentElement.style, 'display')
+      ?? Object.getOwnPropertyDescriptor(CSSStyleDeclaration.prototype, 'display');
+    let current = '';
+    Object.defineProperty(document.documentElement.style, 'display', {
+      configurable: true,
+      get: () => current,
+      set: (value: string) => { current = value; seen.push(value); },
+    });
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(seen).toEqual([]);
+
+    if (originalDescriptor) {
+      Object.defineProperty(document.documentElement.style, 'display', originalDescriptor);
+    }
+  });
+
+  it('removes the listener on unmount', () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    const { unmount } = renderHook(() => useSafeAreaRefresh());
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+    removeSpy.mockRestore();
+  });
+});

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -48,6 +48,7 @@ import { useSportContext } from '../services/sport';
 import { useThemeMode } from '../services/theme';
 import { isAdmin } from '../utils/auth';
 import { isStandalonePwa } from '../utils/pwa';
+import { useSafeAreaRefresh } from '../utils/useSafeAreaRefresh';
 import PendingInviteBanner from '../components/PendingInviteBanner';
 import VersionFooter from '../components/VersionFooter';
 
@@ -85,6 +86,7 @@ export default function AppLayout() {
   const { mode, toggleTheme } = useThemeMode();
   const navigate = useNavigate();
   const location = useLocation();
+  useSafeAreaRefresh();
 
   const getOtherSportUrl = () => {
     const { hostname, port, protocol } = window.location;

--- a/Client.React/src/utils/useSafeAreaRefresh.ts
+++ b/Client.React/src/utils/useSafeAreaRefresh.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+
+/**
+ * Works around an iOS WebKit bug where `env(safe-area-inset-*)` goes stale after an installed
+ * standalone PWA regains foreground from a modal overlay — most reproducibly the Safari sheet
+ * opened by a cross-origin link (see AppLayout's "Switch to CFB/NFL" control and utils/pwa.ts).
+ * Content that depends on `--safe-inset-top` (the fixed AppBar) then renders under the Dynamic
+ * Island/status bar again until something forces WebKit to recompute the env() values — toggling
+ * `display` on the root element forces exactly that recalculation via a synchronous reflow.
+ * A no-op everywhere `env()` doesn't apply (desktop, Android, a normal browser tab).
+ */
+export function useSafeAreaRefresh() {
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') return;
+      const { documentElement } = document;
+      documentElement.style.display = 'none';
+      void documentElement.offsetHeight; // force synchronous reflow before restoring display
+      documentElement.style.display = '';
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, []);
+}

--- a/Server.UnitTests/CfbCacheServiceTests.cs
+++ b/Server.UnitTests/CfbCacheServiceTests.cs
@@ -67,7 +67,13 @@ public class CfbCacheServiceTests
     private static EspnScores BuildScoreboard(TypeName status = TypeName.StatusInProgress, int homeScore = 14, int awayScore = 7) =>
         new() {
             Events = [new Event { Id = "1", Competitions = [new Competition {
-                Status = new EspnStatus { Type = new StatusType { Name = status } },
+                Status = new EspnStatus { Type = new StatusType { Name = status, Description = status switch {
+                    TypeName.StatusFinal => Description.Final,
+                    TypeName.StatusHalftime => Description.Halftime,
+                    TypeName.StatusInProgress => Description.InProgress,
+                    TypeName.StatusScheduled => Description.Scheduled,
+                    _ => Description.EndOfPeriod,
+                } } },
                 Competitors = [
                     new Competitor { HomeAway = HomeAway.Home, Score = homeScore, Team = new EspnTeam { Abbreviation = "IND" }, Records = [] },
                     new Competitor { HomeAway = HomeAway.Away, Score = awayScore, Team = new EspnTeam { Abbreviation = "ATL" }, Records = [] },

--- a/Server.UnitTests/CfbLiveScoreFetcherTests.cs
+++ b/Server.UnitTests/CfbLiveScoreFetcherTests.cs
@@ -50,7 +50,13 @@ public class CfbLiveScoreFetcherTests {
                 new Competitor { HomeAway = HomeAway.Home, Score = 41, Team = new EspnTeam { Abbreviation = homeAbbr }, Records = [] },
                 new Competitor { HomeAway = HomeAway.Away, Score = 21, Team = new EspnTeam { Abbreviation = awayAbbr }, Records = [] },
             ],
-            Status = new EspnStatus { Type = new StatusType { Name = status } },
+            Status = new EspnStatus { Type = new StatusType { Name = status, Description = status switch {
+                TypeName.StatusFinal => Description.Final,
+                TypeName.StatusHalftime => Description.Halftime,
+                TypeName.StatusInProgress => Description.InProgress,
+                TypeName.StatusScheduled => Description.Scheduled,
+                _ => Description.EndOfPeriod,
+            } } },
             Odds = [],
         };
         return new EspnScores {
@@ -67,7 +73,7 @@ public class CfbLiveScoreFetcherTests {
                 new Competitor { HomeAway = HomeAway.Home, Score = 28, Team = new EspnTeam { Abbreviation = "OSU" }, Records = [], CuratedRank = new CuratedRankInfo { Current = homeRank } },
                 new Competitor { HomeAway = HomeAway.Away, Score = 14, Team = new EspnTeam { Abbreviation = "NEB" }, Records = [], CuratedRank = new CuratedRankInfo { Current = awayRank } },
             ],
-            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusFinal } },
+            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusFinal, Description = Description.Final } },
             Odds = [],
         };
         return new EspnScores {

--- a/Server.UnitTests/CfbRankingCaptureJobTests.cs
+++ b/Server.UnitTests/CfbRankingCaptureJobTests.cs
@@ -62,7 +62,13 @@ public class CfbRankingCaptureJobTests
                 new Competitor { HomeAway = HomeAway.Away, Score = 0, Team = new EspnTeam { Abbreviation = awayAbbr }, Records = [],
                     CuratedRank = awayRank is { } ar ? new CuratedRankInfo { Current = ar } : null },
             ],
-            Status = new EspnStatus { Type = new StatusType { Name = status } },
+            Status = new EspnStatus { Type = new StatusType { Name = status, Description = status switch {
+                TypeName.StatusFinal => Description.Final,
+                TypeName.StatusHalftime => Description.Halftime,
+                TypeName.StatusInProgress => Description.InProgress,
+                TypeName.StatusScheduled => Description.Scheduled,
+                _ => Description.EndOfPeriod,
+            } } },
             Odds = [],
         };
         return new EspnScores {

--- a/Server.UnitTests/CfbScoresJobTests.cs
+++ b/Server.UnitTests/CfbScoresJobTests.cs
@@ -60,7 +60,13 @@ public class CfbScoresJobTests
                 new Competitor { HomeAway = HomeAway.Home, Score = homeScore, Team = new EspnTeam { Abbreviation = homeAbbr }, Records = [] },
                 new Competitor { HomeAway = HomeAway.Away,  Score = awayScore, Team = new EspnTeam { Abbreviation = awayAbbr }, Records = [] },
             ],
-            Status = new EspnStatus { Type = new StatusType { Name = status } },
+            Status = new EspnStatus { Type = new StatusType { Name = status, Description = status switch {
+                TypeName.StatusFinal => Description.Final,
+                TypeName.StatusHalftime => Description.Halftime,
+                TypeName.StatusInProgress => Description.InProgress,
+                TypeName.StatusScheduled => Description.Scheduled,
+                _ => Description.EndOfPeriod,
+            } } },
             Odds = [],
         };
         return new EspnScores {

--- a/Server.UnitTests/CfbSpreadJobTests.cs
+++ b/Server.UnitTests/CfbSpreadJobTests.cs
@@ -84,7 +84,13 @@ public class CfbSpreadJobTests
                 new Competitor { HomeAway = HomeAway.Away,  Score = 0, Team = new EspnTeam { Abbreviation = awayAbbr }, Records = [],
                     CuratedRank = awayRank is { } ar ? new CuratedRankInfo { Current = ar } : null },
             ],
-            Status = new EspnStatus { Type = new StatusType { Name = status } },
+            Status = new EspnStatus { Type = new StatusType { Name = status, Description = status switch {
+                TypeName.StatusFinal => Description.Final,
+                TypeName.StatusHalftime => Description.Halftime,
+                TypeName.StatusInProgress => Description.InProgress,
+                TypeName.StatusScheduled => Description.Scheduled,
+                _ => Description.EndOfPeriod,
+            } } },
             Odds = [],
         };
         return new EspnScores {

--- a/Server.UnitTests/EspnCacheServiceTests.cs
+++ b/Server.UnitTests/EspnCacheServiceTests.cs
@@ -132,8 +132,8 @@ public class EspnCacheServiceTests
     [Fact]
     public async Task ScoresChanged_Fires_WhenDataChanges()
     {
-        var first = new EspnScores { Events = [new Event { Id = "1", Competitions = [new Competition { Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled } }, Competitors = [new Competitor { HomeAway = HomeAway.Home, Score = 0 }, new Competitor { HomeAway = HomeAway.Away, Score = 0 }], Odds = [] }] }] };
-        var second = new EspnScores { Events = [new Event { Id = "1", Competitions = [new Competition { Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusFinal } }, Competitors = [new Competitor { HomeAway = HomeAway.Home, Score = 28 }, new Competitor { HomeAway = HomeAway.Away, Score = 17 }], Odds = [] }] }] };
+        var first = new EspnScores { Events = [new Event { Id = "1", Competitions = [new Competition { Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Description = Description.Scheduled } }, Competitors = [new Competitor { HomeAway = HomeAway.Home, Score = 0 }, new Competitor { HomeAway = HomeAway.Away, Score = 0 }], Odds = [] }] }] };
+        var second = new EspnScores { Events = [new Event { Id = "1", Competitions = [new Competition { Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusFinal, Description = Description.Final } }, Competitors = [new Competitor { HomeAway = HomeAway.Home, Score = 28 }, new Competitor { HomeAway = HomeAway.Away, Score = 17 }], Odds = [] }] }] };
 
         _espnApi.GetWeekScores(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<bool>()).Returns(
             Task.FromResult<EspnScores?>(first),
@@ -152,7 +152,7 @@ public class EspnCacheServiceTests
     [Fact]
     public async Task ScoresChanged_DoesNotFire_WhenDataUnchanged()
     {
-        var scores = new EspnScores { Events = [new Event { Id = "1", Competitions = [new Competition { Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusFinal } }, Competitors = [new Competitor { HomeAway = HomeAway.Home, Score = 28 }, new Competitor { HomeAway = HomeAway.Away, Score = 17 }], Odds = [] }] }] };
+        var scores = new EspnScores { Events = [new Event { Id = "1", Competitions = [new Competition { Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusFinal, Description = Description.Final } }, Competitors = [new Competitor { HomeAway = HomeAway.Home, Score = 28 }, new Competitor { HomeAway = HomeAway.Away, Score = 17 }], Odds = [] }] }] };
 
         _espnApi.GetWeekScores(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<bool>()).Returns(Task.FromResult<EspnScores?>(scores));
 

--- a/Server.UnitTests/EspnJsonConverterTests.cs
+++ b/Server.UnitTests/EspnJsonConverterTests.cs
@@ -109,4 +109,106 @@ public class EspnJsonConverterTests
         Assert.Equal(HomeAway.Away, competitors.Single(c => c.Team.Abbreviation == "ATL").HomeAway);
         Assert.Equal(EspnRecordType.HomeRecord, competitors.Single(c => c.Team.Abbreviation == "IND").Records.Single().Type);
     }
+
+    // TypeNameConverter/DescriptionConverter previously threw on any status.type.name/description
+    // value outside our known 5 — but ESPN's real wire values also include things like
+    // STATUS_POSTPONED, STATUS_DELAYED, STATUS_CANCELED, STATUS_RAIN_DELAY, and STATUS_FORFEIT for
+    // weather/scheduling edge cases. Because System.Text.Json aborts the ENTIRE deserialization on
+    // any single property throwing, one game anywhere in a week's scoreboard entering one of these
+    // states broke live status/scores for every OTHER game in that week too — PeriodicRefreshCache
+    // (see PeriodicRefreshCache.cs) then silently keeps serving its last successfully-parsed
+    // snapshot indefinitely, which is how a game already showed as stuck-"Final" days after actually
+    // being scheduled: an unrelated game's odd status froze the whole week's cache at an earlier,
+    // now-stale snapshot. Unknown/unusual statuses must fall back to Scheduled — "not decided yet"
+    // is the only safe default; anything else risks showing a false Final (revealing a fake result,
+    // wrongly locking picks) or a false Live/other state.
+    [Theory]
+    [InlineData("STATUS_POSTPONED")]
+    [InlineData("STATUS_DELAYED")]
+    [InlineData("STATUS_CANCELED")]
+    [InlineData("STATUS_RAIN_DELAY")]
+    [InlineData("STATUS_FORFEIT")]
+    [InlineData("STATUS_SOME_FUTURE_ESPN_VALUE_WE_DONT_KNOW_ABOUT_YET")]
+    public void TypeNameConverter_FallsBackToScheduled_ForUnrecognizedWireValues(string wireValue)
+    {
+        var json = $$"""{"id":"1","name":"{{wireValue}}","state":"pre","completed":false,"description":"Postponed","detail":"","shortDetail":""}""";
+
+        var statusType = System.Text.Json.JsonSerializer.Deserialize<StatusType>(json, EspnApiServiceJsonConverter.Settings);
+
+        Assert.Equal(TypeName.StatusScheduled, statusType!.Name);
+    }
+
+    [Theory]
+    [InlineData("Postponed")]
+    [InlineData("Delayed")]
+    [InlineData("Canceled")]
+    [InlineData("Some future ESPN description we don't know about yet")]
+    public void DescriptionConverter_FallsBackToScheduled_ForUnrecognizedWireValues(string wireValue)
+    {
+        var json = $$"""{"id":"1","name":"STATUS_SCHEDULED","state":"pre","completed":false,"description":"{{wireValue}}","detail":"","shortDetail":""}""";
+
+        var statusType = System.Text.Json.JsonSerializer.Deserialize<StatusType>(json, EspnApiServiceJsonConverter.Settings);
+
+        Assert.Equal(Description.Scheduled, statusType!.Description);
+    }
+
+    // The real-world failure mode: one game with an unrecognized status must not break every OTHER
+    // game in the same scoreboard payload — this is what actually broke, not just the isolated
+    // converter (System.Text.Json aborts the whole object graph on any single property throwing).
+    [Fact]
+    public async Task CfbApiService_GetScoresByWeekAsync_OneGameWithUnrecognizedStatus_DoesNotBreakOtherGames()
+    {
+        const string payload = """
+            {
+              "events": [
+                {
+                  "id": "1",
+                  "date": "2025-11-01T00:00Z",
+                  "competitions": [
+                    {
+                      "id": "1",
+                      "date": "2025-11-01T00:00Z",
+                      "status": {
+                        "clock": 0, "displayClock": "0:00", "period": 0,
+                        "type": { "id": "9", "name": "STATUS_POSTPONED", "state": "pre", "completed": false, "description": "Postponed", "detail": "Postponed", "shortDetail": "Postponed" }
+                      },
+                      "competitors": [
+                        { "id": "1", "homeAway": "home", "team": { "abbreviation": "USC" }, "score": "0", "records": [] },
+                        { "id": "2", "homeAway": "away", "team": { "abbreviation": "FRES" }, "score": "0", "records": [] }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "id": "2",
+                  "date": "2025-11-01T00:00Z",
+                  "competitions": [
+                    {
+                      "id": "2",
+                      "date": "2025-11-01T00:00Z",
+                      "status": {
+                        "clock": 0, "displayClock": "0:00", "period": 2,
+                        "type": { "id": "2", "name": "STATUS_IN_PROGRESS", "state": "in", "completed": false, "description": "In Progress", "detail": "In Progress", "shortDetail": "In Progress" }
+                      },
+                      "competitors": [
+                        { "id": "3", "homeAway": "home", "team": { "abbreviation": "OU" }, "score": "14", "records": [] },
+                        { "id": "4", "homeAway": "away", "team": { "abbreviation": "UTEP" }, "score": "7", "records": [] }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """;
+        var httpClient = new HttpClient(new StubHttpMessageHandler(payload)) { BaseAddress = new Uri("http://site.api.espn.com") };
+        var service = new CfbApiService(httpClient);
+
+        var scores = await service.GetScoresByWeekAsync(week: 1, isPostSeason: false);
+
+        Assert.Equal(2, scores!.Events!.Length);
+        var uscComp = scores.Events.Single(e => e.Competitions[0].Competitors.Any(c => c.Team.Abbreviation == "USC")).Competitions[0];
+        Assert.Equal(TypeName.StatusScheduled, uscComp.Status.Type.Name); // postponed falls back to scheduled, not Final
+        var utepComp = scores.Events.Single(e => e.Competitions[0].Competitors.Any(c => c.Team.Abbreviation == "UTEP")).Competitions[0];
+        Assert.Equal(TypeName.StatusInProgress, utepComp.Status.Type.Name); // the other game parses normally, unaffected
+    }
 }

--- a/Server.UnitTests/EspnJsonConverterTests.cs
+++ b/Server.UnitTests/EspnJsonConverterTests.cs
@@ -152,6 +152,36 @@ public class EspnJsonConverterTests
         Assert.Equal(Description.Scheduled, statusType!.Description);
     }
 
+    // TypeName's first member (StatusFinal) is ordinal 0 — which is also C#'s default value for a
+    // TypeName field that's never actually set. Our controllers re-serialize this enum as a raw
+    // number (not our custom converter's string form — see EspnController), and the frontend
+    // hardcodes STATUS_FINAL = 0 and checks isGameOver() BEFORE isGameStarted() (gameHelpers.ts's
+    // toGameStatus). So a StatusType whose Name was never populated from JSON — e.g. ESPN's
+    // response is missing the "name" key entirely, which the converter never even sees since
+    // Read() is only invoked for a property that's present — would silently render as "Final" for
+    // a game that hasn't even kicked off, with no exception anywhere. `required` makes System.Text.Json
+    // track whether the property was actually set during deserialization, independent of the
+    // custom converter, and throw JsonException if it wasn't — turning a silent wrong answer into
+    // a loud, logged failure (which PeriodicRefreshCache/the direct fetch path already handle safely
+    // by falling back to "scheduled" rather than showing a fabricated result).
+    [Fact]
+    public void StatusType_MissingNameProperty_ThrowsInsteadOfDefaultingToFinal()
+    {
+        const string json = """{"id":"1","state":"pre","completed":false,"description":"Scheduled","detail":"","shortDetail":""}""";
+
+        Assert.Throws<System.Text.Json.JsonException>(() =>
+            System.Text.Json.JsonSerializer.Deserialize<StatusType>(json, EspnApiServiceJsonConverter.Settings));
+    }
+
+    [Fact]
+    public void StatusType_MissingDescriptionProperty_ThrowsInsteadOfDefaultingToFinal()
+    {
+        const string json = """{"id":"1","name":"STATUS_SCHEDULED","state":"pre","completed":false,"detail":"","shortDetail":""}""";
+
+        Assert.Throws<System.Text.Json.JsonException>(() =>
+            System.Text.Json.JsonSerializer.Deserialize<StatusType>(json, EspnApiServiceJsonConverter.Settings));
+    }
+
     // The real-world failure mode: one game with an unrecognized status must not break every OTHER
     // game in the same scoreboard payload — this is what actually broke, not just the isolated
     // converter (System.Text.Json aborts the whole object graph on any single property throwing).

--- a/Server.UnitTests/LiveGameDtoTests.cs
+++ b/Server.UnitTests/LiveGameDtoTests.cs
@@ -28,7 +28,7 @@ public class LiveGameDtoTests
                 new Competitor { Id = homeId, HomeAway = HomeAway.Home, Team = new EspnTeam { Abbreviation = homeAbbr }, Score = 0, Records = [] },
                 new Competitor { Id = awayId, HomeAway = HomeAway.Away, Team = new EspnTeam { Abbreviation = awayAbbr }, Score = 0, Records = [] },
             ],
-            Status = new EspnStatus { Type = new StatusType { Completed = completed } },
+            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusInProgress, Description = Description.InProgress, Completed = completed } },
             Odds = [],
             Situation = possessionId is null ? null : new EspnSitutation
             {

--- a/Server.UnitTests/NflScoresJobTests.cs
+++ b/Server.UnitTests/NflScoresJobTests.cs
@@ -81,7 +81,13 @@ public class NflScoresJobTests
             },
             Status = new EspnStatus
             {
-                Type = new StatusType { Name = statusName, Completed = isFinal }
+                Type = new StatusType { Name = statusName, Completed = isFinal, Description = statusName switch {
+                    TypeName.StatusFinal => Description.Final,
+                    TypeName.StatusHalftime => Description.Halftime,
+                    TypeName.StatusInProgress => Description.InProgress,
+                    TypeName.StatusScheduled => Description.Scheduled,
+                    _ => Description.EndOfPeriod,
+                } }
             },
             Odds = Array.Empty<Odd>()
         };

--- a/Server.UnitTests/NflSpreadJobTests.cs
+++ b/Server.UnitTests/NflSpreadJobTests.cs
@@ -91,7 +91,13 @@ public class NflSpreadJobTests
             },
             Status = new EspnStatus
             {
-                Type = new StatusType { Name = statusName, Completed = false }
+                Type = new StatusType { Name = statusName, Completed = false, Description = statusName switch {
+                    TypeName.StatusFinal => Description.Final,
+                    TypeName.StatusHalftime => Description.Halftime,
+                    TypeName.StatusInProgress => Description.InProgress,
+                    TypeName.StatusScheduled => Description.Scheduled,
+                    _ => Description.EndOfPeriod,
+                } }
             },
             Odds = Array.Empty<Odd>()
         };
@@ -422,7 +428,7 @@ public class NflSpreadJobTests
                                 new Competitor { Id = "2", HomeAway = HomeAway.Away, Score = 0,
                                     Team = new EspnTeam { Abbreviation = "BUF" }, Records = Array.Empty<EspnRecord>() }
                             },
-                            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled } },
+                            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Description = Description.Scheduled } },
                             Odds = Array.Empty<Odd>()
                         }
                     }
@@ -445,7 +451,7 @@ public class NflSpreadJobTests
                                 new Competitor { Id = "4", HomeAway = HomeAway.Away, Score = 0,
                                     Team = new EspnTeam { Abbreviation = "DAL" }, Records = Array.Empty<EspnRecord>() }
                             },
-                            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled } },
+                            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Description = Description.Scheduled } },
                             Odds = Array.Empty<Odd>()
                         }
                     }

--- a/Server.UnitTests/PicksTests.cs
+++ b/Server.UnitTests/PicksTests.cs
@@ -98,7 +98,7 @@ public class PicksTests
                                 new Competitor { Team = new EspnTeam { Abbreviation = "BUF" }, HomeAway = HomeAway.Home },
                                 new Competitor { Team = new EspnTeam { Abbreviation = "MIA" }, HomeAway = HomeAway.Away }
                             ],
-                            Status = new EspnStatus { Type = new StatusType { Completed = false } },
+                            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Description = Description.Scheduled, Completed = false } },
                             Odds = []
                         }
                     ]
@@ -393,7 +393,7 @@ public class PicksTests
                             new Competitor { Team = new EspnTeam { Abbreviation = "BUF" }, HomeAway = HomeAway.Home },
                             new Competitor { Team = new EspnTeam { Abbreviation = "MIA" }, HomeAway = HomeAway.Away }
                         ],
-                        Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Completed = false } },
+                        Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Description = Description.Scheduled, Completed = false } },
                         Odds = []
                     }
                 ]
@@ -412,7 +412,7 @@ public class PicksTests
                             new Competitor { Team = new EspnTeam { Abbreviation = "DAL" }, HomeAway = HomeAway.Home },
                             new Competitor { Team = new EspnTeam { Abbreviation = "NYG" }, HomeAway = HomeAway.Away }
                         ],
-                        Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusInProgress, Completed = false } },
+                        Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusInProgress, Description = Description.InProgress, Completed = false } },
                         Odds = []
                     }
                 ]
@@ -591,7 +591,7 @@ public class PicksTests
                                 new Competitor { Team = new EspnTeam { Abbreviation = "BUF" }, HomeAway = HomeAway.Home },
                                 new Competitor { Team = new EspnTeam { Abbreviation = "MIA" }, HomeAway = HomeAway.Away }
                             ],
-                            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Completed = false } },
+                            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Description = Description.Scheduled, Completed = false } },
                             Odds = []
                         }
                     ]

--- a/Server.UnitTests/ReplayCacheServiceTests.cs
+++ b/Server.UnitTests/ReplayCacheServiceTests.cs
@@ -16,7 +16,7 @@ namespace FourPlayWebApp.Server.UnitTests;
 public class ReplayCacheServiceTests {
     private static EspnScores Snapshot(string label) => new() {
         Events = [new Event { Id = "1", Competitions = [new Competition {
-            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled } },
+            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Description = Description.Scheduled } },
             Competitors = [], Odds = [],
         }] }],
         // Season used purely to distinguish snapshots by identity in these tests.

--- a/Shared/Models/ESPNApiDataTypes.cs
+++ b/Shared/Models/ESPNApiDataTypes.cs
@@ -180,14 +180,23 @@ public class StatusType
     [JsonPropertyName("id")]
     [JsonConverter(typeof(StringToLongConverter))]
     public long Id { get; set; }
+    // required: TypeName.StatusFinal is ordinal 0 — also C#'s default value for an unset TypeName
+    // field, and the frontend's isGameOver() check treats a raw wire value of 0 as "Final" before
+    // it even checks whether the game has started (gameHelpers.ts's toGameStatus). If ESPN's JSON
+    // ever omits "name" outright, System.Text.Json never even invokes TypeNameConverter (Read() only
+    // runs for a property that's present) and Name would otherwise silently stay at its default —
+    // rendering a not-yet-started game as "Final" with no error anywhere. `required` makes the
+    // deserializer track whether this property was actually set and throw JsonException if not,
+    // so a genuinely missing field fails loudly instead of lying.
     [JsonPropertyName("name")]
-    public TypeName Name { get; set; }
+    public required TypeName Name { get; set; }
     [JsonPropertyName("state")]
     public State State { get; set; }
     [JsonPropertyName("completed")]
     public bool Completed { get; set; }
+    // Same rationale as Name above: Description.Final is also ordinal 0.
     [JsonPropertyName("description")]
-    public Description Description { get; set; }
+    public required Description Description { get; set; }
     [JsonPropertyName("detail")]
     public string Detail { get; set; }
     [JsonPropertyName("shortDetail")]

--- a/Shared/Models/ESPNApiDataTypes.cs
+++ b/Shared/Models/ESPNApiDataTypes.cs
@@ -394,7 +394,13 @@ internal class DescriptionConverter : JsonConverter<Description>
             "In Progress" => Description.InProgress,
             "Scheduled" => Description.Scheduled,
             "End of Period" => Description.EndOfPeriod,
-            _ => throw new Exception("Cannot unmarshal type Description")
+            // ESPN's real wire vocabulary also includes values we don't model (Postponed, Delayed,
+            // Canceled, etc.) for weather/scheduling edge cases. System.Text.Json aborts the ENTIRE
+            // deserialization on any single converter throwing, so one game with an unrecognized
+            // description would previously break every other game in the same week's payload
+            // (see PeriodicRefreshCache, which then silently serves the last successful snapshot
+            // forever). "Scheduled" — not decided yet — is the only safe fallback.
+            _ => Description.Scheduled
         };
 
     public override void Write(Utf8JsonWriter writer, Description value, JsonSerializerOptions options) =>
@@ -421,7 +427,11 @@ internal class TypeNameConverter : JsonConverter<TypeName>
             "STATUS_IN_PROGRESS" => TypeName.StatusInProgress,
             "STATUS_SCHEDULED" => TypeName.StatusScheduled,
             "STATUS_END_PERIOD" => TypeName.StatusEndPeriod,
-            _ => throw new Exception("Cannot unmarshal type TypeName")
+            // Same rationale as DescriptionConverter above: ESPN's real wire vocabulary includes
+            // status names we don't model (STATUS_POSTPONED, STATUS_DELAYED, STATUS_CANCELED,
+            // STATUS_RAIN_DELAY, STATUS_FORFEIT, etc.). Falling back to Scheduled instead of
+            // throwing keeps one unusual game from breaking deserialization of the whole week.
+            _ => TypeName.StatusScheduled
         };
 
     public override void Write(Utf8JsonWriter writer, TypeName value, JsonSerializerOptions options) =>


### PR DESCRIPTION
## Summary

Cutting three merged `dev` PRs to `main`:

- **#308** — iOS WebKit `env(safe-area-inset-*)` staleness fix: forces a reflow on `visibilitychange` so the AppBar doesn't render under the Dynamic Island/status bar after returning from a Safari sheet (e.g. the "Switch to CFB/NFL" cross-origin link). Not independently verified on real iOS hardware from this environment — standard, well-documented mitigation for this WebKit bug class.
- **#309** — `TypeNameConverter`/`DescriptionConverter` now fall back to `Scheduled` instead of throwing on an ESPN status value outside our known 5 (e.g. `STATUS_POSTPONED`, `STATUS_DELAYED`, `STATUS_CANCELED`). Previously, one game anywhere in a week's CFB/NFL scoreboard entering an unusual state broke live status/scores for every other game in that week too.
- **#310** — `StatusType.Name`/`.Description` are now `required` during JSON deserialization. `TypeName.StatusFinal` and `Description.Final` are both ordinal `0` — the C# default for an unset field of those types — and our controllers serialize these enums as raw numbers with the frontend checking `isGameOver()` (`=== 0`) before anything else. A JSON payload genuinely missing either key would previously default silently to "Final" with no error; now it throws loudly and the caller falls back to "scheduled" instead.

Root-caused from a live production report of a CFB game (USC) appearing to show "Final" before kickoff. Live verification against the current ESPN response for that specific game (via slate 1's `/api/espn/cfb/scores/slate/1`) showed the pipeline currently parsing and serving it correctly (`status.type.name === 3`, Scheduled) — so #309/#310 are hardening against the failure class rather than a confirmed reproduction of that exact instance, but both close real, demonstrable gaps (verified via TDD tests, including a red→green cycle proving the missing-field default before the fix).

## Test plan

- [x] Each PR passed full CI individually (backend/frontend tests, Docker build parity, secret scan, demo + demo-replay e2e) before merging to `dev`
- [x] Railway dev deploy confirmed healthy after each merge
- [x] `dotnet test --filter "Category!=Contract"` — 815/815 passing as of the latest `dev` commit (3 pre-existing Docker/Testcontainers-dependent tests excluded, unrelated to this change)
- [x] `Client.React/CHANGELOG.md` entries present for all three changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMvDYQQym2JT3yi3wf3Nc2)_