### PR TITLE
Add precise red zone field stripe and card outline highlight

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -6,6 +6,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 
 ## 2026-09-06
 
+- Added: live field position now highlights only the actual 20-yard red zone (near whichever goal the ball is closest to) instead of tinting the entire field, and the game card gets a red outline while a live game is in the red zone, so it's spottable at a glance across a list of games
 - Removed: the dead "Manage Account" button on the Manage Account page — it just navigated to the page you were already on and did nothing
 - Fixed: the live field position ball marker was still on the wrong side whenever the away team had the ball (a follow-up correction to the same-day fix below) — the field-position yard line is a fixed coordinate measured from the home team's own goal regardless of possession, not from whichever team currently has the ball
 - Fixed: live field position ball marker rendered on the wrong side of the field whenever the home team had possession, since the home team's own goal is on the right of the on-screen bar but the marker position was never mirrored for it

--- a/Client.React/src/__tests__/FieldPosition.test.tsx
+++ b/Client.React/src/__tests__/FieldPosition.test.tsx
@@ -48,6 +48,29 @@ describe('FieldPosition', () => {
     expect(screen.getByTestId('field-position-bar')).toHaveAttribute('data-redzone', 'false');
   });
 
+  it('renders the red zone stripe near the home goal when yardLine is 20 or less', () => {
+    render(<FieldPosition situation={buildSituation({ isRedZone: true, yardLine: 12 })} />);
+    const stripe = screen.getByTestId('red-zone-stripe');
+    expect(stripe).toHaveStyle({ left: '80%', width: '20%' });
+  });
+
+  it('renders the red zone stripe near the away goal when yardLine is 80 or more', () => {
+    render(<FieldPosition situation={buildSituation({ isRedZone: true, yardLine: 88 })} />);
+    const stripe = screen.getByTestId('red-zone-stripe');
+    expect(stripe).toHaveStyle({ left: '0%', width: '20%' });
+  });
+
+  it('does not render a red zone stripe when isRedZone is false', () => {
+    render(<FieldPosition situation={buildSituation({ isRedZone: false, yardLine: 12 })} />);
+    expect(screen.queryByTestId('red-zone-stripe')).toBeNull();
+  });
+
+  it('does not render a red zone stripe when isRedZone is true but yardLine is outside either zone', () => {
+    // Defensive: don't guess a side if upstream data is inconsistent (isRedZone true at midfield).
+    render(<FieldPosition situation={buildSituation({ isRedZone: true, yardLine: 50 })} />);
+    expect(screen.queryByTestId('red-zone-stripe')).toBeNull();
+  });
+
   it('positions the ball marker at 100 - yardLine regardless of home possession', () => {
     // Home team is drawn on the right, so their own goal is the right end zone: a yardLine of 9
     // (9 yards from the home team's own goal) must render near the right edge (91%), not the left.

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -584,4 +584,52 @@ describe('ScoresPage', () => {
     await waitFor(() => expect(screen.getByText(/Please select a league/i)).toBeInTheDocument());
     expect(document.querySelectorAll('.MuiSkeleton-root').length).toBe(0);
   });
+
+  describe('red zone card highlight', () => {
+    const setupLiveGame = async (isRedZone: boolean) => {
+      const liveComp = createCompetition({
+        homeTeam: 'BUF', awayTeam: 'MIA', homeScore: 24, awayScore: 10,
+        liveStatus: { name: 'status_in_progress', period: 2, displayClock: '5:00' },
+      });
+      mockedGetNflCurrentWeek.mockResolvedValue(createCurrentWeek(2));
+      mockedGetWeekScores.mockResolvedValue(createScores({
+        week: 2, postSeason: false,
+        events: [{ id: '1', season: { year: 2024, type: 2 }, week: { number: 2 }, date: new Date().toISOString(), competitions: [liveComp] }],
+      }));
+      mockedGetLiveGames.mockResolvedValue([{
+        homeTeam: 'BUF', awayTeam: 'MIA', homeScore: 24, awayScore: 10,
+        isCompleted: false, kickoffUtc: new Date().toISOString(),
+        situation: {
+          possessionTeam: 'BUF', isHomePossession: true, yardLine: 12, down: 1, distance: 10,
+          isRedZone, downDistanceText: '1st & 10 at BUF 12',
+        },
+      }]);
+      mockedDoOddsExist.mockResolvedValue(true);
+      mockedGetLeaguePicks.mockResolvedValue([]);
+      mockedSpreadBatch.mockResolvedValue({ responses: SPREAD_RESPONSES });
+      await renderPage();
+      await waitFor(() => expect(screen.getAllByText(/BUF/i).length).toBeGreaterThan(0));
+    };
+
+    it('outlines the game card in red when the live game is in the red zone', async () => {
+      await setupLiveGame(true);
+      const card = screen.getByTestId('game-card-BUFvsMIA');
+      expect(card).toHaveAttribute('data-redzone', 'true');
+    });
+
+    it('does not outline the game card when the live game is not in the red zone', async () => {
+      await setupLiveGame(false);
+      const card = screen.getByTestId('game-card-BUFvsMIA');
+      expect(card).toHaveAttribute('data-redzone', 'false');
+    });
+
+    it('does not outline a non-live game even if stale situation data says red zone', async () => {
+      // Final/scheduled games never show a red-zone outline — mirrors the existing isLive guard
+      // already used for rendering FieldPosition itself.
+      await setupDefaults();
+      await renderPage();
+      const card = screen.getByTestId('game-card-BUFvsMIA');
+      expect(card).toHaveAttribute('data-redzone', 'false');
+    });
+  });
 });

--- a/Client.React/src/components/FieldPosition.tsx
+++ b/Client.React/src/components/FieldPosition.tsx
@@ -12,13 +12,18 @@ export default function FieldPosition({ situation }: FieldPositionProps) {
   if (!situation) return <Box sx={{ mt: 1, height: 24 + 4 + 20, mx: 1 }} />;
 
   const { yardLine, isHomePossession, isRedZone, downDistanceText } = situation;
-  const fieldColor = isRedZone ? 'error.dark' : 'success.dark';
   // yardLine is a fixed coordinate measured from the HOME team's own goal, regardless of which
   // team currently has the ball (confirmed against a live game: away team with the ball at their
   // own 33 rendered as yardLine=67, i.e. 100 minus their distance from the home team's goal). The
   // home team is always drawn on the right in this layout, so this conversion is unconditional —
   // isHomePossession only decides the arrow's direction, never the position.
   const ballPositionPercent = 100 - yardLine;
+  // The actual red zone is the 20 yards nearest whichever goal the ball is closest to — not the
+  // whole field. yardLine<=20 is near the home goal (right side, local% 80-100); yardLine>=80 is
+  // near the away goal (left side, local% 0-20). These are mutually exclusive by construction. If
+  // isRedZone is true but yardLine falls in neither range (inconsistent upstream data), show no
+  // stripe rather than guessing a side.
+  const redZoneStripeLeft = yardLine <= 20 ? 80 : yardLine >= 80 ? 0 : null;
 
   return (
     <Box sx={{ mt: 1 }}>
@@ -31,7 +36,21 @@ export default function FieldPosition({ situation }: FieldPositionProps) {
         <Box sx={{ width: '8%', bgcolor: 'success.main', flexShrink: 0 }} />
 
         {/* Playing field */}
-        <Box sx={{ flex: 1, position: 'relative', bgcolor: fieldColor }}>
+        <Box sx={{ flex: 1, position: 'relative', bgcolor: 'success.dark' }}>
+          {/* Red zone stripe — behind the yard markers/ball marker so it doesn't obscure them */}
+          {isRedZone && redZoneStripeLeft !== null && (
+            <Box
+              data-testid="red-zone-stripe"
+              sx={{
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                left: `${redZoneStripeLeft}%`,
+                width: '20%',
+                bgcolor: 'error.dark',
+              }}
+            />
+          )}
           {/* Yard markers */}
           {YARD_MARKERS.map(yard => (
             <Box

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -318,10 +318,15 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
                 const ac = game.awayCovers ?? null;
                 const ov = game.overWins ?? null;
                 const uv = game.underWins ?? null;
+                const isCardRedZone = isLive && Boolean(game.situation?.isRedZone);
 
                 return (
                   <Grid size={{ xs: 12, md: 6, lg: 4 }} key={game.id}>
-                    <Paper className={''} sx={{ p: 2 }}>
+                    <Paper
+                      data-testid={`game-card-${game.id}`}
+                      data-redzone={String(isCardRedZone)}
+                      sx={[{ p: 2 }, isCardRedZone && { outline: '3px solid', outlineColor: 'error.main', outlineOffset: -1 }]}
+                    >
                       {/* Score header */}
                       <Stack direction="row" alignItems="center" justifyContent="space-between">
                         <TeamHelmet abbr={game.awayTeam} size={50} />
@@ -333,7 +338,7 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
                         <TeamHelmet abbr={game.homeTeam} size={50} />
                       </Stack>
 
-                      {/* Field position (NFL only — situation is a full GameSituation object) */}
+                      {/* Field position — shared by both NFL and CFB adapters, which populate GameSituation identically */}
                       {isLive && game.situation != null && (
                         <FieldPosition situation={game.situation} />
                       )}


### PR DESCRIPTION
## Summary
- Promoting #327 from `dev` to `main`
- Replaces the old whole-field-flips-red-when-in-red-zone treatment with two composable pieces:
  1. **Precise 20-yard stripe**: `FieldPosition` now highlights only the actual 20 yards nearest whichever goal the ball is closest to, computed dynamically off `yardLine`
  2. **Card-level red outline**: `ScoresPage` adds a red `outline` to a game's card when it's live and in the red zone, for at-a-glance scanning — `outline` chosen specifically to avoid three previously-documented dark-mode Paper/Card bugs and to not affect the box model (no layout shift)
- Shared `FieldPosition`/`ScoresPage` path used identically by both NFL and CFB adapters

## Test plan
- [x] TDD: failing tests written first for both pieces, confirmed red, then implemented to green
- [x] Full frontend suite (595 tests) + `tsc -b` clean
- [x] Visually verified in both light and dark mode via a scratch harness (never committed) using the app's real theme
- [x] `/simplify` and `/code-review` run — no findings
- [x] All CI checks green on #327 (backend 845/845, frontend, demo e2e, demo replay e2e, Docker build, secret scan) before merge to `dev`
- [x] Changelog entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qk5GqcVeR7gaR14CairEd

---
_Generated by [Claude Code](https://claude.ai/code/session_013Qk5GqcVeR7gaR14CairEd)_