### PR TITLE
Promote dev to main: CFB ESPN date-range fix + admin scores job fix

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -10,6 +10,8 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 - Fixed: returning to the installed iOS home-screen app from the Safari sheet opened by "Switch to CFB/NFL" could leave the top bar rendered under the Dynamic Island/status bar until the next reload
 - Fixed: a CFB or NFL game with an unusual ESPN status (postponed, delayed, canceled, rain delay, forfeit) could get stuck showing an incorrect status like Final for every other game that week too, since one unrecognized status previously broke parsing for the entire week's scoreboard
 - Fixed: a CFB or NFL game could silently show as Final before it even started if ESPN's response was ever missing the status field outright — that field now fails loudly and falls back to Scheduled instead of defaulting to Final
+- Fixed: a CFB team with two games landing in ESPN's same weekly scoreboard fetch (e.g. an early-season opener plus that week's real game) could briefly show the wrong game's score and status, since the live fetch queried ESPN by its own week number instead of our own scheduled date range
+- Fixed: the admin Job Manager's "run now" button for CFB scores was broken and always failed; the NFL scores button had a related bug where it could trigger the wrong sport's job
 
 ## 2026-09-03
 

--- a/Server.UnitTests/CfbApiServiceTests.cs
+++ b/Server.UnitTests/CfbApiServiceTests.cs
@@ -1,0 +1,93 @@
+using System.Net;
+using FourPlayWebApp.Server.Services;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+// frizat-11t: regular-season CFB fetch moved from ESPN's week=N bucket (which doesn't respect our
+// slate's own date window — a team can appear twice in one week=N fetch, see CfbLiveScoreFetcherTests'
+// USC/Fresno-vs-SJSU regression) to a dates=yyyyMMdd-yyyyMMdd range scoped to the control table's
+// own WeekStartDate/WeekEndDate. This is a NEW query shape, not a revert to the old broken
+// groups=80 date approach CfbApiService.GetScoresByWeekAsync's own comment references.
+public class CfbApiServiceTests {
+    private sealed class CapturingHandler : HttpMessageHandler {
+        public Uri? LastRequestUri { get; private set; }
+        public string ResponseBody { get; set; } = "{}";
+        public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.OK;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            LastRequestUri = request.RequestUri;
+            return Task.FromResult(new HttpResponseMessage(StatusCode) {
+                Content = new StringContent(ResponseBody),
+            });
+        }
+    }
+
+    private static (CfbApiService sut, CapturingHandler handler) Build() {
+        var handler = new CapturingHandler();
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://site.api.espn.com") };
+        return (new CfbApiService(httpClient), handler);
+    }
+
+    [Fact]
+    public async Task GetScoresByDateRangeAsync_BuildsDatesUrl_WithSeasonType2AndLimit100() {
+        var (sut, handler) = Build();
+
+        await sut.GetScoresByDateRangeAsync(new DateOnly(2026, 9, 1), new DateOnly(2026, 9, 7));
+
+        Assert.NotNull(handler.LastRequestUri);
+        var query = handler.LastRequestUri!.Query;
+        Assert.Contains("dates=20260901-20260907", query);
+        Assert.Contains("seasontype=2", query);
+        Assert.Contains("limit=100", query);
+    }
+
+    [Fact]
+    public async Task GetScoresByDateRangeAsync_ParsesEventsFromResponse() {
+        var (sut, handler) = Build();
+        handler.ResponseBody = """
+        {
+          "season": { "type": 2, "year": 2026 },
+          "week": { "number": 1 },
+          "events": [
+            {
+              "id": "401858436",
+              "season": { "type": 2, "year": 2026 },
+              "week": { "number": 1 },
+              "date": "2026-09-05T01:00Z",
+              "competitions": [
+                {
+                  "id": "401858436",
+                  "date": "2026-09-05T01:00Z",
+                  "competitors": [
+                    { "id": "1", "homeAway": "home", "score": "0", "team": { "abbreviation": "USC" } },
+                    { "id": "2", "homeAway": "away", "score": "0", "team": { "abbreviation": "FRES" } }
+                  ],
+                  "status": {
+                    "clock": 0, "displayClock": "0:00", "period": 0,
+                    "type": { "id": "1", "name": "STATUS_SCHEDULED", "state": "pre", "completed": false, "description": "Scheduled" }
+                  },
+                  "odds": []
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+        var result = await sut.GetScoresByDateRangeAsync(new DateOnly(2026, 9, 1), new DateOnly(2026, 9, 7));
+
+        Assert.NotNull(result);
+        var evt = Assert.Single(result!.Events!);
+        Assert.Equal("401858436", evt.Id);
+    }
+
+    [Fact]
+    public async Task GetScoresByDateRangeAsync_NonSuccessStatus_ReturnsNull() {
+        var (sut, handler) = Build();
+        handler.StatusCode = HttpStatusCode.ServiceUnavailable;
+
+        var result = await sut.GetScoresByDateRangeAsync(new DateOnly(2026, 9, 1), new DateOnly(2026, 9, 7));
+
+        Assert.Null(result);
+    }
+}

--- a/Server.UnitTests/CfbLiveScoreFetcherTests.cs
+++ b/Server.UnitTests/CfbLiveScoreFetcherTests.cs
@@ -66,9 +66,9 @@ public class CfbLiveScoreFetcherTests {
         };
     }
 
-    private static EspnScores BuildScoreboardWithRanking(int homeRank = 99, int awayRank = 99) {
+    private static EspnScores BuildScoreboardWithRanking(int homeRank = 99, int awayRank = 99, DateTimeOffset? date = null) {
         var competition = new Competition {
-            Date = new DateTimeOffset(2025, 9, 27, 18, 0, 0, TimeSpan.Zero),
+            Date = date ?? new DateTimeOffset(2025, 9, 27, 18, 0, 0, TimeSpan.Zero),
             Competitors = [
                 new Competitor { HomeAway = HomeAway.Home, Score = 28, Team = new EspnTeam { Abbreviation = "OSU" }, Records = [], CuratedRank = new CuratedRankInfo { Current = homeRank } },
                 new Competitor { HomeAway = HomeAway.Away, Score = 14, Team = new EspnTeam { Abbreviation = "NEB" }, Records = [], CuratedRank = new CuratedRankInfo { Current = awayRank } },
@@ -83,7 +83,7 @@ public class CfbLiveScoreFetcherTests {
         };
     }
 
-    // ── Regular season / conf-champs: week-based + ranked filter ─────────────
+    // ── Regular season / conf-champs: control-table date-range query (frizat-11t) ────────────
 
     private static CfbSlates BuildRegularSeasonSlate() => new() {
         Id = 1, Season = 2026, SlateNumber = 5,
@@ -97,9 +97,10 @@ public class CfbLiveScoreFetcherTests {
     // in CfbSpreadJob's IsLeagueEligible computation, not here.
     [Fact]
     public async Task FetchForSlateAsync_RegularSeason_IncludesGame_WhenBothTeamsUnranked() {
-        _cfbApi.GetScoresByWeekAsync(5, false).Returns(BuildScoreboardWithRanking(homeRank: 99, awayRank: 99));
+        var slate = BuildRegularSeasonSlate();
+        _cfbApi.GetScoresByDateRangeAsync(slate.StartDate, slate.EndDate).Returns(BuildScoreboardWithRanking(homeRank: 99, awayRank: 99));
 
-        var result = await BuildFetcher().FetchForSlateAsync(BuildRegularSeasonSlate());
+        var result = await BuildFetcher().FetchForSlateAsync(slate);
 
         Assert.NotNull(result);
         Assert.Single(result!.Events!);
@@ -107,12 +108,92 @@ public class CfbLiveScoreFetcherTests {
 
     [Fact]
     public async Task FetchForSlateAsync_RegularSeason_IncludesGame_WhenOneTeamIsRanked() {
-        _cfbApi.GetScoresByWeekAsync(5, false).Returns(BuildScoreboardWithRanking(homeRank: 5, awayRank: 99));
+        var slate = BuildRegularSeasonSlate();
+        _cfbApi.GetScoresByDateRangeAsync(slate.StartDate, slate.EndDate).Returns(BuildScoreboardWithRanking(homeRank: 5, awayRank: 99));
 
-        var result = await BuildFetcher().FetchForSlateAsync(BuildRegularSeasonSlate());
+        var result = await BuildFetcher().FetchForSlateAsync(slate);
 
         Assert.NotNull(result);
         Assert.Single(result!.Events!);
+    }
+
+    // frizat-11t: live incident regression. ESPN's own week=N bucket doesn't respect our slate's
+    // date window — a team with an early "week 0"-ish opener plus its real week-N game can have BOTH
+    // land in one week=N fetch (real example: USC's Aug 29 SJSU game and Sep 5 Fresno State game both
+    // came back under ESPN's week=1). The frontend's live-score join (cfbAdapter.ts's
+    // buildGamesFromEspn, keyed by home-team abbreviation only, deliberately NOT changed by this fix)
+    // assumes one event per team per slate; a second stray event for the same team silently clobbers
+    // the correct one. Querying by our own control-table date range instead of ESPN's week number
+    // means the fetch itself only ever returns events ESPN placed within OUR slate's actual window —
+    // "our week wins, not ESPN's" — so that assumption holds. This test proves the call is built from
+    // slate.StartDate/EndDate, not derived from slate.EspnWeekNumber in any way.
+    [Fact]
+    public async Task FetchForSlateAsync_RegularSeason_QueriesByControlTableDateRange_NotEspnWeekNumber() {
+        // EspnWeekNumber is deliberately something a week-based call would never coincidentally
+        // match against these StartDate/EndDate values — proves the fetch is date-driven, not
+        // secretly still week-driven.
+        var slate = new CfbSlates {
+            Id = 19, Season = 2026, SlateNumber = 1, Label = "Week 1", SlateType = "RegularSeason",
+            StartDate = new DateOnly(2026, 9, 1), EndDate = new DateOnly(2026, 9, 7),
+            EspnWeekNumber = 1, ScoringFormat = "Standard",
+        };
+        _cfbApi.GetScoresByDateRangeAsync(new DateOnly(2026, 9, 1), new DateOnly(2026, 9, 7))
+            .Returns(BuildScoreboardWithRanking(date: new DateTimeOffset(2026, 9, 5, 1, 0, 0, TimeSpan.Zero)));
+
+        var result = await BuildFetcher().FetchForSlateAsync(slate);
+
+        await _cfbApi.Received(1).GetScoresByDateRangeAsync(new DateOnly(2026, 9, 1), new DateOnly(2026, 9, 7));
+        await _cfbApi.DidNotReceiveWithAnyArgs().GetCfpGamesAsync();
+        Assert.NotNull(result);
+    }
+
+    // /code-review: defense-in-depth. The query-time dates= param is verified (live) to exclude
+    // out-of-window events, but this fix's whole premise is "don't fully trust ESPN's own
+    // bucketing" — so apply the same downstream date-window filter FetchCfpAsync already uses,
+    // rather than relying solely on ESPN correctly honoring the query param in every case (e.g. a
+    // timezone-boundary edge case on a late-night/West-Coast CFB kickoff).
+    [Fact]
+    public async Task FetchForSlateAsync_RegularSeason_ExcludesGame_OutsideSlateDateRange_EvenIfEspnReturnsIt() {
+        var slate = new CfbSlates {
+            Id = 19, Season = 2026, SlateNumber = 1, Label = "Week 1", SlateType = "RegularSeason",
+            StartDate = new DateOnly(2026, 9, 1), EndDate = new DateOnly(2026, 9, 7),
+            EspnWeekNumber = 1, ScoringFormat = "Standard",
+        };
+        var inWindow = new Competition {
+            Date = new DateTimeOffset(2026, 9, 5, 1, 0, 0, TimeSpan.Zero),
+            Competitors = [
+                new Competitor { HomeAway = HomeAway.Home, Score = 0, Team = new EspnTeam { Abbreviation = "USC" }, Records = [] },
+                new Competitor { HomeAway = HomeAway.Away, Score = 0, Team = new EspnTeam { Abbreviation = "FRES" }, Records = [] },
+            ],
+            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusScheduled, Description = Description.Scheduled } },
+            Odds = [],
+        };
+        var outOfWindow = new Competition {
+            Date = new DateTimeOffset(2026, 8, 29, 19, 0, 0, TimeSpan.Zero),
+            Competitors = [
+                new Competitor { HomeAway = HomeAway.Home, Score = 42, Team = new EspnTeam { Abbreviation = "USC" }, Records = [] },
+                new Competitor { HomeAway = HomeAway.Away, Score = 26, Team = new EspnTeam { Abbreviation = "SJSU" }, Records = [] },
+            ],
+            Status = new EspnStatus { Type = new StatusType { Name = TypeName.StatusFinal, Description = Description.Final } },
+            Odds = [],
+        };
+        var scoreboard = new EspnScores {
+            Season = new Season { Year = 2026, Type = 2 },
+            Week = new Week { Number = 1 },
+            Events = [
+                new Event { Id = "1", Season = new Season { Year = 2026, Type = 2 }, Week = new Week { Number = 1 }, Competitions = [inWindow] },
+                new Event { Id = "2", Season = new Season { Year = 2026, Type = 2 }, Week = new Week { Number = 1 }, Competitions = [outOfWindow] },
+            ],
+        };
+        _cfbApi.GetScoresByDateRangeAsync(slate.StartDate, slate.EndDate).Returns(scoreboard);
+
+        var result = await BuildFetcher().FetchForSlateAsync(slate);
+
+        Assert.NotNull(result);
+        var evt = Assert.Single(result!.Events!);
+        var comp = evt.Competitions.Single();
+        Assert.Equal(TypeName.StatusScheduled, comp.Status.Type.Name);
+        Assert.Contains(comp.Competitors, c => c.Team.Abbreviation == "FRES");
     }
 
     // ── CFP: week=999 bucket + date-window filter ────────────────────────────
@@ -131,7 +212,7 @@ public class CfbLiveScoreFetcherTests {
         var result = await BuildFetcher().FetchForSlateAsync(BuildCfpSlate());
 
         await _cfbApi.Received(1).GetCfpGamesAsync();
-        await _cfbApi.DidNotReceive().GetScoresByWeekAsync(Arg.Any<int>(), Arg.Any<bool>());
+        await _cfbApi.DidNotReceive().GetScoresByDateRangeAsync(Arg.Any<DateOnly>(), Arg.Any<DateOnly>());
         Assert.NotNull(result);
         Assert.Single(result!.Events!);
     }
@@ -148,8 +229,10 @@ public class CfbLiveScoreFetcherTests {
 
     // ── Missing EspnWeekNumber: the control table (CfbSeasonWeekConfig.EspnWeekNumber) is
     // non-nullable and CfbSlateSeederJob is the only producer of CfbSlates rows, so every real
-    // slate carries a week number. This app makes week-based ESPN queries only — never date-range
-    // "scoreboard" calls. A missing value means the control table wasn't seeded correctly. ────────
+    // slate carries a week number. frizat-11t: the regular-season ESPN fetch itself is now
+    // date-range-based (slate.StartDate/EndDate), not week-based — EspnWeekNumber is still required
+    // as the CfbRanking natural-key component, so a missing value still means the control table
+    // wasn't seeded correctly. ──────────────────────────────────────────────────────────────
 
     private static CfbSlates BuildSlateMissingWeekNumber() => new() {
         Id = 3, Season = 2025, SlateNumber = 1,
@@ -163,7 +246,7 @@ public class CfbLiveScoreFetcherTests {
         var result = await BuildFetcher().FetchForSlateAsync(BuildSlateMissingWeekNumber());
 
         Assert.Null(result);
-        await _cfbApi.DidNotReceiveWithAnyArgs().GetScoresByWeekAsync(default, default);
+        await _cfbApi.DidNotReceiveWithAnyArgs().GetScoresByDateRangeAsync(default, default);
         await _cfbApi.DidNotReceive().GetCfpGamesAsync();
     }
 
@@ -182,7 +265,7 @@ public class CfbLiveScoreFetcherTests {
         var result = await BuildFetcher().FetchForSlateAsync(slate);
 
         Assert.Null(result);
-        await _cfbApi.DidNotReceiveWithAnyArgs().GetScoresByWeekAsync(default, default);
+        await _cfbApi.DidNotReceiveWithAnyArgs().GetScoresByDateRangeAsync(default, default);
         await _cfbApi.DidNotReceive().GetCfpGamesAsync();
     }
 
@@ -206,7 +289,7 @@ public class CfbLiveScoreFetcherTests {
         Assert.Equal("OSU", home.Team.Abbreviation);
         Assert.Equal(28, home.Score);
         Assert.Equal(TypeName.StatusFinal, comp.Status.Type.Name);
-        await _cfbApi.DidNotReceiveWithAnyArgs().GetScoresByWeekAsync(default, default);
+        await _cfbApi.DidNotReceiveWithAnyArgs().GetScoresByDateRangeAsync(default, default);
         await _cfbApi.DidNotReceive().GetCfpGamesAsync();
     }
 
@@ -224,23 +307,23 @@ public class CfbLiveScoreFetcherTests {
         _currentSlateService.GetCurrentSlateAsync().Returns(new CfbSlateInfo(
             slate.Id, slate.Season, slate.SlateNumber, slate.Label, slate.SlateType,
             slate.StartDate, slate.EndDate, null, DateTime.UtcNow));
-        _cfbApi.GetScoresByWeekAsync(5, false).Returns(BuildScoreboardWithRanking());
+        _cfbApi.GetScoresByDateRangeAsync(slate.StartDate, slate.EndDate).Returns(BuildScoreboardWithRanking());
 
         await BuildFetcher().FetchForSlateAsync(slate);
 
-        await _cfbApi.Received(1).GetScoresByWeekAsync(5, false);
+        await _cfbApi.Received(1).GetScoresByDateRangeAsync(slate.StartDate, slate.EndDate);
     }
 
     [Fact]
     public async Task FetchForSlateAsync_WhenDbHasNoRowsForTheSlate_FallsBackToEspn() {
         var slate = BuildRegularSeasonSlate();
         _cfbRepo.GetScoresForSlateAsync(slate.Id).Returns((IEnumerable<CfbScores>)[]);
-        _cfbApi.GetScoresByWeekAsync(5, false).Returns(BuildScoreboardWithRanking());
+        _cfbApi.GetScoresByDateRangeAsync(slate.StartDate, slate.EndDate).Returns(BuildScoreboardWithRanking());
 
         var result = await BuildFetcher().FetchForSlateAsync(slate);
 
         Assert.NotNull(result);
-        await _cfbApi.Received(1).GetScoresByWeekAsync(5, false);
+        await _cfbApi.Received(1).GetScoresByDateRangeAsync(slate.StartDate, slate.EndDate);
     }
 
     // /code-review caught a real bug: gating DB-first purely on "rows.Count > 0" means the moment
@@ -263,11 +346,12 @@ public class CfbLiveScoreFetcherTests {
             new() { Id = 1, CfbSlateId = activeSlate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal, GameTime = DateTimeOffset.UtcNow.AddHours(-3) },
         };
         _cfbRepo.GetScoresForSlateAsync(activeSlate.Id).Returns((IEnumerable<CfbScores>)partialRows);
-        _cfbApi.GetScoresByWeekAsync(3, false).Returns(BuildScoreboardWithRanking());
+        _cfbApi.GetScoresByDateRangeAsync(activeSlate.StartDate, activeSlate.EndDate)
+            .Returns(BuildScoreboardWithRanking(date: DateTimeOffset.UtcNow));
 
         var result = await BuildFetcher().FetchForSlateAsync(activeSlate);
 
-        await _cfbApi.Received(1).GetScoresByWeekAsync(3, false);
+        await _cfbApi.Received(1).GetScoresByDateRangeAsync(activeSlate.StartDate, activeSlate.EndDate);
         Assert.NotNull(result);
         Assert.Single(result!.Events!);
     }

--- a/Server.UnitTests/EspnContractTests.cs
+++ b/Server.UnitTests/EspnContractTests.cs
@@ -77,7 +77,10 @@ public class EspnContractTests
     [Fact]
     public async Task CfbScoreboard_RegularSeasonWeek_DeserializesRealWireShape()
     {
-        var scores = await BuildCfbApiService().GetScoresByWeekAsync(10, isPostSeason: false);
+        // frizat-11t: date-range now, not week=N — 2025 season Week 10's real window (matches
+        // DemoDataSeeder's CfbSlates seed row for the same week).
+        var scores = await BuildCfbApiService().GetScoresByDateRangeAsync(
+            new DateOnly(2025, 10, 25), new DateOnly(2025, 11, 1));
 
         Assert.NotNull(scores);
         Assert.NotEmpty(scores!.Events);

--- a/Server.UnitTests/EspnJsonConverterTests.cs
+++ b/Server.UnitTests/EspnJsonConverterTests.cs
@@ -94,7 +94,7 @@ public class EspnJsonConverterTests
         """;
 
     [Fact]
-    public async Task CfbApiService_GetScoresByWeekAsync_DeserializesRealWireValuesWithoutThrowing()
+    public async Task CfbApiService_GetScoresByDateRangeAsync_DeserializesRealWireValuesWithoutThrowing()
     {
         var httpClient = new HttpClient(new StubHttpMessageHandler(MinimalCfbScoreboardJson))
         {
@@ -102,7 +102,7 @@ public class EspnJsonConverterTests
         };
         var service = new CfbApiService(httpClient);
 
-        var scores = await service.GetScoresByWeekAsync(week: 10, isPostSeason: false);
+        var scores = await service.GetScoresByDateRangeAsync(new DateOnly(2025, 10, 25), new DateOnly(2025, 11, 1));
 
         var competitors = scores!.Events!.Single().Competitions.Single().Competitors;
         Assert.Equal(HomeAway.Home, competitors.Single(c => c.Team.Abbreviation == "IND").HomeAway);
@@ -186,7 +186,7 @@ public class EspnJsonConverterTests
     // game in the same scoreboard payload — this is what actually broke, not just the isolated
     // converter (System.Text.Json aborts the whole object graph on any single property throwing).
     [Fact]
-    public async Task CfbApiService_GetScoresByWeekAsync_OneGameWithUnrecognizedStatus_DoesNotBreakOtherGames()
+    public async Task CfbApiService_GetScoresByDateRangeAsync_OneGameWithUnrecognizedStatus_DoesNotBreakOtherGames()
     {
         const string payload = """
             {
@@ -233,7 +233,7 @@ public class EspnJsonConverterTests
         var httpClient = new HttpClient(new StubHttpMessageHandler(payload)) { BaseAddress = new Uri("http://site.api.espn.com") };
         var service = new CfbApiService(httpClient);
 
-        var scores = await service.GetScoresByWeekAsync(week: 1, isPostSeason: false);
+        var scores = await service.GetScoresByDateRangeAsync(new DateOnly(2025, 9, 1), new DateOnly(2025, 9, 7));
 
         Assert.Equal(2, scores!.Events!.Length);
         var uscComp = scores.Events.Single(e => e.Competitions[0].Competitors.Any(c => c.Team.Abbreviation == "USC")).Competitions[0];

--- a/Server.UnitTests/JobManagerControllerTests.cs
+++ b/Server.UnitTests/JobManagerControllerTests.cs
@@ -174,16 +174,60 @@ public class JobManagerControllerTests
     }
 
     // ── Functional: RunCfbScores happy path ───────────────────────────────────
+    // frizat-11t: the old fixed "CFB Scores Job" JobKey has never existed — CfbScoresJob is
+    // registered under 5 separately-keyed cron triggers ("CFB Scores Sat Noon"/"Sat 4pm"/"Sat
+    // 8pm"/"Sat Midnight"/"Sun 6am"), same shape as RunCfbSpreads' per-week jobs. Must find one via
+    // the same soonest-job lookup, not a hardcoded key that silently 400s every time it's clicked.
 
     [Fact]
     public async Task RunCfbScores_ReturnsOk_WhenSchedulerSucceeds()
     {
         var (factory, scheduler, observer, controller) = BuildSut(isAdmin: true);
-        scheduler.TriggerJob(new JobKey("CFB Scores Job")).Returns(Task.CompletedTask);
+        SetupSchedulerWithJobs(scheduler, ("CFB Scores Sat Noon", DateTimeOffset.UtcNow.AddDays(1)));
+        scheduler.TriggerJob(new JobKey("CFB Scores Sat Noon")).Returns(Task.CompletedTask);
 
         var result = await controller.RunCfbScores();
 
         Assert.IsType<OkObjectResult>(result);
+        await scheduler.Received(1).TriggerJob(new JobKey("CFB Scores Sat Noon"));
+    }
+
+    [Fact]
+    public async Task RunCfbScores_ReturnsNotFound_WhenNoCfbScoresJobExists()
+    {
+        var (factory, scheduler, observer, controller) = BuildSut(isAdmin: true);
+        scheduler.GetJobGroupNames().Returns(new List<string>());
+
+        var result = await controller.RunCfbScores();
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task RunCfbScores_IgnoresNflJobs()
+    {
+        var (factory, scheduler, observer, controller) = BuildSut(isAdmin: true);
+        SetupSchedulerWithJobs(scheduler, ("NFL Scores Thu 10am", DateTimeOffset.UtcNow.AddDays(1)));
+
+        var result = await controller.RunCfbScores();
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task RunCfbScores_PicksSoonestJob_NotArbitraryMatch()
+    {
+        var (factory, scheduler, observer, controller) = BuildSut(isAdmin: true);
+        SetupSchedulerWithJobs(scheduler,
+            ("CFB Scores Sun 6am", DateTimeOffset.UtcNow.AddDays(2)),
+            ("CFB Scores Sat Noon", DateTimeOffset.UtcNow.AddDays(1)));
+        scheduler.TriggerJob(new JobKey("CFB Scores Sat Noon")).Returns(Task.CompletedTask);
+
+        var result = await controller.RunCfbScores();
+
+        Assert.IsType<OkObjectResult>(result);
+        await scheduler.Received(1).TriggerJob(new JobKey("CFB Scores Sat Noon"));
+        await scheduler.DidNotReceive().TriggerJob(new JobKey("CFB Scores Sun 6am"));
     }
 
     // ── Functional: DeleteJob happy path ──────────────────────────────────────
@@ -299,7 +343,12 @@ public class JobManagerControllerTests
         Assert.IsType<NotFoundResult>(result);
     }
 
-    // ── Functional: RunScores — no scores job ────────────────────────────────
+    // ── Functional: RunScores ─────────────────────────────────────────────────
+    // frizat-11t: the old unscoped Contains("Scores") lookup could pick either sport's job
+    // depending on enumeration order — NFL and CFB scores jobs are BOTH registered under multiple
+    // separately-keyed cron triggers whose names all contain "Scores" ("NFL Scores Thu 10am" /
+    // "CFB Scores Sat Noon" etc). Must be scoped to "NFL Scores " and pick the soonest, same as
+    // RunCfbScores/RunSpreads/RunCfbSpreads.
 
     [Fact]
     public async Task RunScores_ReturnsNotFound_WhenNoScoresJobExists()
@@ -310,6 +359,51 @@ public class JobManagerControllerTests
         var result = await controller.RunScores();
 
         Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task RunScores_ReturnsOk_WhenSchedulerSucceeds()
+    {
+        var (factory, scheduler, observer, controller) = BuildSut(isAdmin: true);
+        SetupSchedulerWithJobs(scheduler, ("NFL Scores Thu 10am", DateTimeOffset.UtcNow.AddDays(1)));
+        scheduler.TriggerJob(new JobKey("NFL Scores Thu 10am")).Returns(Task.CompletedTask);
+
+        var result = await controller.RunScores();
+
+        Assert.IsType<OkObjectResult>(result);
+        await scheduler.Received(1).TriggerJob(new JobKey("NFL Scores Thu 10am"));
+    }
+
+    [Fact]
+    public async Task RunScores_IgnoresCfbJobs_EvenWhenSooner()
+    {
+        var (factory, scheduler, observer, controller) = BuildSut(isAdmin: true);
+        SetupSchedulerWithJobs(scheduler,
+            ("CFB Scores Sat Noon", DateTimeOffset.UtcNow.AddHours(1)),
+            ("NFL Scores Thu 10am", DateTimeOffset.UtcNow.AddDays(1)));
+        scheduler.TriggerJob(new JobKey("NFL Scores Thu 10am")).Returns(Task.CompletedTask);
+
+        var result = await controller.RunScores();
+
+        Assert.IsType<OkObjectResult>(result);
+        await scheduler.Received(1).TriggerJob(new JobKey("NFL Scores Thu 10am"));
+        await scheduler.DidNotReceive().TriggerJob(new JobKey("CFB Scores Sat Noon"));
+    }
+
+    [Fact]
+    public async Task RunScores_PicksSoonestJob_NotArbitraryMatch()
+    {
+        var (factory, scheduler, observer, controller) = BuildSut(isAdmin: true);
+        SetupSchedulerWithJobs(scheduler,
+            ("NFL Scores Tue 1am", DateTimeOffset.UtcNow.AddDays(5)),
+            ("NFL Scores Thu 10am", DateTimeOffset.UtcNow.AddDays(1)));
+        scheduler.TriggerJob(new JobKey("NFL Scores Thu 10am")).Returns(Task.CompletedTask);
+
+        var result = await controller.RunScores();
+
+        Assert.IsType<OkObjectResult>(result);
+        await scheduler.Received(1).TriggerJob(new JobKey("NFL Scores Thu 10am"));
+        await scheduler.DidNotReceive().TriggerJob(new JobKey("NFL Scores Tue 1am"));
     }
 
     // ── Functional: GetAllJobsStatusAsync — category/description enrichment ───

--- a/Server/Controllers/JobManagerController.cs
+++ b/Server/Controllers/JobManagerController.cs
@@ -17,28 +17,23 @@ namespace FourPlayWebApp.Server.Controllers {
         [HttpPost("run-spreads")]
         public Task<IActionResult> RunSpreads([FromQuery] bool force = false) =>
             // Each in-scope week now registers its own one-time "NFL Spreads {season} Wk{n}"
-            // job (frizat-pxy) — TriggerSoonestSpreadJobAsync picks the SOONEST one, not an
+            // job (frizat-pxy) — TriggerSoonestJobAsync picks the SOONEST one, not an
             // arbitrary match; a plain Contains("Spreads") FirstOrDefault would grab whichever
             // week sorts first alphabetically ("Wk1" before "Wk10"), not the one coming up next.
-            TriggerSoonestSpreadJobAsync("NFL Spreads ", "Spread", force);
+            TriggerSoonestJobAsync("NFL Spreads ", "Spread", force);
         [Authorize(Roles = "Administrator")]
         [HttpPost("run-scores")]
-        public async Task<IActionResult> RunScores() {
-            try {
-                var scheduler = await schedulerFactory.GetScheduler();
-                var allJobs = await GetAllJobsStatusAsync();
-                var jobName = allJobs.FirstOrDefault(job =>
-                    job.JobName.Contains("Scores", StringComparison.OrdinalIgnoreCase));
-                if (jobName is null)
-                    return NotFound();
-                await scheduler.TriggerJob(new JobKey(jobName.JobName));
-                Log.Information("Started Scores Job");
-                return Ok(new MessageResponseDto("Started Scores Job"));
-            }
-            catch (Exception e) {
-                return BadRequest(e.Message);
-            }
-        }
+        public Task<IActionResult> RunScores() =>
+            // frizat-11t: NflScoresJob is registered under 7 separately-keyed cron triggers ("NFL
+            // Scores Thu 10am", "NFL Scores Fri 1am", ...), all containing "Scores" — same for CFB's
+            // 5 triggers ("CFB Scores Sat Noon", ...). The old unscoped Contains("Scores")
+            // FirstOrDefault could pick either sport's job depending on enumeration order. Scoped to
+            // "NFL Scores " and soonest-first, same pattern as the spread jobs — though unlike the
+            // per-week spread jobs, "soonest" carries no real meaning here: every trigger for a given
+            // sport runs the exact same Execute() regardless of which cron fired it, so any matching
+            // job would do. Reusing the soonest-first helper is just convenient shared plumbing, not
+            // picking a semantically "correct" job the way it does for spreads.
+            TriggerSoonestJobAsync("NFL Scores ", "Scores", force: false);
         [Authorize(Roles = "Administrator")]
         [HttpPost("run-users")]
         public async Task<IActionResult> RunUserJob() {
@@ -71,20 +66,15 @@ namespace FourPlayWebApp.Server.Controllers {
             // The fixed "CFB Spread Job" JobKey this used to trigger no longer exists — CFB
             // spreads now run via per-week "CFB Spreads {season} Wk{n}" triggers (frizat-9m0),
             // same reasoning as RunSpreads above: pick the soonest one, not an arbitrary match.
-            TriggerSoonestSpreadJobAsync("CFB Spreads ", "CFB Spread", force);
+            TriggerSoonestJobAsync("CFB Spreads ", "CFB Spread", force);
         [Authorize(Roles = "Administrator")]
         [HttpPost("run-cfb-scores")]
-        public async Task<IActionResult> RunCfbScores() {
-            try {
-                var scheduler = await schedulerFactory.GetScheduler();
-                await scheduler.TriggerJob(new JobKey("CFB Scores Job"));
-                Log.Information("Started CFB Scores Job");
-                return Ok(new MessageResponseDto("Started CFB Scores Job"));
-            }
-            catch (Exception e) {
-                return BadRequest(e.Message);
-            }
-        }
+        public Task<IActionResult> RunCfbScores() =>
+            // frizat-11t: the fixed "CFB Scores Job" JobKey this used to trigger has never
+            // existed — CfbScoresJob runs via 5 separately-keyed cron triggers ("CFB Scores Sat
+            // Noon"/"Sat 4pm"/"Sat 8pm"/"Sat Midnight"/"Sun 6am"), same shape as the per-week
+            // spread jobs. Pick the soonest one, not a hardcoded key that always 400s.
+            TriggerSoonestJobAsync("CFB Scores ", "CFB Scores", force: false);
 
         [Authorize(Roles = "Administrator")]
         [HttpGet("get-jobs")]
@@ -188,11 +178,12 @@ namespace FourPlayWebApp.Server.Controllers {
         }
 
 
-        // Shared by RunSpreads/RunCfbSpreads: picks the soonest not-yet-fired per-week job whose
-        // name starts with jobNamePrefix and triggers it, optionally bypassing the sport's
-        // lock-time write guard (SpreadLockGuard) via force=true. force is deliberately not the
-        // default — logged distinctly so an early write via this path is always auditable.
-        private async Task<IActionResult> TriggerSoonestSpreadJobAsync(string jobNamePrefix, string sportLabel, bool force) {
+        // Shared by RunSpreads/RunCfbSpreads/RunScores/RunCfbScores: picks the soonest not-yet-fired
+        // job whose name starts with jobNamePrefix and triggers it, optionally bypassing the spread
+        // jobs' lock-time write guard (SpreadLockGuard) via force=true. force is deliberately not
+        // the default — logged distinctly so an early write via this path is always auditable.
+        // Scores jobs don't have a lock-time guard, so their callers always pass force: false.
+        private async Task<IActionResult> TriggerSoonestJobAsync(string jobNamePrefix, string sportLabel, bool force) {
             try {
                 var scheduler = await schedulerFactory.GetScheduler();
                 var allJobs = await GetAllJobsStatusAsync();

--- a/Server/Services/CfbApiService.cs
+++ b/Server/Services/CfbApiService.cs
@@ -11,12 +11,20 @@ public class CfbApiService(HttpClient httpClient) : ICfbApiService {
     // EspnContractTests + EspnJsonConverterTests, frizat-703.5).
     private static readonly JsonSerializerOptions _opts = EspnApiServiceJsonConverter.Settings;
 
-    // Week-based query: seasontype=2 for regular/conf-champs, seasontype=3 for CFP rounds.
-    // Fixes the broken groups=80 date-range approach — one call per slate, no date iteration.
-    public async Task<EspnScores?> GetScoresByWeekAsync(int week, bool isPostSeason) {
-        var seasonType = isPostSeason ? 3 : 2;
-        var limit = isPostSeason ? 50 : 100;
-        var url = $"/apis/site/v2/sports/football/college-football/scoreboard?week={week}&seasontype={seasonType}&limit={limit}";
+    // Date-range query (frizat-11t), scoped to the control table's own WeekStartDate/WeekEndDate —
+    // NOT the old groups=80 date-range approach the previous week-based query's comment referenced
+    // (that one silently ignored ESPN's Top-25 group filter). ESPN's own week=N bucketing doesn't
+    // respect our slate boundaries — e.g. a team's early/"week 0" opener can land in the same
+    // week=N response as their real week-N game, so "one game per team per slate" wasn't actually
+    // true under the week-based query. dates=yyyyMMdd-yyyyMMdd scoped to our own slate window makes
+    // that invariant hold for real, same reasoning as GetCfpGamesAsync's downstream date filter.
+    // Regular season/conf-champs only — no isPostSeason branch, since CFP already has its own
+    // correct, dedicated mechanism below (week=999 + downstream date filter) that this doesn't
+    // need to duplicate or unify with; adding a postseason branch here that no caller would ever
+    // exercise would just be dead code implying an equivalence that doesn't exist.
+    public async Task<EspnScores?> GetScoresByDateRangeAsync(DateOnly startDate, DateOnly endDate) {
+        var dates = $"{startDate:yyyyMMdd}-{endDate:yyyyMMdd}";
+        var url = $"/apis/site/v2/sports/football/college-football/scoreboard?dates={dates}&seasontype=2&limit=100";
         var response = await httpClient.GetAsync(url);
         if (!response.IsSuccessStatusCode) return null;
         var json = await response.Content.ReadAsStringAsync();

--- a/Server/Services/CfbLiveScoreFetcher.cs
+++ b/Server/Services/CfbLiveScoreFetcher.cs
@@ -16,11 +16,15 @@ public class CfbLiveScoreFetcher(ICfbApiService cfbApi, IServiceScopeFactory sco
     public async Task<EspnScores?> FetchForSlateAsync(CfbSlates slate) {
         // CfbSeasonWeekConfig.EspnWeekNumber is non-nullable, and both known producers of CfbSlates
         // rows (CfbSlateSeederJob, DemoDataSeeder) always copy a real week number through — so every
-        // slate in practice carries one, and this app only ever makes week-based ESPN queries, never
-        // date-range "scoreboard" calls. CfbSlates.EspnWeekNumber itself is still nullable at the
-        // model/DB level though, so a future producer could leave it unset — a missing value here
-        // means the control table wasn't seeded correctly, not a case to silently paper over with a
-        // date-range fallback. Checked up front so it applies uniformly to the DB-first branch below
+        // slate in practice carries one. frizat-11t: the regular-season ESPN fetch itself no longer
+        // uses EspnWeekNumber (it queries by slate.StartDate/EndDate instead — see
+        // FetchRegularSeasonAsync — because ESPN's own week=N bucketing doesn't respect our slate's own
+        // date window and can return a team's game from an entirely different slate). EspnWeekNumber
+        // is still required here as the natural key CfbRanking rows and CfbPicksController's ranking
+        // lookup are keyed on (Season, EspnWeekNumber, TeamAbbreviation) — a missing value still means
+        // the control table wasn't seeded correctly, not a case to silently paper over. CfbSlates.
+        // EspnWeekNumber itself is still nullable at the model/DB level though, so a future producer
+        // could leave it unset. Checked up front so it applies uniformly to the DB-first branch below
         // too — /code-review caught that branch silently defaulting a missing value to week 0
         // instead of applying this same guard.
         if (!slate.EspnWeekNumber.HasValue) {
@@ -79,7 +83,7 @@ public class CfbLiveScoreFetcher(ICfbApiService cfbApi, IServiceScopeFactory sco
 
         var result = CfbSlateHelpers.IsCfpSlate(slate.ScoringFormat)
             ? await FetchCfpAsync(slate)
-            : await FetchRankedWeekAsync(slate);
+            : await FetchRegularSeasonAsync(slate);
 
         // Replay mode only (DEMO_REPLAY_MODE=true) — ReplayCacheService is a Singleton registered
         // only then, so this resolves null (a no-op) in every other environment. The replay
@@ -121,14 +125,32 @@ public class CfbLiveScoreFetcher(ICfbApiService cfbApi, IServiceScopeFactory sco
         return events.Length == 0 ? null : WithEvents(scoreboard, events);
     }
 
-    private async Task<EspnScores?> FetchRankedWeekAsync(CfbSlates slate) {
-        // Regular season / conf-champs: full FBS week, no rank filter (frizat-9m0) — every game is
+    private async Task<EspnScores?> FetchRegularSeasonAsync(CfbSlates slate) {
+        // Regular season / conf-champs: full FBS slate, no rank filter (frizat-9m0) — every game is
         // persisted for the audit trail; CfbSpreadJob computes IsLeagueEligible from rank + day of
         // week separately, gating what's *served* to users without dropping data at ingestion.
-        var scoreboard = await cfbApi.GetScoresByWeekAsync(slate.EspnWeekNumber!.Value, isPostSeason: false);
+        //
+        // frizat-11t: queries ESPN by our own slate.StartDate/EndDate, not slate.EspnWeekNumber —
+        // ESPN's week=N scoreboard bucket doesn't respect our slate's date boundaries (e.g. a team's
+        // early "week 0" opener can land in the same week=N response as their real week-N game),
+        // which silently broke the "one game per team per slate" assumption the frontend's live-score
+        // join relies on. Scoping the ESPN call to our own control-table dates instead makes that
+        // assumption hold in practice (verified live). The downstream filter below is defense in
+        // depth on top of that, not a substitute for it — /code-review's point: this fix's whole
+        // premise is "don't fully trust ESPN's own bucketing," so don't trust the dates= query param
+        // to be honored perfectly either (e.g. a timezone-boundary edge case on a late-night/West
+        // Coast kickoff). Same date-window filter FetchCfpAsync already applies above.
+        var scoreboard = await cfbApi.GetScoresByDateRangeAsync(slate.StartDate, slate.EndDate);
         if (scoreboard?.Events is null) return null;
 
-        return scoreboard.Events.Length == 0 ? null : WithEvents(scoreboard, scoreboard.Events);
+        var events = scoreboard.Events.Where(e => {
+            var comp = e.Competitions.FirstOrDefault();
+            return comp is not null
+                && comp.Date.Date >= slate.StartDate.ToDateTime(TimeOnly.MinValue).Date
+                && comp.Date.Date <= slate.EndDate.ToDateTime(TimeOnly.MaxValue).Date;
+        }).ToArray();
+
+        return events.Length == 0 ? null : WithEvents(scoreboard, events);
     }
 
     private static EspnScores WithEvents(EspnScores source, Event[] events) => new() {

--- a/Server/Services/Interfaces/ICfbApiService.cs
+++ b/Server/Services/Interfaces/ICfbApiService.cs
@@ -3,6 +3,6 @@ using FourPlayWebApp.Shared.Models;
 namespace FourPlayWebApp.Server.Services.Interfaces;
 
 public interface ICfbApiService {
-    Task<EspnScores?> GetScoresByWeekAsync(int week, bool isPostSeason);
+    Task<EspnScores?> GetScoresByDateRangeAsync(DateOnly startDate, DateOnly endDate);
     Task<EspnScores?> GetCfpGamesAsync();
 }

--- a/Server/Services/Interfaces/ICfbLiveScoreFetcher.cs
+++ b/Server/Services/Interfaces/ICfbLiveScoreFetcher.cs
@@ -5,8 +5,10 @@ namespace FourPlayWebApp.Server.Services.Interfaces;
 
 /// <summary>
 /// Resolves the live ESPN scoreboard for one CFB slate — CFP week=999 + date filter for postseason,
-/// ranked-team filtering for regular season. A slate missing EspnWeekNumber is a control-table
-/// seeding bug, not a case to fall back on — logs a warning and returns null. Extracted from
+/// full-slate date-range query (frizat-11t: slate.StartDate/EndDate, not ESPN's own week=N bucket)
+/// for regular season/conf-champs, no rank filter at ingestion (frizat-9m0 — eligibility is computed
+/// downstream). A slate missing EspnWeekNumber is a control-table seeding bug, not a case to fall
+/// back on — logs a warning and returns null. Extracted from
 /// CfbScoresJob (frizat-703.6) so the DB-upsert jobs (CfbScoresJob, CfbSpreadJob) and
 /// CfbCacheService's live-serving path share one implementation instead of maintaining the
 /// CFP/ranked branching three times.

--- a/docs/CfbEspnWeekVsDateRange.md
+++ b/docs/CfbEspnWeekVsDateRange.md
@@ -1,0 +1,84 @@
+# CFB: ESPN week numbers vs. date ranges — history and the current design
+
+This has flip-flopped twice already. Read this before changing how `CfbLiveScoreFetcher` queries
+ESPN, so a third flip doesn't happen for a reason already covered here.
+
+## Round 1 (pre-frizat-vaw): date-based queries — buggy
+
+The original CFB jobs (`CfbScoresJob`/`CfbSpreadJob`) queried ESPN by **date**
+(`GetTop25ByDateAsync`/`GetScoresByDateAsync`, using a `groups=80` param meant to filter to Top-25
+games). Two real bugs, closed by bead **frizat-vaw** (GitHub #93):
+
+- ESPN silently **ignored** `groups=80` — it returned every game on that date, not just Top 25.
+- A slate's date range could accidentally overlap a bowl game or another event entirely — date
+  ranges don't respect ESPN's own notion of "this game belongs to this bracket/round."
+
+## Round 2 (frizat-vaw → frizat-9m0): week-based queries — fixed the above, introduced a new gap
+
+frizat-vaw switched regular season / conf-champs to ESPN's `week={N}` scoreboard param (plus a
+`curatedRank <= 25` filter, later removed by frizat-9m0 in favor of ingesting the full slate and
+filtering at the serving layer). CFP rounds use ESPN's `week=999` bucket + a downstream date filter
+(`FetchCfpAsync`), since `week=999` returns every CFP game at once regardless of round.
+
+This fixed both Round 1 bugs. But it introduced a different one, not caught until a live incident:
+**ESPN's own `week=N` bucketing does not respect our `CfbSeasonWeekConfig`/`CfbSlates` date
+boundaries.** A team with an early "week 0"-ish opener can have that game land in the same
+`week=N` response as their real week-N game. Confirmed live: querying `week=1&seasontype=2` for
+the 2026 season returned **both** USC's Aug 29 opener (vs San José State, `Final`) and their real
+Sep 4/5 week-1 game (vs Fresno State, `Scheduled`) — even though Aug 29 is before slate 19's own
+`WeekStartDate` (Sep 1).
+
+The frontend's live-score join (`cfbAdapter.ts`'s `buildGamesFromEspn`) keys its ESPN lookup map by
+**home-team abbreviation only**, on the explicit assumption that a team plays at most one game per
+slate. That assumption is normally true — but wasn't, for this one fetch. Whichever of the two USC
+events iterated last in the response silently overwrote the other in the map, so the Picks/Scores
+page briefly rendered USC vs. Fresno State (not yet started) with San José State's already-final
+42-26 result attached.
+
+## Round 3 (frizat-11t, current): date-range query, scoped to our own control table
+
+The fix (bead **frizat-11t**) is neither of the above — it's not a revert to Round 1's
+`groups=80` date approach:
+
+- `ICfbApiService.GetScoresByDateRangeAsync(DateOnly startDate, DateOnly endDate)` queries ESPN's
+  `dates=yyyyMMdd-yyyyMMdd` scoreboard param, **not** `groups=80`. No `isPostSeason` parameter —
+  CFP already has its own correct, dedicated mechanism (`GetCfpGamesAsync`, below), so this method
+  is regular-season/conf-champs only; a postseason branch here would be dead code no caller
+  exercises.
+- `CfbLiveScoreFetcher.FetchRegularSeasonAsync` (formerly `FetchRankedWeekAsync`) calls it with
+  `slate.StartDate`/`slate.EndDate` — the control table's own boundaries — instead of
+  `slate.EspnWeekNumber`, **and** applies the same downstream date-window filter `FetchCfpAsync`
+  already used, as defense in depth on top of the query param (the fix's whole premise is "don't
+  fully trust ESPN's own bucketing," so it shouldn't fully trust the query param to be honored
+  perfectly in every edge case either — e.g. a timezone boundary on a late-night/West-Coast kickoff).
+- Verified live: `dates=20260901-20260907` (slate 19's actual window) returns **exactly one** USC
+  game — Fresno State. The Aug 29 SJSU game is correctly excluded.
+
+This makes "one game per team per slate" actually true instead of an unchecked assumption, so the
+frontend's home-team-only join key (deliberately **not** changed by this fix — see the
+`buildGamesFromEspn` comment) is safe again. It also extends the same principle PR #285
+(`fix/current-week-control-table-authoritative`) established for *which slate is current* — the
+control table wins over ESPN's own bucketing — to *which games belong to that slate's fetch* too.
+
+**Why NFL doesn't need this fix too:** NFL's regular-season week query can't structurally hit this
+bug class. CFB's early "week 0" openers are tagged `seasontype=2` (regular season) by ESPN despite
+predating the control table's week-1 window — that's the actual mechanism that let USC's Aug 29
+game leak into a `week=1` fetch. NFL has no equivalent: its preseason is a wholly separate
+`seasontype=1` bucket that a `seasontype=2` week query never returns, and the regular season
+schedule gives each team exactly one game per week by construction — there's no "early game
+folded into week 1's bucket" scenario for `EspnCacheService`'s week-based NFL query to reproduce.
+Checked per this repo's NFL/CFB sharing rule; this is a genuine CFB-only difference, not a gap.
+
+`EspnWeekNumber` is **not removed** from `CfbSlates`/`CfbSeasonWeekConfig`. It's still required as
+the natural-key component `CfbRanking` rows and `CfbPicksController`'s ranking lookup use
+(`(Season, EspnWeekNumber, TeamAbbreviation)`) — it's just no longer used to construct the
+scoreboard query itself. `CfbRankingCaptureJob` shares the same `FetchForSlateAsync` call as scores,
+so rankings and scores are now both date-scoped together automatically — nothing is left on a
+week-based path to drift out of sync with the other.
+
+## If this needs to change a fourth time
+
+Before reverting to week-based or introducing yet another approach: the actual failure mode was a
+**team appearing twice in one raw ESPN response**, not the date-range mechanism itself. Any future
+change should be checked against that specific scenario (a team with two games — e.g. a rescheduled
+game, a make-up game, a true week-0 opener — landing in the same fetch) before shipping.


### PR DESCRIPTION
## Summary
Promotes the CFB live-score fix (PR #312) to production.

- Live incident: USC vs Fresno State (Scheduled) briefly rendered San José State's already-final 42-26 result, because ESPN's `week=1` scoreboard bucket included both USC games (an early "week 0"-ish opener plus their real week-1 game) — and the frontend's live-score join assumes one game per team per slate.
- `CfbLiveScoreFetcher`'s regular-season path now queries ESPN by our own slate's `dates=yyyyMMdd-yyyyMMdd` (the control table's `WeekStartDate`/`WeekEndDate`) instead of `week={EspnWeekNumber}`, plus a downstream date-window filter as defense in depth — verified live against real ESPN that this correctly excludes the stray game.
- Fixes the admin Job Manager's "run CFB/NFL scores now" buttons — `RunCfbScores` was hardcoded to a `JobKey` that never existed; `RunScores` could trigger either sport's job.
- `docs/CfbEspnWeekVsDateRange.md` documents the full history so this ESPN-query strategy doesn't get re-litigated a fourth time.

## Test plan
- [x] `dotnet test` — 826 backend tests pass
- [x] `npm run test -- --run` — 561 frontend tests pass
- [x] `npm run test:e2e -- --project=chromium` — 92/92 pass
- [x] Verified live end-to-end against real ESPN
- [x] PR #312 CI green (backend/frontend build & test, demo/replay e2e, Docker build, secret scan)
- [x] Railway dev deploy healthy post-merge — clean startup, no exceptions
- [x] `/simplify` + `/code-review` run, all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)