### PR TITLE
fix(pwa): hide switch-sport control inside installed home-screen app

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -12,6 +12,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 - Fixed: a CFB or NFL game could silently show as Final before it even started if ESPN's response was ever missing the status field outright — that field now fails loudly and falls back to Scheduled instead of defaulting to Final
 - Fixed: a CFB team with two games landing in ESPN's same weekly scoreboard fetch (e.g. an early-season opener plus that week's real game) could briefly show the wrong game's score and status, since the live fetch queried ESPN by its own week number instead of our own scheduled date range
 - Fixed: the admin Job Manager's "run now" button for CFB scores was broken and always failed; the NFL scores button had a related bug where it could trigger the wrong sport's job
+- Fixed: "Switch to CFB/NFL" from an installed home-screen app always dropped into the browser with no way back into the app — this control is now hidden inside an installed app (it's still on the regular website); each sport's installed home-screen icon is now labeled distinctly instead of both reading "IV League"
 
 ## 2026-09-03
 

--- a/Client.React/index.html
+++ b/Client.React/index.html
@@ -6,12 +6,35 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="manifest" href="/manifest.json" />
+    <!-- NFL (ivleague.xyz) and CFB (cfb.ivleague.xyz) are separate origins sharing this one
+         build/index.html, so which manifest/home-screen title applies has to be picked at
+         runtime by hostname, not baked into a static tag — otherwise both sports' installed
+         home-screen icons would be indistinguishable ("IV League" for both). This duplicates the
+         same hostname check src/services/sport.tsx's detectSport() and AppLayout.tsx's
+         getOtherSportUrl() already do — deliberately, not an oversight: this script runs before
+         any JS module loads (it has to append the manifest link ASAP), so it can't import either
+         of those. Keep the `cfb.` prefix check here in sync with theirs if that logic ever changes.
+         manifest.json (NFL) and manifest.cfb.json (CFB) are intentionally near-duplicates —
+         name/short_name differ, everything else (icons, theme_color, background_color) must
+         match. JSON can't hold a same-file comment, so if you change one, change the other. -->
+    <script>
+      (function () {
+        var isCfb = location.hostname.startsWith('cfb.');
+        var manifestLink = document.createElement('link');
+        manifestLink.rel = 'manifest';
+        manifestLink.href = isCfb ? '/manifest.cfb.json' : '/manifest.json';
+        document.head.appendChild(manifestLink);
+
+        var titleMeta = document.createElement('meta');
+        titleMeta.name = 'apple-mobile-web-app-title';
+        titleMeta.content = isCfb ? 'IV League CFB' : 'IV League NFL';
+        document.head.appendChild(titleMeta);
+      })();
+    </script>
     <!-- Mobile optimization for iOS and Android -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=yes, maximum-scale=5" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="IV League" />
     <meta name="theme-color" content="#1a2847" />
 
 

--- a/Client.React/public/manifest.cfb.json
+++ b/Client.React/public/manifest.cfb.json
@@ -1,6 +1,6 @@
 {
-  "name": "IV League NFL",
-  "short_name": "IVL NFL",
+  "name": "IV League CFB",
+  "short_name": "IVL CFB",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#1a2847",

--- a/Client.React/src/__tests__/sportAccess.test.tsx
+++ b/Client.React/src/__tests__/sportAccess.test.tsx
@@ -186,11 +186,14 @@ describe('Sport access control', () => {
     });
   });
 
-  // frizat nitpick: tapping "Switch to CFB" from an installed iOS PWA silently drops the user
-  // into Safari, out of standalone mode — a platform constraint (each sport is a separate origin,
-  // so a separate installed PWA) that no routing change can fix. The controls just say so up
-  // front now, so it isn't a surprise.
-  describe('Switch-sport copy inside an installed standalone PWA', () => {
+  // frizat: tapping "Switch to CFB" from an installed iOS/Android PWA always drops the user into
+  // the system browser, out of standalone mode — a platform constraint (each sport is a separate
+  // origin, so a separate installed PWA, and neither iOS nor Android lets a plain web link hand
+  // off to a different origin's installed app) that no routing change or in-app dialog can fix.
+  // The control is only ever shown to users who already have access to both sports (`hasOther`),
+  // so hiding it in standalone mode doesn't hide the other sport's existence from anyone — it just
+  // removes a control whose only possible action is an unexpected app-to-browser jump.
+  describe('Switch-sport controls inside an installed standalone PWA', () => {
     let originalMatchMedia: typeof window.matchMedia;
 
     beforeEach(() => {
@@ -211,20 +214,22 @@ describe('Sport access control', () => {
       window.matchMedia = originalMatchMedia;
     });
 
-    it('flags the toolbar quick-switch link as opening in the browser', () => {
+    it('hides the toolbar quick-switch control entirely when running as a standalone PWA', () => {
       renderLayout();
-      expect(screen.getByRole('link', { name: /switch to cfb site \(opens in your browser\)/i })).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /switch to cfb/i })).not.toBeInTheDocument();
     });
 
-    it('adds an explanatory caption under the empty-state "Go to {sport} site" button', () => {
+    // /code-review: unlike the toolbar chip, this button is the ONLY link on the "no access"
+    // empty-state screen — hiding it in standalone mode would strand a user who installed the
+    // wrong sport's PWA with no way out. It stays visible in every mode.
+    it('still shows the empty-state "Go to {sport} site" button when running as a standalone PWA', () => {
       Object.assign(sportContext, { sport: 'CFB', isCfb: true, isNfl: false });
       Object.assign(sessionState, { hasNflAccess: true, hasCfbAccess: false, currentLeague: null });
       renderLayout();
       expect(screen.getByRole('link', { name: /go to nfl/i })).toBeInTheDocument();
-      expect(screen.getByText(/opens in your browser/i)).toBeInTheDocument();
     });
 
-    it('does not flag the toolbar quick-switch link when not running as a standalone PWA', () => {
+    it('still shows the toolbar quick-switch link when not running as a standalone PWA', () => {
       window.matchMedia = originalMatchMedia;
       renderLayout();
       expect(screen.getByRole('link', { name: /^switch to cfb site$/i })).toBeInTheDocument();

--- a/Client.React/src/layouts/AppLayout.tsx
+++ b/Client.React/src/layouts/AppLayout.tsx
@@ -23,7 +23,6 @@ import {
 } from '@mui/material';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import MenuIcon from '@mui/icons-material/Menu';
@@ -96,11 +95,13 @@ export default function AppLayout() {
   };
 
   // NFL and CFB are separate origins, so each is its own installed PWA — a cross-origin link
-  // from one always drops a standalone-mode install into the regular browser (see utils/pwa.ts).
-  // Not fixable via routing; the switch-sport controls below just say so up front instead of
-  // surprising the user with an unexpected app-to-browser jump.
+  // from one always drops a standalone-mode install into the regular browser, on every platform
+  // (see utils/pwa.ts). Not fixable via routing or an in-app dialog, so the switch-sport controls
+  // below are hidden entirely in standalone mode rather than showing a control whose only
+  // possible action is an unexpected app-to-browser jump. This control is only ever shown to
+  // users who already have access to both sports (hasOther), so hiding it doesn't hide the other
+  // sport's existence from anyone — they already know it exists.
   const inStandalonePwa = isStandalonePwa();
-  const otherSportOpensInBrowser = inStandalonePwa ? ' (opens in your browser)' : '';
 
   const handleNavClick = (to: string) => {
     if (isMobile) setOpen(false);
@@ -143,14 +144,15 @@ export default function AppLayout() {
           <Typography color="text.secondary" sx={{ mb: 2 }}>
             Your account has {isCfb ? 'NFL' : 'CFB'} leagues but not {isCfb ? 'CFB' : 'NFL'}.
           </Typography>
+          {/* /code-review: unlike the toolbar chip (a convenience shortcut on an otherwise fully
+              functional page), this is the ONLY link on this screen — there's no nav, no content,
+              nothing else to do here. Hiding it in standalone mode would strand a user who
+              installed the wrong sport's PWA with a dead end and no way out. Keep it visible
+              always, even though it still has to open the system browser (same platform
+              constraint as the toolbar chip). */}
           <Button variant="contained" href={getOtherSportUrl()}>
             Go to {isCfb ? 'NFL' : 'CFB'} site
           </Button>
-          {inStandalonePwa && (
-            <Typography variant="caption" color="text.secondary" sx={{ mt: 1 }}>
-              Opens in your browser — this installed app can only show {isCfb ? 'CFB' : 'NFL'}.
-            </Typography>
-          )}
         </>
       ) : (
         <Typography color="text.secondary">
@@ -189,16 +191,13 @@ export default function AppLayout() {
             </Typography>
           </Box>
           <Stack direction="row" spacing={1} alignItems="center">
-            {hasOther && !noAccessContent && (
+            {hasOther && !noAccessContent && !inStandalonePwa && (
               <Chip
                 component="a"
                 href={getOtherSportUrl()}
-                // A distinct "leaves the app" icon when installed standalone — always visible,
-                // unlike a hover title/tooltip, which a one-tap mobile navigation never shows.
-                icon={inStandalonePwa ? <OpenInNewIcon /> : <SwapHorizIcon />}
+                icon={<SwapHorizIcon />}
                 label={otherSport}
-                title={inStandalonePwa ? 'Opens in your browser, outside this installed app' : undefined}
-                aria-label={`Switch to ${otherSport} site${otherSportOpensInBrowser}`}
+                aria-label={`Switch to ${otherSport} site`}
                 clickable
                 variant="outlined"
                 sx={{

--- a/Client.React/src/utils/pwa.ts
+++ b/Client.React/src/utils/pwa.ts
@@ -3,8 +3,10 @@
  * equivalent). NFL (ivleague.xyz) and CFB (cfb.ivleague.xyz) are separate origins, so each is
  * its own installed PWA with its own scope — a cross-origin link between them always breaks out
  * of standalone mode into the regular browser, on every platform. That's a platform constraint
- * (manifest scope is origin-bound), not something a link/route change here can fix — the only
- * thing AppLayout's "Switch to CFB/NFL" control can do is warn the user before it happens.
+ * (manifest scope is origin-bound, and neither iOS nor Android lets a plain web link hand off to
+ * a different origin's installed home-screen app), not something a link/route change here can
+ * fix — AppLayout hides the "Switch to CFB/NFL" control entirely in standalone mode instead of
+ * showing a control whose only possible action is an unexpected app-to-browser jump.
  */
 export function isStandalonePwa(): boolean {
   if (window.matchMedia?.('(display-mode: standalone)').matches) return true;


### PR DESCRIPTION
## Summary
- "Switch to CFB/NFL" from an installed home-screen PWA always dropped into the system browser with no way back — a hard platform constraint (neither iOS nor Android lets a plain web link hand off to a different origin's installed app). The toolbar control is now hidden entirely in standalone mode; it's only ever shown to users who already have access to both sports, so hiding it doesn't hide anything from them.
- The "No {sport} access" empty-state button is deliberately **not** hidden — `/code-review` caught that it's the only link on that screen; hiding it would strand a user who installed the wrong sport's app.
- Both sports' installed icons currently read "IV League" with no way to tell them apart — added a per-sport manifest (`manifest.cfb.json`), with `index.html` picking the right one + `apple-mobile-web-app-title` at runtime by hostname.
- Regular browser behavior (mobile or desktop, not installed) is completely unchanged.

## Test plan
- [x] `npm run test -- --run` — 561 tests pass
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm run test:e2e -- --project=chromium` — 91/92 pass (1 known pre-existing flake, unrelated)
- [x] Verified manifest injection live in a real browser (Playwright) against both `localhost` and `cfb.localhost` — correct manifest + apple title per host
- [x] `/simplify` (4 parallel agents) and `/code-review` run; both findings addressed (empty-state button reverted to always-visible; manifest-sync note added since `manifest.json`/`manifest.cfb.json` can't hold same-file comments)
- [x] `CHANGELOG.md` entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)