### PR TITLE
Remove dead Manage Account button that navigated to its own page

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -6,6 +6,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 
 ## 2026-09-06
 
+- Removed: the dead "Manage Account" button on the Manage Account page — it just navigated to the page you were already on and did nothing
 - Fixed: the live field position ball marker was still on the wrong side whenever the away team had the ball (a follow-up correction to the same-day fix below) — the field-position yard line is a fixed coordinate measured from the home team's own goal regardless of possession, not from whichever team currently has the ball
 - Fixed: live field position ball marker rendered on the wrong side of the field whenever the home team had possession, since the home team's own goal is on the right of the on-screen bar but the marker position was never mirrored for it
 

--- a/Client.React/src/pages/account/ManageAccountPage.tsx
+++ b/Client.React/src/pages/account/ManageAccountPage.tsx
@@ -44,9 +44,6 @@ export default function ManageAccountPage() {
           <Button variant="contained" onClick={() => navigate('/account/manage/changeusername')}>
             Change Username
           </Button>
-          <Button variant="outlined" onClick={() => navigate('/account/manage')}>
-            Manage Account
-          </Button>
         </Stack>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- Removes the "Manage Account" button on the Manage Account page (`ManageAccountPage.tsx`), which called `navigate('/account/manage')` — the exact route the page is already rendered at, so clicking it did nothing
- Reported by a user who reached the page (via the account menu, itself labeled with the user's own username rather than "Manage Account" — a separate, known UX confusion) and found the third button non-functional
- No other button or test referenced it; `Change Password` and `Change Username` are unaffected

## Test plan
- [x] Existing `ManageAccountPage.test.tsx` suite (4 tests) still passes — none referenced the removed button
- [x] Full frontend suite: 588 tests passing, `tsc -b` clean
- [x] Changelog entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qk5GqcVeR7gaR14CairEd

---
_Generated by [Claude Code](https://claude.ai/code/session_013Qk5GqcVeR7gaR14CairEd)_