### PR TITLE
fix(scores): away team's spread cover was derived by negating home's, breaking backdoor covers

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -8,6 +8,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 
 - Added: users can now change their own username from the Account page, without needing to contact an admin
 - Fixed: email subject lines with special characters (e.g. an em-dash) could render as garbled text in the received email
+- Fixed: on the Scores page, an away team that "backdoor covered" its own teased spread (e.g. lost the game outright but by less than its spread) could show a red loss icon instead of green — the away result was being derived by inverting the home team's result, which only works when spreads are mirror images, but this league's tease makes them asymmetric
 
 ## 2026-09-04
 

--- a/Client.React/src/__tests__/gameHelpers.covers.test.ts
+++ b/Client.React/src/__tests__/gameHelpers.covers.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { computeHomeCovers, computeAwayCovers } from '../utils/gameHelpers';
+
+// frizat: reported live bug — a CFB Scores page game (UTEP @ OU, final 0-51) showed UTEP's pick
+// as a loss even though UTEP had backdoor-covered its own +53.5 line. Root cause: this app's
+// "teased" spread adds the league's juice independently to EACH side (SpreadCalculator.GetSpread,
+// called once per team), so home/away spreads are NOT mirror images of each other once juice is
+// nonzero (e.g. OU -27.5 / UTEP +53.5 — these do not sum to zero). The Scores page derived the
+// away team's cover as `!homeCovers`, which is only correct when the two spreads are exact
+// opposites. It must be computed independently from the away team's own spread instead.
+describe('computeHomeCovers / computeAwayCovers', () => {
+  it('home team covers when it wins by more than its own (juiced) spread', () => {
+    // OU -27.5, final OU 51 - UTEP 0: 51 + (-27.5) = 23.5 > 0
+    expect(computeHomeCovers('final', -27.5, 51, 0)).toBe(true);
+  });
+
+  it('away team backdoor-covers its own teased spread even though it lost outright — independent of the home team result', () => {
+    // UTEP +53.5, final OU 51 - UTEP 0: 0 + 53.5 = 53.5 > 51 → UTEP covers its own line,
+    // even though the home team (OU) ALSO covers its own line — juice can make both sides "win"
+    // their pick simultaneously, so away must never be derived by negating home.
+    expect(computeAwayCovers('final', 53.5, 51, 0)).toBe(true);
+  });
+
+  it('negating homeCovers would give the wrong answer for this exact matchup (regression guard)', () => {
+    const homeCovers = computeHomeCovers('final', -27.5, 51, 0);
+    const awayCovers = computeAwayCovers('final', 53.5, 51, 0);
+    expect(homeCovers).toBe(true);
+    expect(awayCovers).toBe(true);
+    expect(awayCovers).not.toBe(!homeCovers);
+  });
+
+  it('away team fails to cover when it loses by more than its own spread', () => {
+    // MIA +37.5, final MIA 45 - STAN... wait, MIA is home here in the real game; use as a plain
+    // away-underdog example: away +37.5, loses by 39 → -39 is not > -37.5
+    expect(computeAwayCovers('final', 37.5, 39, 0)).toBe(false);
+  });
+
+  it('returns null when the game is not decided', () => {
+    expect(computeAwayCovers('scheduled', 53.5, null, null)).toBeNull();
+  });
+
+  it('returns null when the away spread is unavailable', () => {
+    expect(computeAwayCovers('final', null, 51, 0)).toBeNull();
+  });
+});

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -70,7 +70,8 @@ const mockedGetCfbCurrentSlate = vi.mocked(getCfbCurrentSlate);
 
 
 // BUF home (24-10), spread -7: homeCovers = 24+(-7)=17 > 10 ✓ (BUF covers → green)
-// MIA away: !homeCovers → red; Over at 47.5: 24+10=34 < 47.5 → Under wins
+// MIA away, spread +7 (mirror of -7 in this default fixture): awayCovers = 10+7=17 > 24 is false
+// → red. Over at 47.5: 24+10=34 < 47.5 → Under wins
 const SPREAD_RESPONSES = {
   BUF: createSpreadResponse('BUF', -7, 47.5, 47.5),
   MIA: createSpreadResponse('MIA', 7, 47.5, 47.5),
@@ -281,6 +282,25 @@ describe('ScoresPage', () => {
     await setupDefaults({ picks, gameStarted: true });
     const { getByTestId } = await renderPage();
     expect(getByTestId('badge-MIA-spread')).toHaveAttribute('data-tone', 'error');
+  });
+
+  // frizat: reported live bug (CFB Scores page, UTEP @ OU final 0-51) — the away team backdoor
+  // covered its own teased spread but showed a loss icon anyway. This league's juice is applied
+  // independently to each team's spread (SpreadCalculator.GetSpread), so home/away spreads aren't
+  // mirror images once juice is nonzero — an away pick can cover its OWN line even when the home
+  // team also covers its own line. Deriving away's result as `!homeCovers` gets this backwards.
+  it('spread badge is success for an away pick that backdoor-covers its own teased spread, even though the home team also covers (asymmetric juiced spreads)', async () => {
+    // BUF (home) -7, wins 24-10: 24-7=17 > 10 → BUF covers.
+    // MIA (away) +20 (a teased line, NOT the mirror of -7), loses 10-24: 10+20=30 > 24 → MIA ALSO
+    // covers its own line. If away were derived as !homeCovers, this would wrongly show 'error'.
+    const picks = [createPick({ team: 'MIA', userName: 'OtherUser', userId: '456' })];
+    await setupDefaults({ picks, gameStarted: true });
+    mockedSpreadBatch.mockResolvedValue({
+      responses: { ...SPREAD_RESPONSES, MIA: createSpreadResponse('MIA', 20, 47.5, 47.5) },
+    });
+    const { getByTestId } = await renderPage();
+    expect(getByTestId('badge-BUF-spread')).toHaveAttribute('data-tone', 'success');
+    expect(getByTestId('badge-MIA-spread')).toHaveAttribute('data-tone', 'success');
   });
 
   it('current user picks always show info badge regardless of result', async () => {

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -34,8 +34,10 @@ function isDecided(game: GameView): boolean {
 function teamWins(game: GameView, team: string, pickType: PickType): boolean | null {
   if (!isDecided(game)) return null;
   if (pickType === 'Spread') {
-    if (game.homeCovers == null) return null;
-    return team === game.homeTeam ? game.homeCovers : !game.homeCovers;
+    // Teased spreads add juice per-team (see SpreadCalculator.GetSpread) — home/away spreads
+    // aren't mirror images, so the away side's result must come from its own computed value,
+    // never from negating homeCovers.
+    return team === game.homeTeam ? (game.homeCovers ?? null) : (game.awayCovers ?? null);
   }
   if (game.overWins == null) return null;
   return pickType === 'Over' ? game.overWins : !game.overWins;
@@ -184,10 +186,10 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
   const matrixSpreads = useMemo(() => {
     const result: Record<string, { isWinner: boolean; isOverWinner: boolean; isUnderWinner: boolean; spread: number | null; over: number | null; under: number | null }> = {};
     for (const game of (data?.games ?? [])) {
-      if (game.homeCovers == null) continue; // not final
+      if (game.homeCovers == null || game.awayCovers == null) continue; // not final
       const ov = game.overWins ?? false;
       result[game.homeTeam] = { isWinner: game.homeCovers, isOverWinner: ov, isUnderWinner: !ov, spread: game.homeSpread, over: game.overUnder, under: game.overUnder };
-      result[game.awayTeam] = { isWinner: !game.homeCovers, isOverWinner: ov, isUnderWinner: !ov, spread: game.awaySpread, over: game.overUnder, under: game.overUnder };
+      result[game.awayTeam] = { isWinner: game.awayCovers ?? false, isOverWinner: ov, isUnderWinner: !ov, spread: game.awaySpread, over: game.overUnder, under: game.overUnder };
     }
     return result;
   }, [data?.games]);
@@ -311,6 +313,7 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
                 const isFinal = isGameFinal(game.gameStatus);
                 const isLive = isGameLive(game.gameStatus);
                 const hc = game.homeCovers ?? null;
+                const ac = game.awayCovers ?? null;
                 const ov = game.overWins ?? null;
 
                 return (
@@ -354,7 +357,7 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
                               only "not decided yet"; `invisible` above still hides the pick-count bubble
                               when nobody picked, but the button itself stays colored by outcome. */}
                           <IconButton
-                            color={(isFinal || isLive) ? (hc === false ? 'success' : hc === true ? 'error' : 'inherit') : 'inherit'}
+                            color={(isFinal || isLive) ? (ac === true ? 'success' : ac === false ? 'error' : 'inherit') : 'inherit'}
                             disabled={!isFinal && !isLive}
                             onClick={() => showDialog(game, game.awayTeam, 'Spread')}
                             size="small"

--- a/Client.React/src/services/cfbAdapter.ts
+++ b/Client.React/src/services/cfbAdapter.ts
@@ -1,6 +1,6 @@
 import { getCfbCurrentSlate, getCfbSlates, getCfbSpreads, getCfbScores as getCfbDbScores, getCfbUserPicks, getCfbAllPicks, addCfbPicks, deleteCfbPicks } from '../api/cfb';
 import { getCfbScoresForSlate, getCfbLiveGames } from '../api/espn';
-import { cfbSlateNumberToWeek, cfbWeekToSlateNumber, getCfbWeekName, computeHomeCovers, computeOverWins, getCfbRequiredPicks, isGameLive } from '../utils/gameHelpers';
+import { cfbSlateNumberToWeek, cfbWeekToSlateNumber, getCfbWeekName, computeHomeCovers, computeAwayCovers, computeOverWins, getCfbRequiredPicks, isGameLive } from '../utils/gameHelpers';
 import type { CfbSlateDto, CfbSpreadDto, CfbScoreDto, CfbPickDto } from '../types/league';
 import type { EspnScores } from '../types/espn';
 import { getHomeTeamScore, getAwayTeamScore, toGameStatus, isHomeAway } from '../utils/gameHelpers';
@@ -101,6 +101,7 @@ function buildGamesFromEspn(
       gameStatus: status,
       gameTime: sp.gameTime,
       homeCovers: computeHomeCovers(status, sp.homeTeamSpread, hs, as_),
+      awayCovers: computeAwayCovers(status, sp.awayTeamSpread, hs, as_),
       overWins: computeOverWins(status, sp.overUnder, hs, as_),
       spreadPostedAt: sp.dateCreated,
       homeRank: sp.homeTeamRank,

--- a/Client.React/src/services/nflAdapter.ts
+++ b/Client.React/src/services/nflAdapter.ts
@@ -11,7 +11,7 @@ import {
   getWeekFromEspnWeek, getEspnRequiredPicks,
   isPostSeason as isPostSeasonHelper,
   isGameOver, isGameStarted, toGameStatus,
-  computeHomeCovers, computeOverWins,
+  computeHomeCovers, computeAwayCovers, computeOverWins,
 } from '../utils/gameHelpers';
 import type { SportAdapter, GameView, PickView, PickType } from './sportAdapter';
 import { revealPicksForStartedGames, memoizeOnce } from './sportAdapter';
@@ -28,6 +28,7 @@ function competitionToGameView(
   const homeScore = getHomeTeamScore(competition);
   const awayScore = getAwayTeamScore(competition);
   const homeSpreadVal = spreadCache[homeAbbr]?.spread ?? null;
+  const awaySpreadVal = spreadCache[awayAbbr]?.spread ?? null;
   const overUnderVal = spreadCache[homeAbbr]?.over ?? null;
   const status = toGameStatus(competition);
   return {
@@ -35,13 +36,14 @@ function competitionToGameView(
     homeTeam: homeAbbr,
     awayTeam: awayAbbr,
     homeSpread: homeSpreadVal,
-    awaySpread: spreadCache[awayAbbr]?.spread ?? null,
+    awaySpread: awaySpreadVal,
     overUnder: overUnderVal,
     homeScore,
     awayScore,
     gameStatus: status,
     gameTime: competition.date,
     homeCovers: computeHomeCovers(status, homeSpreadVal, homeScore, awayScore),
+    awayCovers: computeAwayCovers(status, awaySpreadVal, homeScore, awayScore),
     overWins: computeOverWins(status, overUnderVal, homeScore, awayScore),
     weather: event.weather ? {
       displayValue: event.weather.displayValue,

--- a/Client.React/src/services/sportAdapter.ts
+++ b/Client.React/src/services/sportAdapter.ts
@@ -95,6 +95,7 @@ export interface GameView {
   awayLogo?: string;
   situation?: import('../types/liveGame').GameSituation | null;
   homeCovers?: boolean | null;  // null = not final / no odds
+  awayCovers?: boolean | null;  // computed independently — NOT !homeCovers (teased spreads aren't mirror images)
   overWins?: boolean | null;
   /** When the spread was first posted (DateCreated). Undefined where the adapter's spread source
    *  doesn't carry it — NFL's spreadBatch endpoint returns computed, juice-adjusted odds rather

--- a/Client.React/src/utils/gameHelpers.ts
+++ b/Client.React/src/utils/gameHelpers.ts
@@ -253,14 +253,36 @@ export function getPickLabel(pickType: PickType) {
  * hasn't started or spread data isn't available.
  * Works for final, in-progress, and halftime.
  */
+// This league's spread is "teased" (juice added per-team, see SpreadCalculator.GetSpread on the
+// backend) — home/away spreads are NOT mirror images of each other once juice is nonzero, so one
+// side's cover can't be derived by negating the other's. Each must be computed independently from
+// its own spread, sharing this one guard/formula so they can't drift apart.
+function computeCovers(
+  status: GameStatusValue,
+  teamSpread: number | null,
+  teamScore: number | null,
+  opponentScore: number | null,
+): boolean | null {
+  if (!isGameDecided(status) || teamSpread == null || teamScore == null || opponentScore == null) return null;
+  return (teamScore + teamSpread) > opponentScore;
+}
+
 export function computeHomeCovers(
   status: GameStatusValue,
   homeSpread: number | null,
   homeScore: number | null,
   awayScore: number | null,
 ): boolean | null {
-  if (!isGameDecided(status) || homeSpread == null || homeScore == null || awayScore == null) return null;
-  return (homeScore + homeSpread) > awayScore;
+  return computeCovers(status, homeSpread, homeScore, awayScore);
+}
+
+export function computeAwayCovers(
+  status: GameStatusValue,
+  awaySpread: number | null,
+  homeScore: number | null,
+  awayScore: number | null,
+): boolean | null {
+  return computeCovers(status, awaySpread, awayScore, homeScore);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Reported live bug: on the CFB Scores page, an away team that "backdoor covered" its own teased spread (lost the game outright, but by less than its spread) showed a red loss icon instead of green.
- Root cause: this league's spread is teased/juiced independently per team (`SpreadCalculator.GetSpread`, backend), so home and away spreads are **not** mirror images of each other once juice is nonzero (e.g. a real example from the report: home -27.5 / away +53.5 — these don't sum to zero). `ScoresPage.tsx` derived the away team's result as `!homeCovers` in three places, which is only correct when the two spreads are exact opposites.
- Backend pick grading (`SpreadCalculator.DidUserWinSpread`, used by `LeaderboardService`) already computes each side independently per-team and was never affected — this was purely a frontend display bug on the Scores page.
- Fix: added a shared `computeCovers` helper in `gameHelpers.ts` with `computeHomeCovers`/`computeAwayCovers` wrappers (mirrors the backend's own generic `DidUserWinSpread` shape), threaded a new `awayCovers` field through `GameView` in both the NFL and CFB adapters, and replaced all three `!homeCovers`/`!hc` call sites in `ScoresPage.tsx`.

## Test plan
- [x] New unit tests in `gameHelpers.covers.test.ts` reproducing the exact reported matchup (home -27.5, away +53.5, final 51-0) and asserting both sides can independently cover
- [x] New component regression test in `scores.test.tsx` with asymmetric juiced spreads, asserting the away badge shows `success` even though it lost outright
- [x] Full frontend suite: 578/578 passing; `dotnet test`: 849/849 passing (backend untouched, confirms no regression)
- [x] `npm run typecheck`, `npm run lint` clean
- [x] Mock e2e suite (`--project=chromium`): 94/95 passing — the 1 failure is the pre-existing documented `leaderboard.spec.ts` season-selector flake (confirmed via isolated re-run, unrelated to this change)
- [x] `/simplify` (4 parallel agents) + `/code-review` run; findings applied (collapsed the two cover functions into one shared helper; hardened the `matrixSpreads` null guard to check both `homeCovers`/`awayCovers`)
- [x] Manually verified live in a real browser: an away team that backdoor-covers now renders its pick icon green instead of red
- [x] `CHANGELOG.md` entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)