### PR TITLE
Fix Share button dropping the invite message when navigator.share is unavailable

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -19,7 +19,8 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 ## 2026-09-08
 
 - Added: the installed home-screen icon for each sport now shows a small NFL or CFB badge, so the two apps are distinguishable by icon alone instead of only by the label underneath
-- Fixed: a shared invite link could preview with no title, description, or image at all in apps like iOS Messages that build their own link preview instead of using the share sheet's message — the site now has a real preview by default
+- Fixed: sharing a league invite link on a browser without native share support (e.g. most desktop browsers) silently copied just the bare url to the clipboard, dropping the inviting message entirely
+- Added: shared links now have a real title, description, and image for link previews in apps that build their own instead of using the share sheet's message
 
 ## 2026-09-06
 

--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -19,6 +19,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 ## 2026-09-08
 
 - Added: the installed home-screen icon for each sport now shows a small NFL or CFB badge, so the two apps are distinguishable by icon alone instead of only by the label underneath
+- Fixed: a shared invite link could preview with no title, description, or image at all in apps like iOS Messages that build their own link preview instead of using the share sheet's message — the site now has a real preview by default
 
 ## 2026-09-06
 

--- a/Client.React/index.html
+++ b/Client.React/index.html
@@ -47,13 +47,15 @@
 
 
     <title>IV League</title>
-    <!-- Static site-level preview for any shared link (invite links included). Several native
-         share targets — iOS Messages chief among them — ignore navigator.share()'s `text` field
-         whenever a `url` is also present, and instead fetch the page and build their own preview
-         from these tags; with none defined that preview came back with no title/description/image
-         at all. This can't carry a per-league name into the preview (that needs server-rendering
-         the /join/:token route, which this doesn't attempt) but ensures every shared link previews
-         as IV League instead of blank. -->
+    <!-- Static site-level preview for any shared link (invite links included). Some share targets
+         (Slack, WhatsApp link cards, etc.) fetch the page and build their own rich preview from
+         these tags independently of whatever text navigator.share() carried; with none defined
+         that preview came back with no title/description/image at all. This can't carry a
+         per-league name into the preview (that needs server-rendering the /join/:token route,
+         which this doesn't attempt) but ensures every shared link previews as IV League instead
+         of blank. See useShareLink.ts for the actual root cause of "share produced no message at
+         all" — the clipboard fallback used when navigator.share isn't available was dropping the
+         text message entirely, independent of these tags. -->
     <meta name="description" content="IV League is what fantasy football should have been — no draft, no waiver wire, no dead lineups. Pick NFL or college football games against the spread each week and watch the leaderboard." />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="IV League" />

--- a/Client.React/index.html
+++ b/Client.React/index.html
@@ -47,6 +47,23 @@
 
 
     <title>IV League</title>
+    <!-- Static site-level preview for any shared link (invite links included). Several native
+         share targets — iOS Messages chief among them — ignore navigator.share()'s `text` field
+         whenever a `url` is also present, and instead fetch the page and build their own preview
+         from these tags; with none defined that preview came back with no title/description/image
+         at all. This can't carry a per-league name into the preview (that needs server-rendering
+         the /join/:token route, which this doesn't attempt) but ensures every shared link previews
+         as IV League instead of blank. -->
+    <meta name="description" content="IV League is what fantasy football should have been — no draft, no waiver wire, no dead lineups. Pick NFL or college football games against the spread each week and watch the leaderboard." />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="IV League" />
+    <meta property="og:title" content="IV League — Skip the Draft. Make Picks. Beat Your Friends." />
+    <meta property="og:description" content="Pick games against the spread every week. All picks must hit to win — winners collect the pot from losers." />
+    <meta property="og:image" content="/icon-512.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="IV League — Skip the Draft. Make Picks. Beat Your Friends." />
+    <meta name="twitter:description" content="Pick games against the spread every week. All picks must hit to win — winners collect the pot from losers." />
+    <meta name="twitter:image" content="/icon-512.png" />
     <link rel="stylesheet" href="/Icons/Weather/css/weather-icons.min.css" />
     <link rel="stylesheet" href="https://unpkg.com/flipdown/dist/flipdown.css" />
   </head>

--- a/Client.React/src/__tests__/useShareLink.test.tsx
+++ b/Client.React/src/__tests__/useShareLink.test.tsx
@@ -88,4 +88,16 @@ describe('useShareLink', () => {
     await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith('https://ivleague.com/scores'));
     expect(toastPush).toHaveBeenCalledWith('Link copied', 'info');
   });
+
+  it('share() falls back to copying the text message alongside the url when navigator.share is unavailable', async () => {
+    Object.defineProperty(navigator, 'share', { value: undefined, configurable: true });
+
+    const { result } = renderHook(() => useShareLink());
+    result.current.share('Join my league', 'https://ivleague.com/join/abc', "You're invited to join OG FourPlayaz.");
+
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "You're invited to join OG FourPlayaz. https://ivleague.com/join/abc"
+    ));
+    expect(toastPush).toHaveBeenCalledWith('Link copied', 'info');
+  });
 });

--- a/Client.React/src/utils/useShareLink.ts
+++ b/Client.React/src/utils/useShareLink.ts
@@ -21,7 +21,10 @@ export function useShareLink() {
     if (typeof navigator.share === 'function') {
       shareViaNavigator(text ? { title, text, url } : { title, url });
     } else {
-      void copy(url);
+      // Without navigator.share, the only thing we can hand the user is the clipboard — so the
+      // message has to travel with the url here, or it's lost entirely (this was the actual bug:
+      // a browser/context lacking Web Share support silently copied the bare url with no message).
+      void copy(text ? `${text} ${url}` : url);
     }
   };
 


### PR DESCRIPTION
## Summary
- **Real bug fixed**: `useShareLink.ts`'s clipboard fallback (used whenever `navigator.share` isn't available, e.g. most desktop browsers) copied only the bare invite url, silently discarding the inviting message entirely — reported live against production, reproduced with a TDD regression test, then fixed so the fallback copies the message and link together.
- An earlier commit in the source PR mistakenly attributed the symptom to iOS Messages dropping `navigator.share()`'s `text` field. Research (Apple Developer Forums, corroborated independently) showed the opposite is true — iOS Messages drops `title` but keeps `text`+`url`. That commit's message, the PR description, and the CHANGELOG/code comments were corrected in the follow-up commit before merge.
- Also kept as a separate, valid improvement: static Open Graph/Twitter Card `<meta>` tags in `Client.React/index.html` (existing brand copy from `HomePage.tsx`), for share targets that build their own link-preview card from page metadata rather than the share sheet's message.

## Test plan
- [x] `npm run typecheck` — clean
- [x] Targeted Vitest run (`useShareLink.test.tsx`, `nativeShare.test.ts`, `LeaguePortalPage.test.tsx`, `changelogFormat.test.ts`) — all pass, including the new regression test proving the clipboard fallback preserves the message
- [x] `npm run build` — verified `dist/index.html` renders the new meta tags correctly
- [x] Full CI (Backend/Frontend build & test, Docker build, Secret scan, Demo backend e2e, Demo replay e2e) — all green
- [x] `Client.React/CHANGELOG.md` entries added under `## 2026-09-08`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qk5GqcVeR7gaR14CairEd

---
_Generated by [Claude Code](https://claude.ai/code/session_013Qk5GqcVeR7gaR14CairEd)_