### PR TITLE
Fix CFB Picks nav cap + leaderboard treating an unopened week as a terminal loss

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -25,6 +25,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 - Added: shared links now have a real title, description, and image for link previews in apps that build their own instead of using the share sheet's message
 - Fixed: the Picks and Scores pages let you navigate past the current week into weeks that hadn't opened yet, including showing clickable pick buttons for a week with no released spread — navigation is now capped at the real current week, and picks for any other week are rejected server-side
 - Fixed: clicking "My Picks" or "Scores" while already on that page didn't return you to the current week if you'd navigated away — it now always does
+- Fixed: on CFB, the Picks page still let you navigate past the current week all the way to the end of the season — the fix above only covered NFL; Picks now caps at the current week on both sports the same way Scores already did
 
 ## 2026-09-06
 

--- a/Client.React/src/__tests__/cfbAdapter.test.ts
+++ b/Client.React/src/__tests__/cfbAdapter.test.ts
@@ -165,6 +165,26 @@ describe('cfbAdapter', () => {
       expect(result.season).toBe(2026);
     });
 
+    // frizat-8y4: maxWeek used to be computed by scanning ALL pre-seeded RegularSeason slates
+    // for the season (CfbSlateSeederJob seeds the whole season up front, unlike NFL's NflScores
+    // rows which only exist once a game is final) — so it reflected the season's total length,
+    // not the real current week, letting Next walk all the way to the last regular-season slate
+    // regardless of which week is actually live. loadCurrentScores already got this right via
+    // maxWeek: weekState.week; loadCurrentGames must match it.
+    it('caps maxWeek at the real current week, not the season-wide last pre-seeded slate', async () => {
+      const futureSlates: CfbSlateDto[] = [9, 10, 11, 12, 13].map(slateNumber => ({
+        id: slateNumber, season: 2026, slateNumber, label: `Week ${slateNumber}`,
+        slateType: 'RegularSeason', startDate: '2026-11-01', endDate: '2026-11-07',
+      }));
+      vi.mocked(getCfbSlates).mockResolvedValue([slate, ...futureSlates]); // current slateNumber=8
+      vi.mocked(getCfbSpreads).mockResolvedValue([]);
+      vi.mocked(getCfbScoresForSlate).mockResolvedValue(null);
+      vi.mocked(getCfbUserPicks).mockResolvedValue([]);
+
+      const result = await adapter.loadCurrentGames(1, 'user1');
+      expect(result.maxWeek).toBe(8);
+    });
+
     it('game shows scheduled when ESPN has no matching event', async () => {
       vi.mocked(getCfbSlates).mockResolvedValue([slate]);
       vi.mocked(getCfbSpreads).mockResolvedValue([spread]);
@@ -209,6 +229,17 @@ describe('cfbAdapter', () => {
       const fn = adapter.weekSelectorConfig.weekLabelFn!;
       expect(fn(5, true)).toBe('CFP Championship');
       expect(() => fn(5, true)).not.toThrow();
+    });
+
+    // frizat-8y4: WeekYearSelector prioritizes a non-empty regularWeekOptions unconditionally
+    // over the dynamic maxRegularSeasonWeek prop PicksPage/ScoresPage pass in per-load — a
+    // static full-season regularWeekOptions here silently made maxWeek/maxRegularSeasonWeek
+    // inert for capping regular-season navigation, so Next stayed clickable through the whole
+    // season regardless of which week was actually current. Must stay unset so
+    // WeekYearSelector's dynamic fallback (built from maxRegularSeasonWeek) governs instead —
+    // the same mechanism nflAdapter.ts (which never sets this either) already relies on.
+    it('does not set a static regularWeekOptions, so the dynamic maxWeek/maxRegularSeasonWeek prop actually caps navigation', () => {
+      expect(adapter.weekSelectorConfig.regularWeekOptions).toBeUndefined();
     });
   });
 });

--- a/Client.React/src/__tests__/cfbAdapter.test.ts
+++ b/Client.React/src/__tests__/cfbAdapter.test.ts
@@ -19,7 +19,7 @@ vi.mock('../api/espn', () => ({
   getCfbLiveGames: vi.fn(),
 }));
 
-import { getCfbCurrentSlate, getCfbSlates, getCfbSpreads, getCfbScores, getCfbUserPicks, addCfbPicks } from '../api/cfb';
+import { getCfbCurrentSlate, getCfbSlates, getCfbSpreads, getCfbScores, getCfbUserPicks, getCfbAllPicks, addCfbPicks } from '../api/cfb';
 import { getCfbScoresForSlate, getCfbLiveGames } from '../api/espn';
 
 const slate: CfbSlateDto = {
@@ -185,6 +185,32 @@ describe('cfbAdapter', () => {
       expect(result.maxWeek).toBe(8);
     });
 
+    // frizat-8y7: caught by CI right after the frizat-8y4 fix landed — maxWeek: weekState.week
+    // doesn't distinguish regular season from postseason. When the current slate IS postseason
+    // (e.g. CFP Championship, slateNumber 18 -> postseason week 5), that small postseason week
+    // number leaked in as the REGULAR SEASON cap instead of the real regular-season length (13)
+    // — collapsing the regular-season selector down to 5 options instead of all 13 the moment
+    // navigation was no longer hidden behind the old static regularWeekOptions override.
+    it('caps maxWeek at the full regular-season length when the current slate is postseason', async () => {
+      // Fresh adapter — createCfbAdapter() wraps getCfbCurrentSlate in memoizeOnce, and the
+      // module-level `adapter` shared by every other test in this file has already cached its
+      // own (regular-season) "current slate" by the time this test runs.
+      const freshAdapter = createCfbAdapter();
+      const postseasonSlate: CfbSlateDto = {
+        id: 18, season: 2026, slateNumber: 18, label: 'CFP Championship',
+        slateType: 'Postseason', startDate: '2027-01-01', endDate: '2027-01-07',
+      };
+      vi.mocked(getCfbCurrentSlate).mockResolvedValue(postseasonSlate);
+      vi.mocked(getCfbSlates).mockResolvedValue([postseasonSlate]);
+      vi.mocked(getCfbSpreads).mockResolvedValue([]);
+      vi.mocked(getCfbScoresForSlate).mockResolvedValue(null);
+      vi.mocked(getCfbUserPicks).mockResolvedValue([]);
+
+      const result = await freshAdapter.loadCurrentGames(1, 'user1');
+      expect(result.isPostSeason).toBe(true);
+      expect(result.maxWeek).toBe(13);
+    });
+
     it('game shows scheduled when ESPN has no matching event', async () => {
       vi.mocked(getCfbSlates).mockResolvedValue([slate]);
       vi.mocked(getCfbSpreads).mockResolvedValue([spread]);
@@ -194,6 +220,29 @@ describe('cfbAdapter', () => {
       const result = await adapter.loadCurrentGames(1, 'user1');
       expect(result.games[0].gameStatus).toBe('scheduled');
       expect(result.games[0].homeScore).toBeNull();
+    });
+  });
+
+  describe('loadCurrentScores', () => {
+    // frizat-8y7: same bug as loadCurrentGames — maxWeek: weekState.week doesn't distinguish
+    // regular season from postseason, so a postseason current slate (e.g. CFP Championship)
+    // leaked its small postseason week number in as the regular-season cap.
+    it('caps maxWeek at the full regular-season length when the current slate is postseason', async () => {
+      // Fresh adapter — see the identical note in the loadCurrentGames test above.
+      const freshAdapter = createCfbAdapter();
+      const postseasonSlate: CfbSlateDto = {
+        id: 18, season: 2026, slateNumber: 18, label: 'CFP Championship',
+        slateType: 'Postseason', startDate: '2027-01-01', endDate: '2027-01-07',
+      };
+      vi.mocked(getCfbCurrentSlate).mockResolvedValue(postseasonSlate);
+      vi.mocked(getCfbSpreads).mockResolvedValue([]);
+      vi.mocked(getCfbScoresForSlate).mockResolvedValue(null);
+      vi.mocked(getCfbAllPicks).mockResolvedValue([]);
+      vi.mocked(getCfbUserPicks).mockResolvedValue([]);
+
+      const result = await freshAdapter.loadCurrentScores(1, 'user1');
+      expect(result.isPostSeason).toBe(true);
+      expect(result.maxWeek).toBe(13);
     });
   });
 

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -510,17 +510,20 @@ describe('ScoresPage', () => {
   it('keys the scores query by adapter.sport, so NFL and CFB never share a cache entry', async () => {
     await setupDefaults();
     const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: Infinity } } });
-    const { rerender } = renderWithClient(<ScoresPage adapter={createNflAdapter()} />, client);
+    const { unmount } = renderWithClient(<ScoresPage adapter={createNflAdapter()} />, client);
     await screen.findByText(/Scores/i);
     await waitFor(() => expect(screen.queryByRole('progressbar')).toBeNull());
     expect(screen.getAllByText(/BUF/i).length).toBeGreaterThan(0);
 
-    // CFB gets its own real, resolved dataset with entirely different teams (MICH/PSU — CFB
-    // has no BUF/MIA). placeholderData: keepPreviousData legitimately shows NFL's stale BUF/MIA
-    // as a transient placeholder while CFB's own query is pending (that's the point of
-    // keepPreviousData — no spinner flash on navigation) — the real assertion for "separate
-    // cache entries" is that once CFB's OWN query settles, ITS data (MICH/PSU) is what renders,
-    // not that NFL's cache entry got clobbered or that a spinner necessarily appears.
+    // Switching sports is always a cross-domain navigation in the real app (ivleague.xyz vs.
+    // cfb.ivleague.xyz — confirmed live), which fully remounts the page; an in-place adapter
+    // swap on the same component instance (the old rerender() here) can never happen in
+    // production and masked a real bug (frizat-8y4: it relied on CFB's static regularWeekOptions
+    // never shrinking below whatever week a stale NFL snapshot happened to hold). Simulate the
+    // real remount instead, sharing one QueryClient — that's what the cache-keying assertion
+    // below actually needs.
+    unmount();
+
     const cfbSlate = { id: 1, season: 2025, slateNumber: 8, label: 'Week 8', slateType: 'RegularSeason', startDate: '2025-10-11', endDate: '2025-10-18' };
     const cfbSpread = { id: 1, cfbSlateId: 1, homeTeam: 'MICH', awayTeam: 'PSU', homeTeamSpread: -3.5, awayTeamSpread: 3.5, over: 44.5, under: 44.5, gameTime: '2025-10-11T20:00:00Z', dateCreated: '2025-10-09T14:00:00Z', homeTeamRank: null, awayTeamRank: null };
     mockedGetCfbCurrentSlate.mockResolvedValue(cfbSlate);
@@ -531,11 +534,7 @@ describe('ScoresPage', () => {
     mockedGetCfbScoresForSlate.mockResolvedValue({ leagues: [], season: { year: 2025, type: 2 }, week: { number: 8 }, events: [] });
     mockedGetCfbLiveGames.mockResolvedValue([]);
 
-    rerender(
-      <QueryClientProvider client={client}>
-        <MemoryRouter><ScoresPage adapter={createCfbAdapter()} /></MemoryRouter>
-      </QueryClientProvider>,
-    );
+    renderWithClient(<ScoresPage adapter={createCfbAdapter()} />, client);
 
     await waitFor(() => expect(screen.getAllByText(/MICH/i).length).toBeGreaterThan(0));
     expect(screen.queryByText(/BUF/i)).toBeNull();

--- a/Client.React/src/services/cfbAdapter.ts
+++ b/Client.React/src/services/cfbAdapter.ts
@@ -13,7 +13,6 @@ import { revealPicksForStartedGames, memoizeOnce } from './sportAdapter';
 const CFB_CONFIGURED_SEASON = 2026;
 // Earliest supported CFB season (controls the lower bound of the season dropdown).
 const CFB_FIRST_SEASON = 2025;
-const CFB_REGULAR_WEEKS = Array.from({ length: 13 }, (_, i) => i + 1); // weeks 1-13
 const CFB_POST_WEEKS = [1, 2, 3, 4, 5]; // Conf.Champs + CFP First Round/QF/SF/Championship
 
 function slateToWeekState(slate: CfbSlateDto): WeekState {
@@ -207,7 +206,12 @@ export function createCfbAdapter(): SportAdapter {
     // VITE_API_TARGET URL (breaks the same-origin proxy path and the SameSite=Lax auth cookie).
     sseUrl: '/api/cfb/live-stream',
     weekSelectorConfig: {
-      regularWeekOptions: CFB_REGULAR_WEEKS,
+      // No regularWeekOptions override — WeekYearSelector falls back to deriving the regular-
+      // season option list from the dynamic maxRegularSeasonWeek prop (PicksPage/ScoresPage
+      // pass the real current week via `maxWeek`), same mechanism nflAdapter.ts already relies
+      // on. A static full-season array here previously always won over that dynamic value
+      // (WeekYearSelector prioritizes a non-empty regularWeekOptions unconditionally), so Next
+      // stayed clickable through the whole season regardless of maxWeek (frizat-8y4).
       postSeasonWeekOptions: CFB_POST_WEEKS,
       maxRegularSeasonWeek: 13,
       minSeason: CFB_FIRST_SEASON,
@@ -224,16 +228,14 @@ export function createCfbAdapter(): SportAdapter {
       if (!active) {
         return { season: CFB_CONFIGURED_SEASON, week: 1, isPostSeason: false, games: [], userPicks: [], hasOdds: false, requiredPicks: 0, maxWeek: 1, maxSeason: CFB_CONFIGURED_SEASON };
       }
-      const [slates, { games, userPicks }] = await Promise.all([
-        getSlates(),
-        loadSlate(leagueId, userId, active.id, active),
-      ]);
+      const { games, userPicks } = await loadSlate(leagueId, userId, active.id, active);
       const weekState = slateToWeekState(active);
-      // maxWeek = max REGULAR season week with data (caps the regular season selector)
-      const maxRegularSlate = slates
-        .filter(s => s.slateType === 'RegularSeason')
-        .reduce((max, s) => Math.max(max, s.slateNumber), 0);
-      return { ...weekState, games, userPicks, hasOdds: games.length > 0, requiredPicks: getCfbRequiredPicks(active.slateNumber), maxWeek: maxRegularSlate || 13, maxSeason: active.season };
+      // Cap navigation at the real current week, not the season-wide last pre-seeded slate —
+      // CfbSlates is fully seeded ahead of time for the whole season (CfbSlateSeederJob), so
+      // scanning all of them for the max RegularSeason slateNumber returns the season's total
+      // length regardless of which week is actually live. Matches loadCurrentScores below,
+      // which already used weekState.week (frizat-8y4).
+      return { ...weekState, games, userPicks, hasOdds: games.length > 0, requiredPicks: getCfbRequiredPicks(active.slateNumber), maxWeek: weekState.week, maxSeason: active.season };
     },
 
     async loadHistoricalGames(leagueId, userId, { season, week, isPostSeason }) {

--- a/Client.React/src/services/cfbAdapter.ts
+++ b/Client.React/src/services/cfbAdapter.ts
@@ -14,6 +14,15 @@ const CFB_CONFIGURED_SEASON = 2026;
 // Earliest supported CFB season (controls the lower bound of the season dropdown).
 const CFB_FIRST_SEASON = 2025;
 const CFB_POST_WEEKS = [1, 2, 3, 4, 5]; // Conf.Champs + CFP First Round/QF/SF/Championship
+// Regular season = slates 1-13 (cfbSlateNumberToWeek's own cutoff) — the correct maxWeek to
+// report once the season has moved into postseason, when weekState.week is a small postseason
+// week number instead (frizat-8y7: that number was briefly leaking in as the regular-season cap
+// the moment CFB's navigation stopped being capped by a separate static option list).
+const CFB_REGULAR_SEASON_LENGTH = 13;
+
+function maxWeekFor(weekState: WeekState): number {
+  return weekState.isPostSeason ? CFB_REGULAR_SEASON_LENGTH : weekState.week;
+}
 
 function slateToWeekState(slate: CfbSlateDto): WeekState {
   const { week, isPostSeason } = cfbSlateNumberToWeek(slate.slateNumber);
@@ -213,7 +222,7 @@ export function createCfbAdapter(): SportAdapter {
       // (WeekYearSelector prioritizes a non-empty regularWeekOptions unconditionally), so Next
       // stayed clickable through the whole season regardless of maxWeek (frizat-8y4).
       postSeasonWeekOptions: CFB_POST_WEEKS,
-      maxRegularSeasonWeek: 13,
+      maxRegularSeasonWeek: CFB_REGULAR_SEASON_LENGTH,
       minSeason: CFB_FIRST_SEASON,
       weekLabelFn: getCfbWeekName,
     },
@@ -230,12 +239,12 @@ export function createCfbAdapter(): SportAdapter {
       }
       const { games, userPicks } = await loadSlate(leagueId, userId, active.id, active);
       const weekState = slateToWeekState(active);
-      // Cap navigation at the real current week, not the season-wide last pre-seeded slate —
+      // Cap navigation at the real current week (or the full regular-season length once
+      // postseason is active — see maxWeekFor), not the season-wide last pre-seeded slate.
       // CfbSlates is fully seeded ahead of time for the whole season (CfbSlateSeederJob), so
       // scanning all of them for the max RegularSeason slateNumber returns the season's total
-      // length regardless of which week is actually live. Matches loadCurrentScores below,
-      // which already used weekState.week (frizat-8y4).
-      return { ...weekState, games, userPicks, hasOdds: games.length > 0, requiredPicks: getCfbRequiredPicks(active.slateNumber), maxWeek: weekState.week, maxSeason: active.season };
+      // length regardless of which week is actually live (frizat-8y4/frizat-8y7).
+      return { ...weekState, games, userPicks, hasOdds: games.length > 0, requiredPicks: getCfbRequiredPicks(active.slateNumber), maxWeek: maxWeekFor(weekState), maxSeason: active.season };
     },
 
     async loadHistoricalGames(leagueId, userId, { season, week, isPostSeason }) {
@@ -283,7 +292,7 @@ export function createCfbAdapter(): SportAdapter {
       const weekState = slateToWeekState(active);
       const { games, allPicks, userPicks } = await loadScoresForSlate(leagueId, userId, active);
       const hasActiveGames = games.some(g => isGameLive(g.gameStatus));
-      return { ...weekState, games, allPicks, userPicks, hasOdds: games.length > 0, hasActiveGames, requiredPicks: getCfbRequiredPicks(active.slateNumber), maxWeek: weekState.week, maxSeason: active.season };
+      return { ...weekState, games, allPicks, userPicks, hasOdds: games.length > 0, hasActiveGames, requiredPicks: getCfbRequiredPicks(active.slateNumber), maxWeek: maxWeekFor(weekState), maxSeason: active.season };
     },
 
     async loadHistoricalScores(leagueId, userId, { season, week, isPostSeason }) {

--- a/Server.UnitTests/GameHelpersTests.cs
+++ b/Server.UnitTests/GameHelpersTests.cs
@@ -147,6 +147,34 @@ public class GameHelpersTests
         Assert.Equal(expected, GameHelpers.GetTeamLogo(abbreviation));
     }
 
+    // ─── AllGamesStarted ────────────────────────────────────────────────────────
+    // frizat-8y6: reported live — a CFB slate with zero spreads released yet (the picking window
+    // hasn't even opened) was shown on the leaderboard as a terminal loss (MissingPicks) for
+    // every user, because LINQ's .All() on an empty sequence is vacuously true — "all games
+    // started" read as true for a week with NO games to check, the opposite of the real answer.
+    // Both LeaderboardService.CalculatePicks (NFL) and CfbLeaderboardService.EvaluateSlate (CFB)
+    // key their MissingPicks-vs-MissingGameResults decision directly off this return value.
+
+    [Fact]
+    public void AllGamesStarted_ReturnsFalse_WhenGameTimesIsEmpty() {
+        // No games exist for this week/slate at all yet — cannot conclude they've "all started".
+        Assert.False(GameHelpers.AllGamesStarted([], DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void AllGamesStarted_ReturnsTrue_WhenEveryGameTimeHasPassed() {
+        var now = DateTimeOffset.UtcNow;
+        var gameTimes = new[] { now.AddHours(-2), now.AddHours(-1) };
+        Assert.True(GameHelpers.AllGamesStarted(gameTimes, now));
+    }
+
+    [Fact]
+    public void AllGamesStarted_ReturnsFalse_WhenAnyGameTimeIsInTheFuture() {
+        var now = DateTimeOffset.UtcNow;
+        var gameTimes = new[] { now.AddHours(-2), now.AddHours(1) };
+        Assert.False(GameHelpers.AllGamesStarted(gameTimes, now));
+    }
+
     // ─── DaysHoursMinutesUntilNoonCst ─────────────────────────────────────────
 
     [Fact]

--- a/Server.UnitTests/LeaderboardTests.cs
+++ b/Server.UnitTests/LeaderboardTests.cs
@@ -546,6 +546,41 @@ public class LeaderboardServiceTests {
         Assert.Equal(WeekResult.MissingPicks, result[0].WeekResults[0].WeekResult);
     }
 
+    // frizat-8y6: reported live on prod — a slate with ZERO spreads released yet (the picking
+    // window hasn't even opened) showed on the leaderboard as MissingPicks — a terminal loss —
+    // for every user, because AllGamesStarted's underlying .All() is vacuously true on an empty
+    // sequence. A week that hasn't started must never read as "everyone missed their picks".
+    [Fact]
+    public async Task CfbBuildLeaderboard_ReturnsMissingGameResults_NotMissingPicks_WhenNoSpreadsExistYet() {
+        var userId = Guid.NewGuid().ToString();
+        const int leagueId = 1;
+        const int slateId = 1;
+        var leagueInfo = new LeagueInfo { Id = leagueId, LeagueName = "CFB Test", OwnerUserId = userId };
+        var userMapping = new LeagueUserMapping { LeagueId = leagueId, League = leagueInfo, User = new ApplicationUser { Id = userId, UserName = "Alice" }, UserId = userId };
+        var juiceMapping = new LeagueJuiceMapping { Id = 1, LeagueId = leagueId, Season = 2025, Juice = 5, JuiceDivisional = 10, JuiceConference = 6, WeeklyCost = 5 };
+        var slate = new CfbSlates { Id = slateId, Season = 2025, SlateNumber = 2, SlateType = "RegularSeason", Label = "Week 2", StartDate = DateOnly.FromDateTime(DateTime.Today), EndDate = DateOnly.FromDateTime(DateTime.Today.AddDays(6)) };
+
+        var leagueRepo = Substitute.For<ILeagueRepository>();
+        leagueRepo.GetLeagueUserMappingsAsync(leagueId).Returns([userMapping]);
+        leagueRepo.GetLeagueJuiceMappingAsync(leagueId, 2025).Returns(juiceMapping);
+
+        var cfbRepo = Substitute.For<ICfbRepository>();
+        cfbRepo.GetSlatesForSeasonAsync(2025).Returns([slate]);
+        cfbRepo.GetSpreadsForSlateAsync(slateId).Returns((IEnumerable<CfbSpreads>)[]); // nothing released yet
+        cfbRepo.GetScoresForSlateAsync(slateId).Returns((IEnumerable<CfbScores>)[]);
+
+        var picksRepo = Substitute.For<ICfbPicksRepository>();
+        picksRepo.GetUserPicksAsync(leagueId, slateId, userId).Returns((IEnumerable<CfbPicks>)[]);
+
+        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(),
+            leagueRepo, cfbRepo, picksRepo, BuildCurrentSlateService(slateNumber: 2), TimeProvider.System);
+        var result = await service.BuildLeaderboard(leagueId, 2025);
+
+        Assert.Equal(WeekResult.MissingGameResults, result[0].WeekResults[0].WeekResult);
+        // Not a terminal loss, so no payout is computed for a week that hasn't started.
+        Assert.Equal(0, result[0].WeekResults[0].Score);
+    }
+
     // frizat-tf1: a user can submit picks for any individual game right up until that game's own
     // kickoff (CfbPicksController.StartedTeams uses the identical GameTime <= now check) — so an
     // incomplete pick set must not be treated as a terminal loss while any of that slate's games

--- a/Shared/Helpers/GameHelpers.cs
+++ b/Shared/Helpers/GameHelpers.cs
@@ -168,8 +168,14 @@ public static class GameHelpers {
     // tell a terminal MissingPicks (every game for the week/slate has already kicked off) apart
     // from a still-open picking window (MissingGameResults) — same GameTime <= now boundary
     // CfbPicksController.StartedTeams already enforces for locking individual picks.
-    public static bool AllGamesStarted(IEnumerable<DateTimeOffset> gameTimes, DateTimeOffset now) =>
-        gameTimes.All(t => t <= now);
+    // frizat-8y6: .All() is vacuously true on an empty sequence — a week/slate with literally no
+    // games (spreads not released yet) must never read as "already started" (that flips a
+    // genuinely not-yet-open picking window into a terminal MissingPicks loss). Require at least
+    // one real game before concluding anything has started.
+    public static bool AllGamesStarted(IEnumerable<DateTimeOffset> gameTimes, DateTimeOffset now) {
+        var times = gameTimes as ICollection<DateTimeOffset> ?? gameTimes.ToList();
+        return times.Count > 0 && times.All(t => t <= now);
+    }
     public static bool IsGameOver(Competition competition) => competition.Status.Type.Name == TypeName.StatusFinal;
     public static long GetTeamScore(Competitor competitor) => competitor.Score;
     public static string GetTeamAbbr(Competitor competitor) => competitor.Team.Abbreviation;


### PR DESCRIPTION
## Summary

Promotes #337 from `dev` to `main`.

**1. CFB Picks page still let you navigate past the current week**

The NFL fix (#336) worked, but CFB's Picks page still let Next walk to the end of the season. Two compounding bugs in `cfbAdapter.ts`:
- `loadCurrentGames` computed `maxWeek` from the season's total pre-seeded slate count instead of the real current week — fixed to match `loadCurrentScores`'s already-correct `weekState.week`.
- A static `regularWeekOptions` (the full season's week list) silently overrode the dynamic `maxRegularSeasonWeek` prop in `WeekYearSelector` — removed.

**2. Leaderboard showed a week that hasn't started as a terminal loss**

A CFB week with zero spreads released yet showed as `MissingPicks` (a hard loss) for every user, because `GameHelpers.AllGamesStarted`'s `.All()` is vacuously true on an empty sequence. Fixed at the shared helper (used identically by NFL and CFB).

**3. Follow-up caught by CI**: removing the static week-list override in fix #1 exposed a second, previously-latent bug — `maxWeek` didn't distinguish regular season from postseason, so a postseason current slate leaked its small postseason week number in as the regular-season cap. Fixed with the same `maxWeekFor` pattern `nflAdapter.ts` already uses, verified against the exact CI failure locally before pushing.

## Verified
- [x] `dotnet test` — 888 passing
- [x] `npm run test -- --run` — 624 passing
- [x] `npm run test:e2e -- --project=chromium` — 94/95 passing (1 known pre-existing flake, unrelated)
- [x] `npm run test:e2e:demo` — 46/46 passing (including the exact tests CI caught)
- [x] Live-verified on `dev.ivleague.xyz`/`cfb.dev.ivleague.xyz` after deploy: DB Migrate succeeded, Railway deploy succeeded, `/api/version` confirms the live commit
- [x] Live-verified locally via Chrome (demo stack): CFB Picks + Scores Next correctly disabled at the real current week, both regular season and postseason, no blank page, leaderboard renders correctly

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs