### PR TITLE
Fix field position ball marker: yardLine is home-relative, not possessor-relative

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -6,6 +6,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 
 ## 2026-09-06
 
+- Fixed: the live field position ball marker was still on the wrong side whenever the away team had the ball (a follow-up correction to the same-day fix below) — the field-position yard line is a fixed coordinate measured from the home team's own goal regardless of possession, not from whichever team currently has the ball
 - Fixed: live field position ball marker rendered on the wrong side of the field whenever the home team had possession, since the home team's own goal is on the right of the on-screen bar but the marker position was never mirrored for it
 
 ## 2026-09-05

--- a/Client.React/src/__tests__/FieldPosition.test.tsx
+++ b/Client.React/src/__tests__/FieldPosition.test.tsx
@@ -48,18 +48,38 @@ describe('FieldPosition', () => {
     expect(screen.getByTestId('field-position-bar')).toHaveAttribute('data-redzone', 'false');
   });
 
-  it('positions the ball marker at the correct percentage for away possession', () => {
-    // Away team is drawn on the left, so their own-goal-relative yardLine maps straight through.
-    render(<FieldPosition situation={buildSituation({ yardLine: 75, isHomePossession: false })} />);
-    const marker = screen.getByTestId('ball-marker');
-    expect(marker).toHaveStyle({ left: '75%' });
-  });
-
-  it('mirrors the ball marker position for home possession', () => {
+  it('positions the ball marker at 100 - yardLine regardless of home possession', () => {
     // Home team is drawn on the right, so their own goal is the right end zone: a yardLine of 9
     // (9 yards from the home team's own goal) must render near the right edge (91%), not the left.
     render(<FieldPosition situation={buildSituation({ yardLine: 9, isHomePossession: true })} />);
     const marker = screen.getByTestId('ball-marker');
     expect(marker).toHaveStyle({ left: '91%' });
+  });
+
+  it('positions the ball marker at 100 - yardLine regardless of away possession', () => {
+    // Confirmed against a live game: away team (Clemson) with the ball at their own 33 was sent
+    // to the frontend as yardLine=67 (distance from the HOME team's goal, not the possessor's) —
+    // the previous "away possession maps yardLine straight through" test asserted the bug's own
+    // behavior as correct. yardLine is a fixed home-relative coordinate; possession never changes
+    // the position formula, only the arrow direction.
+    render(<FieldPosition situation={buildSituation({ yardLine: 67, isHomePossession: false })} />);
+    const marker = screen.getByTestId('ball-marker');
+    expect(marker).toHaveStyle({ left: '33%' });
+  });
+
+  it('matches real captured ESPN wire data: away team driving into home territory', () => {
+    // sample_espn_nfl.json (real Super Bowl LX payload, repo root): NE is home, SEA is away and
+    // holds possession ("possession": "26" = SEA's team id), yet downDistanceText names NE ("2nd
+    // & 7 at NE 35") because SEA has driven into NE's territory. yardLine=35 only makes sense as
+    // "35 yards from NE's (home's) own goal" — proving yardLine is home-relative regardless of
+    // who has the ball, not offense-relative. Correct position: 100 - 35 = 65% (near home's side,
+    // where NE's goal is under threat).
+    render(<FieldPosition situation={buildSituation({
+      yardLine: 35,
+      isHomePossession: false,
+      downDistanceText: '2nd & 7 at NE 35',
+    })} />);
+    const marker = screen.getByTestId('ball-marker');
+    expect(marker).toHaveStyle({ left: '65%' });
   });
 });

--- a/Client.React/src/components/FieldPosition.tsx
+++ b/Client.React/src/components/FieldPosition.tsx
@@ -13,10 +13,12 @@ export default function FieldPosition({ situation }: FieldPositionProps) {
 
   const { yardLine, isHomePossession, isRedZone, downDistanceText } = situation;
   const fieldColor = isRedZone ? 'error.dark' : 'success.dark';
-  // yardLine is measured from the possessing team's own goal. The away team is always drawn on
-  // the left and the home team on the right, so a home possession's own goal is on the right —
-  // mirror the position, or the ball renders on the opposite side of the field from reality.
-  const ballPositionPercent = isHomePossession ? 100 - yardLine : yardLine;
+  // yardLine is a fixed coordinate measured from the HOME team's own goal, regardless of which
+  // team currently has the ball (confirmed against a live game: away team with the ball at their
+  // own 33 rendered as yardLine=67, i.e. 100 minus their distance from the home team's goal). The
+  // home team is always drawn on the right in this layout, so this conversion is unconditional —
+  // isHomePossession only decides the arrow's direction, never the position.
+  const ballPositionPercent = 100 - yardLine;
 
   return (
     <Box sx={{ mt: 1 }}>


### PR DESCRIPTION
## Summary
- Promoting #323 from `dev` to `main` — corrects the earlier same-day field-position fix (#321/#322)
- The prior fix mirrored the ball marker's position only when the home team had possession, on the unverified assumption that ESPN's `yardLine` is measured from whichever team currently has the ball
- A live game report (Clemson at their own 33, ball rendering on LSU's side instead of Clemson's) disproved that assumption
- Confirmed against real captured ESPN wire data already in this repo (`sample_espn_nfl.json`): away team SEA holds possession while `downDistanceText` reads `"2nd & 7 at NE 35"` (NE is home) with `yardLine: 35` — only consistent if `yardLine` is always measured from the home team's own goal, regardless of possession
- Fix is now unconditional: `position = 100 - yardLine`; `isHomePossession` only controls arrow direction

## Test plan
- [x] New regression test built directly from the real captured ESPN payload
- [x] Fixed the pre-existing test that had asserted the buggy behavior as correct
- [x] Full frontend suite (588 tests) + `tsc -b` clean
- [x] All CI checks green on #323 (backend 845/845, frontend, demo e2e, demo replay e2e, Docker build, secret scan) before merge to `dev`
- [x] Changelog entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qk5GqcVeR7gaR14CairEd

---
_Generated by [Claude Code](https://claude.ai/code/session_013Qk5GqcVeR7gaR14CairEd)_