### PR TITLE
Make NFL's API contract WeekId-primary, matching CFB; fix Job Manager NFL/CFB mix-up

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to IV League, most recent first. For admins — see the version 
 
 Format: `## ` release headings and single-line `- ` bullets only — no bold, links, or multi-line/nested bullets. The admin Changelog page renders this with a small hand-rolled parser (`parseChangelog.ts`), not a full Markdown engine; anything outside this subset renders as literal syntax instead of being formatted. A test guards this file against drifting outside the subset.
 
+## 2026-09-09
+
+- Fixed: the admin Job Manager page had one generically-labeled "Run Scores Job" / "Run Spreads Job" button that only ever ran NFL's job, with no way to trigger CFB's scores or spreads jobs at all — each sport now has its own clearly-labeled button
+
 ## 2026-09-07
 
 - Fixed: the admin League Costs page's season dropdown was a hardcoded 4-year window unrelated to any real league's history, and could bill a league its flat base cost for seasons before it ever existed — the dropdown now only offers seasons from the earliest any league has actually been configured for, and leagues that didn't exist yet in the selected season are excluded from the cost table entirely

--- a/Client.React/e2e/helpers/routes.ts
+++ b/Client.React/e2e/helpers/routes.ts
@@ -195,15 +195,15 @@ export async function setupRoutes(page: Page, options: SetupRoutesOptions = {}):
     }
 
     // ── NFL current-week (control table) — nflAdapter.ts resolves this FIRST for the current-
-    // week path, then fetches that exact week via /api/espn/scores/week/ below. Must match
+    // week path, then fetches that exact week via /api/espn/scores/nfl-week/ below. Must match
     // scoresData's week/season/isPostSeason or the two responses disagree.
     if (url.includes('/api/league/current-week') && method === 'GET') {
       void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(createCurrentWeek(week, isPostSeason, season)) });
       return;
     }
 
-    // ── ESPN scores/week — historical ──────────────────────────────────────
-    if (url.includes('/api/espn/scores/week/') && method === 'GET') {
+    // ── ESPN scores/nfl-week — our own (season, nflWeek), historical + current (frizat-3nv) ──
+    if (url.includes('/api/espn/scores/nfl-week/') && method === 'GET') {
       void route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(scoresData) });
       return;
     }

--- a/Client.React/e2e/scores.spec.ts
+++ b/Client.React/e2e/scores.spec.ts
@@ -30,8 +30,10 @@ test.describe('Scores page (authenticated)', () => {
 
   // gameStarted: true so shouldShowGamePicks() = true and badge counts are visible
   const scoresOptions = { leaguePicks, gameStarted: true };
-  // postseason variant for Over/Under badge tests
-  const postSeasonOptions = { leaguePicks, gameStarted: true, isPostSeason: true };
+  // postseason variant for Over/Under badge tests — week must be a valid internal postseason
+  // WeekId (19-22), not the regular-season default (frizat-3nv: WeekId is the only numbering
+  // used now, no more ESPN week 1-5).
+  const postSeasonOptions = { leaguePicks, gameStarted: true, isPostSeason: true, week: 20 };
 
   test('renders scores page for authenticated user', async ({ page }) => {
     await mockAuth(page, { navigateTo: '/scores', ...scoresOptions });

--- a/Client.React/src/__tests__/JobManagerPage.test.tsx
+++ b/Client.React/src/__tests__/JobManagerPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import AdminJobManagerPage from '../pages/admin/JobManagerPage';
 import type { JobStatusResponse } from '../types/admin';
@@ -6,12 +7,14 @@ import type { JobStatusResponse } from '../types/admin';
 vi.mock('../api/jobManager', () => ({
   getAllJobsStatus: vi.fn(),
   runSpreads: vi.fn(),
+  runCfbSpreads: vi.fn(),
   runUserManager: vi.fn(),
   runScores: vi.fn(),
+  runCfbScores: vi.fn(),
 }));
 vi.mock('../services/toast', () => ({ useToast: () => ({ push: vi.fn() }) }));
 
-import { getAllJobsStatus } from '../api/jobManager';
+import { getAllJobsStatus, runScores, runCfbScores, runSpreads, runCfbSpreads } from '../api/jobManager';
 
 const mockedGetAllJobsStatus = vi.mocked(getAllJobsStatus);
 
@@ -62,5 +65,50 @@ describe('AdminJobManagerPage', () => {
 
     expect(await screen.findByText('System', { exact: true })).toBeInTheDocument();
     expect(screen.getByText('Juice', { exact: true })).toBeInTheDocument();
+  });
+
+  // Regression: a single generically-labeled "Run Scores Job" button previously ran NFL's job
+  // only, with no way to trigger CFB's scores/spreads jobs from this page at all — a real prod
+  // admin mix-up (clicked expecting it to cover CFB, it silently only ran NFL). Each sport now
+  // gets its own explicitly-labeled button wired to its own API call — pin both the labels and
+  // that each one calls the correct (and only the correct) underlying function.
+  it('renders a dedicated button per job type, never combining NFL and CFB', async () => {
+    mockedGetAllJobsStatus.mockResolvedValue([]);
+    render(<AdminJobManagerPage />);
+
+    expect(await screen.findByRole('button', { name: /run nfl scores job/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /run cfb scores job/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /run nfl spreads job/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /run cfb spreads job/i })).toBeInTheDocument();
+  });
+
+  it('clicking "Run NFL Scores Job" calls runScores only, never runCfbScores', async () => {
+    mockedGetAllJobsStatus.mockResolvedValue([]);
+    render(<AdminJobManagerPage />);
+
+    await userEvent.click(await screen.findByRole('button', { name: /run nfl scores job/i }));
+
+    expect(runScores).toHaveBeenCalledTimes(1);
+    expect(runCfbScores).not.toHaveBeenCalled();
+  });
+
+  it('clicking "Run CFB Scores Job" calls runCfbScores only, never runScores', async () => {
+    mockedGetAllJobsStatus.mockResolvedValue([]);
+    render(<AdminJobManagerPage />);
+
+    await userEvent.click(await screen.findByRole('button', { name: /run cfb scores job/i }));
+
+    expect(runCfbScores).toHaveBeenCalledTimes(1);
+    expect(runScores).not.toHaveBeenCalled();
+  });
+
+  it('clicking "Run CFB Spreads Job" calls runCfbSpreads only, never runSpreads', async () => {
+    mockedGetAllJobsStatus.mockResolvedValue([]);
+    render(<AdminJobManagerPage />);
+
+    await userEvent.click(await screen.findByRole('button', { name: /run cfb spreads job/i }));
+
+    expect(runCfbSpreads).toHaveBeenCalledTimes(1);
+    expect(runSpreads).not.toHaveBeenCalled();
   });
 });

--- a/Client.React/src/__tests__/nflAdapter.test.ts
+++ b/Client.React/src/__tests__/nflAdapter.test.ts
@@ -34,7 +34,7 @@ function makeScores(homeTeam: string, awayTeam: string, homeScore = 24, awayScor
 // considers current (e.g. the most recently completed game during any gap in play) regardless of
 // the league's actual spread-release schedule.
 const DEFAULT_CURRENT_WEEK = {
-  weekId: 8, espnWeek: 8, season: 2023, isPostSeason: false,
+  weekId: 8, season: 2023, isPostSeason: false,
   weekLabel: 'Week 8', scoringFormat: 'Standard', spreadLockDatetime: '2023-10-26T17:00:00Z',
 };
 
@@ -137,7 +137,7 @@ describe('nflAdapter', () => {
 
       const result = await adapter.loadCurrentGames(1, 'user1');
 
-      expect(getWeekScores).toHaveBeenCalledWith(8, 2023, false);
+      expect(getWeekScores).toHaveBeenCalledWith(2023, 8);
       expect(loadScoresWithRetry).not.toHaveBeenCalled();
       expect(result.season).toBe(2023);
       expect(result.week).toBe(8);
@@ -178,7 +178,7 @@ describe('nflAdapter', () => {
 
       const result = await adapter.loadCurrentScores(1, 'user1');
 
-      expect(getWeekScores).toHaveBeenCalledWith(8, 2023, false);
+      expect(getWeekScores).toHaveBeenCalledWith(2023, 8);
       expect(loadScoresWithRetry).not.toHaveBeenCalled();
       expect(result.season).toBe(2023);
       expect(result.week).toBe(8);
@@ -213,7 +213,7 @@ describe('nflAdapter', () => {
     // season's Super Bowl as "current" throughout the summer offseason gap).
     it('currentSeasonYear uses the control table, never ESPN\'s own scoreboard', async () => {
       vi.mocked(getNflCurrentWeek).mockResolvedValue({
-        weekId: 1, espnWeek: 1, season: 2026, isPostSeason: false,
+        weekId: 1, season: 2026, isPostSeason: false,
         weekLabel: 'Week 1', scoringFormat: 'Standard', spreadLockDatetime: '2026-09-09T13:20:00Z',
       });
 

--- a/Client.React/src/__tests__/picks.test.tsx
+++ b/Client.React/src/__tests__/picks.test.tsx
@@ -208,7 +208,7 @@ describe('PicksPage', () => {
 
   it('shows picks remaining (1) for postseason week 1 with two existing picks', async () => {
     const existing = [createPick({ team: 'BUF' }), createPick({ team: 'DAL' })];
-    await setupDefaults({ week: 1, postSeason: true, existingPicks: existing });
+    await setupDefaults({ week: 19, postSeason: true, existingPicks: existing });
     await renderPage();
     expect(screen.getByText(/Picks Remaining \(1\)/i)).toBeInTheDocument();
   });
@@ -351,7 +351,7 @@ describe('PicksPage', () => {
     // getWeekScores now serves both the current week (season 2024) and the historical navigation
     // below (season 2022) — differentiate by the requested year so the initial current-week load
     // isn't overwritten by the season-2022 fixture before the snapshot is even captured.
-    mockedGetWeekScores.mockImplementation(async (_week: number, year: number) => year === 2022
+    mockedGetWeekScores.mockImplementation(async (season: number) => season === 2022
       ? createScores({ week: 2, seasonYear: 2022, gameStarted: false })
       : createScores({ week: 2, postSeason: false, gameStarted: false }));
 
@@ -433,25 +433,25 @@ describe('PicksPage', () => {
   });
 
   it('postseason week 1 displays wild card title', async () => {
-    await setupDefaults({ week: 1, postSeason: true });
+    await setupDefaults({ week: 19, postSeason: true });
     await renderPage();
     expect(screen.getAllByText(/Wild Card/i).length).toBeGreaterThan(0);
   });
 
   it('postseason week 2 displays divisional round title', async () => {
-    await setupDefaults({ week: 2, postSeason: true });
+    await setupDefaults({ week: 20, postSeason: true });
     await renderPage();
     expect(screen.getAllByText(/Divisional Round/i).length).toBeGreaterThan(0);
   });
 
   it('postseason week 3 displays conference championship title', async () => {
-    await setupDefaults({ week: 3, postSeason: true });
+    await setupDefaults({ week: 21, postSeason: true });
     await renderPage();
     expect(screen.getAllByText(/Conference Championship/i).length).toBeGreaterThan(0);
   });
 
   it('postseason week 4 displays super bowl title', async () => {
-    await setupDefaults({ week: 4, postSeason: true });
+    await setupDefaults({ week: 22, postSeason: true });
     await renderPage();
     await waitFor(() => expect(screen.getAllByText(/Super Bowl/i).length).toBeGreaterThan(0));
   });
@@ -505,7 +505,7 @@ describe('PicksPage', () => {
   });
 
   it('postseason shows over/under buttons and toggles', async () => {
-    await setupDefaults({ week: 1, postSeason: true });
+    await setupDefaults({ week: 19, postSeason: true });
     await renderPage();
 
     const overButton = screen.getAllByRole('button', { name: /^Over$/i })[0];
@@ -518,7 +518,7 @@ describe('PicksPage', () => {
   });
 
   it('postseason allows selecting spread and over picks together', async () => {
-    await setupDefaults({ week: 1, postSeason: true });
+    await setupDefaults({ week: 19, postSeason: true });
     await renderPage();
 
     const pickButton = screen.getAllByRole('button', { name: /^Pick /i })[0];
@@ -531,7 +531,7 @@ describe('PicksPage', () => {
   });
 
   it('renders a dedicated over/under control block per postseason matchup', async () => {
-    await setupDefaults({ week: 1, postSeason: true });
+    await setupDefaults({ week: 19, postSeason: true });
     await renderPage();
 
     const controls = screen.getAllByTestId('over-under-controls');

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -167,7 +167,7 @@ describe('ScoresPage', () => {
   });
 
   it('shows postseason wild card title', async () => {
-    await setupDefaults({ week: 1, postSeason: true });
+    await setupDefaults({ week: 19, postSeason: true });
     await renderPage();
     expect(screen.getAllByText(/Wild Card/i).length).toBeGreaterThan(0);
   });
@@ -201,7 +201,7 @@ describe('ScoresPage', () => {
   });
 
   it('postseason displays over/under icons', async () => {
-    await setupDefaults({ week: 1, postSeason: true });
+    await setupDefaults({ week: 19, postSeason: true });
     await renderPage();
     expect(screen.getAllByTestId('ArrowCircleUpIcon').length).toBeGreaterThan(0);
     expect(screen.getAllByTestId('ArrowCircleDownIcon').length).toBeGreaterThan(0);
@@ -215,7 +215,7 @@ describe('ScoresPage', () => {
     // BUF 24, MIA 10 -> total 34. Over threshold 30 (34>30 -> wins) and Under threshold 40
     // (34<40 -> ALSO wins) simultaneously — negating Over's result to get Under's would wrongly
     // report Under as a loss here.
-    await setupDefaults({ week: 1, postSeason: true, gameStarted: true });
+    await setupDefaults({ week: 19, postSeason: true, gameStarted: true });
     mockedSpreadBatch.mockResolvedValue({
       responses: { ...SPREAD_RESPONSES, BUF: createSpreadResponse('BUF', -7, 30, 40) },
     });
@@ -246,7 +246,7 @@ describe('ScoresPage', () => {
   // state. Arrows now stay a fixed neutral color; the badges are the one signal.
   it('keeps the Over/Under arrows a neutral color regardless of win/loss — the badges already carry that signal', async () => {
     // BUF 24, MIA 10 → total 34 < O/U 47.5 → Under wins (see makeScores comment above)
-    await setupDefaults({ week: 1, postSeason: true, gameStarted: true });
+    await setupDefaults({ week: 19, postSeason: true, gameStarted: true });
     await renderPage();
     const upArrow = screen.getAllByTestId('ArrowCircleUpIcon')[0];
     const downArrow = screen.getAllByTestId('ArrowCircleDownIcon')[0];
@@ -431,7 +431,7 @@ describe('ScoresPage', () => {
       // getWeekScores now serves BOTH the current week (2, via loadCurrentScores) and historical
       // navigation (week 1 — a PAST week; navigation is capped at the real current week now, so
       // this can no longer be a future week like the old week-5 version of this test used).
-      mockedGetWeekScores.mockImplementation(async (week: number) => week === 1
+      mockedGetWeekScores.mockImplementation(async (_season: number, nflWeek: number) => nflWeek === 1
         ? makeScores(1, false, true)
         : createScores({
             week: 2, postSeason: false,
@@ -478,7 +478,7 @@ describe('ScoresPage', () => {
     // getWeekScores now serves both the current week (season 2024) and the historical navigation
     // below (season 2022) — differentiate by the requested year so the initial current-week load
     // isn't overwritten by the season-2022 fixture before the snapshot is even captured.
-    mockedGetWeekScores.mockImplementation(async (_week: number, year: number) => year === 2022
+    mockedGetWeekScores.mockImplementation(async (season: number) => season === 2022
       ? createScores({ week: 2, seasonYear: 2022, gameStarted: true })
       : makeScores(2, false, true));
     await renderPage();

--- a/Client.React/src/__tests__/sharedPickLayout.test.tsx
+++ b/Client.React/src/__tests__/sharedPickLayout.test.tsx
@@ -52,7 +52,7 @@ describe('NFL PicksPage — GameCard layout regression', () => {
       competitions: [createCompetition({ homeTeam: 'KC', awayTeam: 'BUF' })],
     }]});
     vi.mocked(getNflCurrentWeek).mockResolvedValue({
-      weekId: 8, espnWeek: 8, season: 2023, isPostSeason: false,
+      weekId: 8, season: 2023, isPostSeason: false,
       weekLabel: 'Week 8', scoringFormat: 'Standard', spreadLockDatetime: new Date().toISOString(),
     });
     vi.mocked(getWeekScores).mockResolvedValue(scores);

--- a/Client.React/src/api/espn.ts
+++ b/Client.React/src/api/espn.ts
@@ -42,9 +42,9 @@ export async function getCfbScoresForSlate(slateId: number): Promise<EspnScores 
   return data ?? null;
 }
 
-export async function getWeekScores(week: number, year: number, postSeason = false): Promise<EspnScores | null> {
-  const { data } = await http.get<EspnScores>(`/api/espn/scores/week/${week}/${year}`, {
-    params: { postSeason },
-  });
+/** Live/historical NFL scores for a specific (season, nflWeek) — our own control-table WeekId,
+ * never ESPN's own week numbering — same role as getCfbScoresForSlate() for CFB (frizat-3nv). */
+export async function getWeekScores(season: number, nflWeek: number): Promise<EspnScores | null> {
+  const { data } = await http.get<EspnScores>(`/api/espn/scores/nfl-week/${season}/${nflWeek}`);
   return data ?? null;
 }

--- a/Client.React/src/api/jobManager.ts
+++ b/Client.React/src/api/jobManager.ts
@@ -10,12 +10,20 @@ export async function runSpreads() {
   await http.post('/api/jobmanager/run-spreads');
 }
 
+export async function runCfbSpreads() {
+  await http.post('/api/jobmanager/run-cfb-spreads');
+}
+
 export async function runUserManager() {
   await http.post('/api/jobmanager/run-users');
 }
 
 export async function runScores() {
   await http.post('/api/jobmanager/run-scores');
+}
+
+export async function runCfbScores() {
+  await http.post('/api/jobmanager/run-cfb-scores');
 }
 
 export async function deleteJob(jobName: string) {

--- a/Client.React/src/pages/RulesPage.tsx
+++ b/Client.React/src/pages/RulesPage.tsx
@@ -10,7 +10,7 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import { getEspnRequiredPicks, getCfbRequiredPicks } from '../utils/gameHelpers';
+import { getNflRequiredPicks, getCfbRequiredPicks } from '../utils/gameHelpers';
 import { useSportContext } from '../services/sport';
 import { getNflSpreadLockSchedule } from '../api/league';
 import { getCfbSpreadLockSchedule } from '../api/cfb';
@@ -179,7 +179,7 @@ function MatchupExample() {
 function OverUnderExample() {
   const { isCfb } = useSportContext();
   const roundLabel = isCfb ? 'CFP First Round' : 'Wild Card';
-  const requiredPicks = isCfb ? getCfbRequiredPicks(15) : getEspnRequiredPicks(1, true);
+  const requiredPicks = isCfb ? getCfbRequiredPicks(15) : getNflRequiredPicks(19);
   const picks = isCfb
     ? [
         { type: 'spread' as const, label: 'Ohio State Buckeyes', detail: 'Teased line +8.5' },
@@ -343,10 +343,10 @@ function PlayoffGrid() {
         { round: 'Championship', picks: getCfbRequiredPicks(18) },
       ]
     : [
-        { round: 'Wild Card', picks: getEspnRequiredPicks(1, true) },
-        { round: 'Divisional', picks: getEspnRequiredPicks(2, true) },
-        { round: 'Championship', picks: getEspnRequiredPicks(3, true) },
-        { round: 'Super Bowl', picks: getEspnRequiredPicks(5, true) },
+        { round: 'Wild Card', picks: getNflRequiredPicks(19) },
+        { round: 'Divisional', picks: getNflRequiredPicks(20) },
+        { round: 'Championship', picks: getNflRequiredPicks(21) },
+        { round: 'Super Bowl', picks: getNflRequiredPicks(22) },
       ];
 
   return (
@@ -495,7 +495,7 @@ function SpreadLockInfo({ isCfb }: { isCfb: boolean }) {
 
 export function RulesContent() {
   const { isCfb } = useSportContext();
-  const regularPicks = getEspnRequiredPicks(1, false);
+  const regularPicks = getNflRequiredPicks(1);
 
   return (
     <Stack spacing={3}>

--- a/Client.React/src/pages/admin/JobManagerPage.tsx
+++ b/Client.React/src/pages/admin/JobManagerPage.tsx
@@ -18,7 +18,7 @@ import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import PeopleIcon from '@mui/icons-material/People';
 import ScoreboardIcon from '@mui/icons-material/Scoreboard';
 import PageHeader from '../../components/PageHeader';
-import { getAllJobsStatus, runScores, runSpreads, runUserManager } from '../../api/jobManager';
+import { getAllJobsStatus, runCfbScores, runCfbSpreads, runScores, runSpreads, runUserManager } from '../../api/jobManager';
 import type { JobStatusResponse } from '../../types/admin';
 import { useToast } from '../../services/toast';
 import { stickyColumnSx } from '../../utils/tableStyles';
@@ -82,6 +82,11 @@ export default function AdminJobManagerPage() {
         <Typography variant="h5" align="center" sx={{ mb: 2 }}>
           Admin Tasks
         </Typography>
+        {/* One dedicated button per job TYPE (NFL/CFB Scores, NFL/CFB Spreads are always
+            separate jobs, never combined — see LeagueController/CfbPicksController siblings) —
+            a single generically-labeled "Run Scores Job" button here previously ran NFL only,
+            with no way to trigger CFB's scores/spreads jobs from this page at all. That silently
+            reads as "did nothing" for CFB and has caused a real admin mix-up in prod. */}
         <Grid container spacing={2} justifyContent="center">
           <Grid size={{ xs: 12, sm: 6 }}>
             <Button
@@ -89,9 +94,42 @@ export default function AdminJobManagerPage() {
               fullWidth
               startIcon={<TrendingUpIcon />}
               disabled={jobRunning || loading}
-              onClick={() => runJob(runSpreads, 'Spread Job')}
+              onClick={() => runJob(runSpreads, 'NFL Spreads Job')}
             >
-              {jobRunning ? 'Running...' : 'Run Spreads Job'}
+              {jobRunning ? 'Running...' : 'Run NFL Spreads Job'}
+            </Button>
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <Button
+              variant="contained"
+              fullWidth
+              startIcon={<TrendingUpIcon />}
+              disabled={jobRunning || loading}
+              onClick={() => runJob(runCfbSpreads, 'CFB Spreads Job')}
+            >
+              {jobRunning ? 'Running...' : 'Run CFB Spreads Job'}
+            </Button>
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <Button
+              variant="contained"
+              fullWidth
+              startIcon={<ScoreboardIcon />}
+              disabled={jobRunning || loading}
+              onClick={() => runJob(runScores, 'NFL Scores Job')}
+            >
+              {jobRunning ? 'Running...' : 'Run NFL Scores Job'}
+            </Button>
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <Button
+              variant="contained"
+              fullWidth
+              startIcon={<ScoreboardIcon />}
+              disabled={jobRunning || loading}
+              onClick={() => runJob(runCfbScores, 'CFB Scores Job')}
+            >
+              {jobRunning ? 'Running...' : 'Run CFB Scores Job'}
             </Button>
           </Grid>
           <Grid size={{ xs: 12, sm: 6 }}>
@@ -103,17 +141,6 @@ export default function AdminJobManagerPage() {
               onClick={() => runJob(runUserManager, 'User Manager Job')}
             >
               {jobRunning ? 'Running...' : 'Run User Manager Job'}
-            </Button>
-          </Grid>
-          <Grid size={{ xs: 12, sm: 6 }}>
-            <Button
-              variant="contained"
-              fullWidth
-              startIcon={<ScoreboardIcon />}
-              disabled={jobRunning || loading}
-              onClick={() => runJob(runScores, 'Scores Job')}
-            >
-              {jobRunning ? 'Running...' : 'Run Scores Job'}
             </Button>
           </Grid>
         </Grid>

--- a/Client.React/src/services/nflAdapter.ts
+++ b/Client.React/src/services/nflAdapter.ts
@@ -8,7 +8,7 @@ import {
   getHomeTeam, getAwayTeam,
   getHomeTeamScore, getAwayTeamScore,
   getTeamRecord, getTeamLogo,
-  getWeekFromEspnWeek, getEspnRequiredPicks,
+  getWeekFromEspnWeek, getNflWeekName, getNflRequiredPicks,
   isPostSeason as isPostSeasonHelper,
   isGameOver, isGameStarted, toGameStatus,
   computeHomeCovers, computeAwayCovers, computeOverWins, computeUnderWins,
@@ -117,6 +117,16 @@ async function buildSituationMap(events: Event[]): Promise<Map<string, import('.
   return map;
 }
 
+// The frozen demo/replay fixture is real captured ESPN wire data (its own week.number is ESPN's
+// raw numbering, not our internal WeekId) — this is the one place nflAdapter.ts still legitimately
+// needs to interpret ESPN's own shape, since a frozen fixture genuinely IS an ESPN ingestion point.
+function isFrozenWeekMatch(frozenData: Awaited<ReturnType<typeof loadScoresWithRetry>>, season: number, nflWeek: number, isPostSeason: boolean): boolean {
+  if (!frozenData?.week || !frozenData.season) return false;
+  const frozenIsPostSeason = isPostSeasonHelper(frozenData);
+  const frozenNflWeek = getWeekFromEspnWeek(frozenData.week.number, frozenIsPostSeason);
+  return frozenData.season.year === season && frozenNflWeek === nflWeek && frozenIsPostSeason === isPostSeason;
+}
+
 export function createNflAdapter(): SportAdapter {
   // The control table (NflSeasonWeekConfigs, via SeasonWindowResolver/NflCurrentWeekService) is
   // the SOLE source of truth for which week is "current" — mirrors cfbAdapter.ts's
@@ -124,7 +134,8 @@ export function createNflAdapter(): SportAdapter {
   // with no week param) must never be used to decide season/week: it has its own notion of
   // "current" — e.g. during any gap in play it returns the last-completed event — which can
   // disagree with the league's actual spread-release schedule. Once resolved here, the specific
-  // week is always fetched by week (getWeekScores), same as historical navigation.
+  // week is always fetched by (season, weekId) — our own control table, never ESPN's own week
+  // numbering (frizat-3nv) — same as historical navigation.
   //
   // NflCurrentWeekService NEVER legitimately resolves to "nothing" — it either returns a real
   // week or throws (e.g. no NflSeasonWeekConfig rows seeded at all, a genuine data-integrity
@@ -147,18 +158,11 @@ export function createNflAdapter(): SportAdapter {
     weekSelectorConfig: {
       maxRegularSeasonWeek: 18,
       minSeason: 2020,
-      // Skip week 4 (Pro Bowl) — Super Bowl is week 5 in ESPN's 2025 postseason
-      postSeasonWeekOptions: [1, 2, 3, 5],
-      weekLabelFn: (week, isPostSeason) => {
-        if (!isPostSeason) return `Week ${week}`;
-        switch (week) {
-          case 1: return 'Wild Card';
-          case 2: return 'Divisional Round';
-          case 3: return 'Conference Championship';
-          case 5: return 'Super Bowl';
-          default: return `Postseason Week ${week}`;
-        }
-      },
+      // Our own internal WeekId (19-22) — contiguous, no ESPN Pro-Bowl-skip gap to work around
+      // here at all (frizat-3nv/frizat-4k9: that quirk is normalized once, at the ESPN-ingestion
+      // boundary, and never leaks past it).
+      postSeasonWeekOptions: [19, 20, 21, 22],
+      weekLabelFn: getNflWeekName,
     },
 
     async currentSeasonYear() {
@@ -170,37 +174,33 @@ export function createNflAdapter(): SportAdapter {
 
     async loadCurrentGames(leagueId, userId) {
       const current = await getCurrentWeek();
-      const { season, espnWeek: weekNum, isPostSeason: postSeason } = current;
-      const nflWeek = getWeekFromEspnWeek(weekNum, postSeason);
+      const { season, weekId: nflWeek, isPostSeason: postSeason } = current;
       const [data, picksResult, hasOdds] = await Promise.all([
-        getWeekScores(weekNum, season, postSeason),
+        getWeekScores(season, nflWeek),
         getUserPicks(userId, leagueId, season, nflWeek),
         doOddsExist(leagueId, season, nflWeek),
       ]);
       const sc = await buildSpreadCache(data?.events ?? [], leagueId, season, nflWeek, hasOdds);
       const games: GameView[] = (data?.events ?? []).flatMap(ev => ev.competitions.map(c => competitionToGameView(c, ev, sc)));
       const userPicks = picksResult.map(p => nflPickToPickView(p, games)).filter((p): p is PickView => p !== null);
-      return { season, week: weekNum, isPostSeason: postSeason, games, userPicks, hasOdds, requiredPicks: getEspnRequiredPicks(weekNum, postSeason), maxWeek: maxWeekFor(postSeason, nflWeek), maxSeason: season };
+      return { season, week: nflWeek, isPostSeason: postSeason, games, userPicks, hasOdds, requiredPicks: getNflRequiredPicks(nflWeek), maxWeek: maxWeekFor(postSeason, nflWeek), maxSeason: season };
     },
 
     async loadHistoricalGames(leagueId, userId, { season, week, isPostSeason }) {
       // Use frozen JSON when requesting the current demo week for consistent in-progress state
       const frozenData = await loadScoresWithRetry();
-      const frozenIsPostSeason = isPostSeasonHelper(frozenData);
-      const isFrozenWeek = frozenData?.season?.year === season && frozenData?.week?.number === week && frozenIsPostSeason === isPostSeason;
-      const data = isFrozenWeek ? frozenData : await getWeekScores(week, season, isPostSeason);
+      const isFrozenWeek = isFrozenWeekMatch(frozenData, season, week, isPostSeason);
+      const data = isFrozenWeek ? frozenData : await getWeekScores(season, week);
       if (!data?.events?.length) return null;
-      const nflWeek = getWeekFromEspnWeek(week, isPostSeason);
-      const [picksResult, hasOdds] = await Promise.all([getUserPicks(userId, leagueId, season, nflWeek), doOddsExist(leagueId, season, nflWeek)]);
-      const sc = await buildSpreadCache(data.events, leagueId, season, nflWeek, hasOdds);
+      const [picksResult, hasOdds] = await Promise.all([getUserPicks(userId, leagueId, season, week), doOddsExist(leagueId, season, week)]);
+      const sc = await buildSpreadCache(data.events, leagueId, season, week, hasOdds);
       const games: GameView[] = data.events.flatMap(ev => ev.competitions.map(c => competitionToGameView(c, ev, sc)));
       const userPicks = picksResult.map(p => nflPickToPickView(p, games)).filter((p): p is PickView => p !== null);
-      return { season, week, isPostSeason, games, userPicks, hasOdds, requiredPicks: getEspnRequiredPicks(week, isPostSeason), maxWeek: maxWeekFor(isPostSeason, nflWeek), maxSeason: season };
+      return { season, week, isPostSeason, games, userPicks, hasOdds, requiredPicks: getNflRequiredPicks(week), maxWeek: maxWeekFor(isPostSeason, week), maxSeason: season };
     },
 
-    async submitPicks(leagueId, { season, week, isPostSeason }, picks) {
-      const nflWeek = getWeekFromEspnWeek(week, isPostSeason);
-      await addPicks(picks.map(p => ({ id: 0, leagueId, userId: '', userName: '', team: p.team, pick: p.pickType as PickType, nflWeek, season, dateCreated: new Date().toISOString() } as NflPickDto)));
+    async submitPicks(leagueId, { season, week }, picks) {
+      await addPicks(picks.map(p => ({ id: 0, leagueId, userId: '', userName: '', team: p.team, pick: p.pickType as PickType, nflWeek: week, season, dateCreated: new Date().toISOString() } as NflPickDto)));
     },
 
     async clearPicks() { return []; },
@@ -211,10 +211,9 @@ export function createNflAdapter(): SportAdapter {
 
     async loadCurrentScores(leagueId, userId) {
       const current = await getCurrentWeek();
-      const { season, espnWeek: weekNum, isPostSeason: postSeason } = current;
-      const nflWeek = getWeekFromEspnWeek(weekNum, postSeason);
+      const { season, weekId: nflWeek, isPostSeason: postSeason } = current;
       const [data, hasOdds, allPicksDtos] = await Promise.all([
-        getWeekScores(weekNum, season, postSeason),
+        getWeekScores(season, nflWeek),
         doOddsExist(leagueId, season, nflWeek),
         getLeaguePicks(leagueId, season, nflWeek),
       ]);
@@ -229,23 +228,21 @@ export function createNflAdapter(): SportAdapter {
       );
       const allPicks = (allPicksDtos ?? []).map(p => nflPickToPickView(p, games)).filter((p): p is PickView => p !== null);
       const userPicks = allPicks.filter(p => p.userId === userId);
-      return { season, week: weekNum, isPostSeason: postSeason, games, allPicks: revealPicksForStartedGames(allPicks, games, userId), userPicks, hasOdds, hasActiveGames, requiredPicks: getEspnRequiredPicks(weekNum, postSeason), maxWeek: maxWeekFor(postSeason, nflWeek), maxSeason: season };
+      return { season, week: nflWeek, isPostSeason: postSeason, games, allPicks: revealPicksForStartedGames(allPicks, games, userId), userPicks, hasOdds, hasActiveGames, requiredPicks: getNflRequiredPicks(nflWeek), maxWeek: maxWeekFor(postSeason, nflWeek), maxSeason: season };
     },
 
     async loadHistoricalScores(leagueId, userId, { season, week, isPostSeason }) {
       const frozenData = await loadScoresWithRetry();
-      const frozenIsPostSeason = isPostSeasonHelper(frozenData);
-      const isFrozenWeek = frozenData?.season?.year === season && frozenData?.week?.number === week && frozenIsPostSeason === isPostSeason;
-      const data = isFrozenWeek ? frozenData : await getWeekScores(week, season, isPostSeason);
+      const isFrozenWeek = isFrozenWeekMatch(frozenData, season, week, isPostSeason);
+      const data = isFrozenWeek ? frozenData : await getWeekScores(season, week);
       if (!data?.events?.length) return null;
-      const nflWeek = getWeekFromEspnWeek(week, isPostSeason);
-      const hasOdds = await doOddsExist(leagueId, season, nflWeek);
-      const sc = await buildSpreadCache(data.events, leagueId, season, nflWeek, hasOdds);
+      const hasOdds = await doOddsExist(leagueId, season, week);
+      const sc = await buildSpreadCache(data.events, leagueId, season, week, hasOdds);
       const games = data.events.flatMap(ev => ev.competitions.map(c => competitionToGameView(c, ev, sc)));
-      const allPicksDtos = await getLeaguePicks(leagueId, season, nflWeek);
+      const allPicksDtos = await getLeaguePicks(leagueId, season, week);
       const allPicks = (allPicksDtos ?? []).map(p => nflPickToPickView(p, games)).filter((p): p is PickView => p !== null);
       const userPicks = allPicks.filter(p => p.userId === userId);
-      return { season, week, isPostSeason, games, allPicks, userPicks, hasOdds, hasActiveGames: false, requiredPicks: getEspnRequiredPicks(week, isPostSeason), maxWeek: maxWeekFor(isPostSeason, nflWeek), maxSeason: season };
+      return { season, week, isPostSeason, games, allPicks, userPicks, hasOdds, hasActiveGames: false, requiredPicks: getNflRequiredPicks(week), maxWeek: maxWeekFor(isPostSeason, week), maxSeason: season };
     },
   };
 }

--- a/Client.React/src/test/fixtures.ts
+++ b/Client.React/src/test/fixtures.ts
@@ -175,7 +175,7 @@ export function createSpreadResponse(team: string, spread: number, over?: number
  * createScores'/makeScores' fixture convention (season 2024 unless overridden). */
 export function createCurrentWeek(week: number, postSeason = false, season = 2024) {
   return {
-    weekId: week, espnWeek: week, season, isPostSeason: postSeason,
+    weekId: week, season, isPostSeason: postSeason,
     weekLabel: postSeason ? `Postseason Week ${week}` : `Week ${week}`,
     scoringFormat: 'Standard', spreadLockDatetime: new Date().toISOString(),
   };

--- a/Client.React/src/types/league.ts
+++ b/Client.React/src/types/league.ts
@@ -77,9 +77,10 @@ export interface NflWeekDto {
 
 // GET /api/league/current-week — mirrors CfbSlateDto's role for NFL: the season/week to treat
 // as "current," resolved server-side with a real off-season/pre-season fallback (NflCurrentWeekService).
+// No espnWeek field — nothing on the frontend routes by ESPN's own week numbering anymore,
+// only weekId (frizat-3nv).
 export interface NflCurrentWeekDto {
   weekId: number;
-  espnWeek: number;
   season: number;
   isPostSeason: boolean;
   weekLabel: string;

--- a/Client.React/src/utils/gameHelpers.ts
+++ b/Client.React/src/utils/gameHelpers.ts
@@ -18,12 +18,35 @@ export function isGameDecided(status: GameStatusValue): boolean {
   return isGameFinal(status) || isGameLive(status);
 }
 
+// Converts ESPN's own raw week numbering into our internal WeekId — legitimately still needed
+// wherever raw ESPN data is genuinely being ingested/interpreted (e.g. the frozen demo/replay
+// fixture, which IS a real captured ESPN wire snapshot) — but never for routing/fetching, which
+// is WeekId-primary everywhere now (frizat-3nv).
 export function getWeekFromEspnWeek(week: number, isPostSeason = false) {
   if (!isPostSeason) return week;
   // ESPN skips Pro Bowl (week 4); Super Bowl is ESPN week 5.
-  // NflScoresJob normalizes week 5 → 4 before storing (j == 5 ? 4 : j).
   // DB postseason weeks: WC=19, Div=20, CC=21, SB=22.
   return (week === 5 ? 4 : week) + 18;
+}
+
+// NFL week name/required-picks, keyed by our own internal WeekId (1-18 regular, 19-22
+// postseason) — never ESPN's own week numbering (frizat-3nv). getNflRequiredPicks mirrors
+// GameHelpers.GetRequiredPicks on the backend exactly; getNflWeekName reuses getWeekName's own
+// round-name table below (1-4) rather than re-declaring it, offset by the constant 18 gap
+// between WeekId's postseason range and that table's index.
+export function getNflWeekName(nflWeek: number, isPostSeason = false): string {
+  return getWeekName(isPostSeason ? nflWeek - 18 : nflWeek, isPostSeason);
+}
+
+export function getNflRequiredPicks(nflWeek: number): number {
+  if (nflWeek < 19) return 4;
+  switch (nflWeek) {
+    case 19: return 3;
+    case 20: return 3;
+    case 21: return 2;
+    case 22: return 1;
+    default: throw new Error('Invalid week number');
+  }
 }
 
 export function spreadLabel(spread: number): string {
@@ -66,19 +89,6 @@ export function getWeekName(week: number, isPostSeason = false) {
       return 'Conference Championship';
     case 4:
       return 'Super Bowl';
-    default:
-      throw new Error('Invalid week number');
-  }
-}
-
-export function getEspnRequiredPicks(week: number, isPostSeason = false) {
-  if (!isPostSeason) return 4;
-  switch (week) {
-    case 1: return 3; // Wild Card
-    case 2: return 3; // Divisional
-    case 3: return 2; // Conference Championship
-    case 4:
-    case 5: return 1; // Super Bowl (week 5 in ESPN; week 4 = Pro Bowl)
     default:
       throw new Error('Invalid week number');
   }

--- a/Server.UnitTests/DemoEspnCacheServiceTests.cs
+++ b/Server.UnitTests/DemoEspnCacheServiceTests.cs
@@ -90,7 +90,7 @@ public class DemoEspnCacheServiceTests
 
         var sut = new DemoEspnCacheService(BuildFactory(db), TimeProvider.System);
 
-        var result = await sut.GetWeekScoresAsync(1, 2025, postSeason: true);
+        var result = await sut.GetWeekScoresAsync(2025, 19);
 
         Assert.NotNull(result);
         Assert.NotNull(result!.Events);
@@ -132,7 +132,7 @@ public class DemoEspnCacheServiceTests
         var sut = new DemoEspnCacheService(BuildFactory(db), TimeProvider.System);
 
         // Week 5, regular season — nothing seeded for that combo.
-        var result = await sut.GetWeekScoresAsync(5, 2025, postSeason: false);
+        var result = await sut.GetWeekScoresAsync(2025, 5);
 
         Assert.Null(result);
     }
@@ -172,7 +172,7 @@ public class DemoEspnCacheServiceTests
         var sut = new DemoEspnCacheService(BuildFactory(db), TimeProvider.System);
 
         // Raw ESPN week 5 = Super Bowl = internal WeekId 22 (GameHelpers.GetWeekFromEspnWeek).
-        var result = await sut.GetWeekScoresAsync(5, 2025, postSeason: true);
+        var result = await sut.GetWeekScoresAsync(2025, 22);
 
         Assert.NotNull(result);
         Assert.NotNull(result!.Events);
@@ -224,7 +224,7 @@ public class DemoEspnCacheServiceTests
         var sut = new DemoEspnCacheService(BuildFactory(db), new FakeTimeProvider(frozen));
 
         // Raw ESPN week 3 = Conference Championship = internal WeekId 21 (week + 18).
-        var result = await sut.GetWeekScoresAsync(3, 2025, postSeason: true);
+        var result = await sut.GetWeekScoresAsync(2025, 21);
 
         Assert.NotNull(result);
         Assert.NotNull(result!.Events);

--- a/Server.UnitTests/EspnCacheServiceTests.cs
+++ b/Server.UnitTests/EspnCacheServiceTests.cs
@@ -22,7 +22,7 @@ public class EspnCacheServiceTests
     private readonly IMemoryCache _memoryCache = new MemoryCache(new MemoryCacheOptions());
 
     // Default week returned by the mock — tests that don't care about the specific week use this
-    private static readonly NflWeekInfo DefaultWeek = new(5, 5, 2025, false, "Week 5", "Standard", new DateTime(2025, 10, 2, 18, 0, 0, DateTimeKind.Utc));
+    private static readonly NflWeekInfo DefaultWeek = new(5, 2025, false, "Week 5", "Standard", new DateTime(2025, 10, 2, 18, 0, 0, DateTimeKind.Utc));
 
     private static NflSeasonWeekConfig BuildConfig(int weekId, int season, DateTime? start = null, DateTime? end = null) => new() {
         Id = weekId,
@@ -266,7 +266,7 @@ public class EspnCacheServiceTests
         });
 
         await using var svc = new EspnCacheService(_fetcher, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMinutes(5));
-        var result = await svc.GetWeekScoresAsync(1, 2025, postSeason: true);
+        var result = await svc.GetWeekScoresAsync(2025, 19);
 
         Assert.NotNull(result);
         var comp = result!.Events!.Single().Competitions[0];
@@ -301,7 +301,7 @@ public class EspnCacheServiceTests
         _fetcher.FetchForWeekAsync(Arg.Is<NflSeasonWeekConfig>(c => c.WeekId == 19 && c.Season == 2025)).Returns(Task.FromResult<EspnScores?>(espnScores));
 
         await using var svc = new EspnCacheService(_fetcher, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMinutes(5));
-        var result = await svc.GetWeekScoresAsync(1, 2025, postSeason: true);
+        var result = await svc.GetWeekScoresAsync(2025, 19);
 
         Assert.Same(espnScores, result);
         await _fetcher.Received(1).FetchForWeekAsync(Arg.Is<NflSeasonWeekConfig>(c => c.WeekId == 19 && c.Season == 2025));
@@ -319,7 +319,7 @@ public class EspnCacheServiceTests
         _fetcher.FetchForWeekAsync(Arg.Is<NflSeasonWeekConfig>(c => c.WeekId == 5 && c.Season == 2025)).Returns(Task.FromResult<EspnScores?>(espnScores));
 
         await using var svc = new EspnCacheService(_fetcher, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMinutes(5));
-        var result = await svc.GetWeekScoresAsync(5, 2025, postSeason: false);
+        var result = await svc.GetWeekScoresAsync(2025, 5);
 
         Assert.Same(espnScores, result);
         await _fetcher.Received(1).FetchForWeekAsync(Arg.Is<NflSeasonWeekConfig>(c => c.WeekId == 5 && c.Season == 2025));
@@ -333,7 +333,7 @@ public class EspnCacheServiceTests
         _leagueRepo.GetNflSeasonWeekConfigsAsync().Returns(new List<NflSeasonWeekConfig>());
 
         await using var svc = new EspnCacheService(_fetcher, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMinutes(5));
-        var result = await svc.GetWeekScoresAsync(5, 2025, postSeason: false);
+        var result = await svc.GetWeekScoresAsync(2025, 5);
 
         Assert.Null(result);
         await _fetcher.DidNotReceiveWithAnyArgs().FetchForWeekAsync(default!);
@@ -367,8 +367,8 @@ public class EspnCacheServiceTests
         });
 
         await using var svc = new EspnCacheService(_fetcher, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMinutes(5));
-        var first = await svc.GetWeekScoresAsync(1, 2025, postSeason: false);
-        var second = await svc.GetWeekScoresAsync(1, 2025, postSeason: false);
+        var first = await svc.GetWeekScoresAsync(2025, 1);
+        var second = await svc.GetWeekScoresAsync(2025, 1);
 
         Assert.NotNull(first);
         Assert.NotNull(second);
@@ -399,7 +399,7 @@ public class EspnCacheServiceTests
         _fetcher.FetchForWeekAsync(Arg.Is<NflSeasonWeekConfig>(c => c.WeekId == 3 && c.Season == 2026)).Returns(Task.FromResult<EspnScores?>(espnScores));
 
         await using var svc = new EspnCacheService(_fetcher, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMinutes(5));
-        var result = await svc.GetWeekScoresAsync(3, 2026, postSeason: false);
+        var result = await svc.GetWeekScoresAsync(2026, 3);
 
         await _fetcher.Received(1).FetchForWeekAsync(Arg.Is<NflSeasonWeekConfig>(c => c.WeekId == 3 && c.Season == 2026));
         Assert.Same(espnScores, result);
@@ -431,9 +431,9 @@ public class EspnCacheServiceTests
         });
 
         await using var svc = new EspnCacheService(_fetcher, _nflCurrentWeekService, _leagueRepo, _memoryCache, initialDelay: TimeSpan.FromMinutes(5));
-        await svc.GetWeekScoresAsync(1, 2025, postSeason: false);
+        await svc.GetWeekScoresAsync(2025, 1);
         svc.InvalidateWeekCache(2025, 1);
-        await svc.GetWeekScoresAsync(1, 2025, postSeason: false);
+        await svc.GetWeekScoresAsync(2025, 1);
 
         await _leagueRepo.Received(2).GetNflScoresAsync(2025, 1);
     }

--- a/Server.UnitTests/EspnControllerTests.cs
+++ b/Server.UnitTests/EspnControllerTests.cs
@@ -67,16 +67,16 @@ public class EspnControllerTests
         Assert.IsType<EspnScores>(ok.Value);
     }
 
-    // ── GetWeekScores (proxied from IEspnCacheService — demo-aware, frizat fix for ESPN calls
-    //    bypassing the demo cache abstraction on non-current weeks) ──────────
+    // ── GetWeekScores (proxied from IEspnCacheService — takes our own (season, nflWeek), never
+    //    ESPN's own week numbering — frizat-3nv) ──────────
 
     [Fact]
     public async Task GetWeekScores_ReturnsOk_WithScores()
     {
         var scores = new EspnScores { Season = new Season { Year = 2025 } };
-        _espnCacheService.GetWeekScoresAsync(10, 2025, false).Returns(scores);
+        _espnCacheService.GetWeekScoresAsync(2025, 10).Returns(scores);
 
-        var result = await _sut.GetWeekScores(10, 2025);
+        var result = await _sut.GetWeekScores(2025, 10);
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Same(scores, ok.Value);
@@ -85,9 +85,9 @@ public class EspnControllerTests
     [Fact]
     public async Task GetWeekScores_ReturnsOk_WhenServiceReturnsNull()
     {
-        _espnCacheService.GetWeekScoresAsync(1, 2025, false).Returns((EspnScores?)null);
+        _espnCacheService.GetWeekScoresAsync(2025, 1).Returns((EspnScores?)null);
 
-        var result = await _sut.GetWeekScores(1, 2025);
+        var result = await _sut.GetWeekScores(2025, 1);
 
         // Fail-open: returns empty EspnScores
         var ok = Assert.IsType<OkObjectResult>(result.Result);
@@ -95,13 +95,13 @@ public class EspnControllerTests
     }
 
     [Fact]
-    public async Task GetWeekScores_PassesPostSeasonFlag_ToService()
+    public async Task GetWeekScores_PassesPostseasonWeekId_ToService()
     {
-        _espnCacheService.GetWeekScoresAsync(1, 2025, true).Returns(new EspnScores());
+        _espnCacheService.GetWeekScoresAsync(2025, 19).Returns(new EspnScores());
 
-        await _sut.GetWeekScores(1, 2025, postSeason: true);
+        await _sut.GetWeekScores(2025, 19);
 
-        await _espnCacheService.Received(1).GetWeekScoresAsync(1, 2025, true);
+        await _espnCacheService.Received(1).GetWeekScoresAsync(2025, 19);
     }
 
     // ── GetCfbScores (cached, current slate — mirrors GetScores for NFL) ─────

--- a/Server.UnitTests/NflCurrentWeekEndpointTests.cs
+++ b/Server.UnitTests/NflCurrentWeekEndpointTests.cs
@@ -49,7 +49,7 @@ public class NflCurrentWeekEndpointTests
     public async Task GetCurrentWeek_ReturnsWeekInfo_FromNflCurrentWeekService()
     {
         var svc = Substitute.For<INflCurrentWeekService>();
-        var info = new NflWeekInfo(6, 6, 2026, false, "Week 6", "Standard", new DateTime(2026, 10, 8, 18, 0, 0, DateTimeKind.Utc));
+        var info = new NflWeekInfo(6, 2026, false, "Week 6", "Standard", new DateTime(2026, 10, 8, 18, 0, 0, DateTimeKind.Utc));
         svc.GetCurrentWeekAsync().Returns(info);
 
         var result = await BuildController(svc).GetCurrentWeek(svc);
@@ -68,7 +68,7 @@ public class NflCurrentWeekEndpointTests
         // (most recent completed week, or upcoming Week 1) — the controller just passes it through
         // unconditionally rather than re-implementing any of that logic.
         var svc = Substitute.For<INflCurrentWeekService>();
-        var info = new NflWeekInfo(18, 18, 2025, false, "Week 18", "Standard", new DateTime(2026, 1, 4, 18, 0, 0, DateTimeKind.Utc));
+        var info = new NflWeekInfo(18, 2025, false, "Week 18", "Standard", new DateTime(2026, 1, 4, 18, 0, 0, DateTimeKind.Utc));
         svc.GetCurrentWeekAsync().Returns(info);
 
         var result = await BuildController(svc).GetCurrentWeek(svc);

--- a/Server.UnitTests/NflCurrentWeekServiceTests.cs
+++ b/Server.UnitTests/NflCurrentWeekServiceTests.cs
@@ -102,10 +102,12 @@ public class NflCurrentWeekServiceTests
         Assert.Equal(5, result.WeekId);
     }
 
+    // frizat-3nv: NflWeekInfo no longer carries an EspnWeek field at all — nothing on the
+    // backend or frontend needs ESPN's own week numbering anymore, only WeekId. ToWeekInfo's
+    // former WeekId->EspnWeek mapping (and its unconditional, non-season-gated Pro-Bowl-skip
+    // special case, flagged separately under frizat-4k9) is gone, not relocated.
     [Fact]
-    public async Task GetCurrentWeekAsync_MapsEspnWeek_ForPostseasonRounds() {
-        // ToWeekInfo's WeekId -> ESPN week mapping is unchanged by this refactor — Super
-        // Bowl (WeekId 22) maps to ESPN week 5 (ESPN skips week 4 = Pro Bowl).
+    public async Task GetCurrentWeekAsync_ResolvesPostseasonRounds_ByWeekIdOnly() {
         var now = DateTime.UtcNow;
         var svc = BuildService([
             Config(2025, 22, now.AddDays(-1), now.AddDays(1)),
@@ -114,7 +116,6 @@ public class NflCurrentWeekServiceTests
         var result = await svc.GetCurrentWeekAsync();
 
         Assert.Equal(22, result.WeekId);
-        Assert.Equal(5, result.EspnWeek);
         Assert.True(result.IsPostSeason);
     }
 

--- a/Server.UnitTests/NflScoresJobTests.cs
+++ b/Server.UnitTests/NflScoresJobTests.cs
@@ -42,7 +42,7 @@ public class NflScoresJobTests
         // unscoped weekList sync override this explicitly below.
         _currentWeekService.IsSeasonActiveAsync().Returns(true);
         _currentWeekService.GetCurrentWeekAsync().Returns(new NflWeekInfo(
-            WeekId: 1, EspnWeek: 1, Season: _year, IsPostSeason: false,
+            WeekId: 1, Season: _year, IsPostSeason: false,
             WeekLabel: "Week 1", ScoringFormat: "Standard", SpreadLockDatetime: DateTime.UtcNow.AddDays(-1)));
         // NflScoresJob filters the current season's rows out of the one unscoped fetch (no
         // second, season-scoped DB call) — see Execute_FetchesOnlyTheCurrentSeasonsConfigs...

--- a/Server.UnitTests/NflSpreadJobTests.cs
+++ b/Server.UnitTests/NflSpreadJobTests.cs
@@ -37,7 +37,7 @@ public class NflSpreadJobTests
     // happy-path tests.
     private static readonly DateTime PastLockTime = FakeNow.UtcDateTime.AddDays(-1);
     private static readonly DateTime FutureLockTime = FakeNow.UtcDateTime.AddDays(1);
-    private static readonly NflWeekInfo DefaultWeek = new(5, 5, 2024, false, "Week 5", "Standard", PastLockTime);
+    private static readonly NflWeekInfo DefaultWeek = new(5, 2024, false, "Week 5", "Standard", PastLockTime);
 
     public NflSpreadJobTests()
     {
@@ -537,7 +537,7 @@ public class NflSpreadJobTests
     public async Task Execute_PostSeasonConferenceChampionshipWeek_IsNotTreatedAsByeWeek()
     {
         _nflCurrentWeekService.GetCurrentWeekAsync()
-            .Returns(new NflWeekInfo(21, 3, 2024, true, "Conference Championship", "Standard", PastLockTime));
+            .Returns(new NflWeekInfo(21, 2024, true, "Conference Championship", "Standard", PastLockTime));
         _repo.GetNflSeasonWeekConfigsAsync(2024).Returns(new List<NflSeasonWeekConfig> { BuildConfig(weekId: 21, season: 2024) });
         _fetcher.FetchForWeekAsync(Arg.Any<NflSeasonWeekConfig>())
                 .Returns(BuildScoreboard(weekNumber: 3, seasonType: (int)TypeOfSeason.PostSeason));
@@ -556,9 +556,9 @@ public class NflSpreadJobTests
     [Fact]
     public async Task Execute_PostSeasonWeek1_MapsToWeek19()
     {
-        // Wild Card: NflCurrentWeekService returns WeekId=19, EspnWeek=1, IsPostSeason=true
+        // Wild Card: NflCurrentWeekService returns WeekId=19, IsPostSeason=true
         _nflCurrentWeekService.GetCurrentWeekAsync()
-            .Returns(new NflWeekInfo(19, 1, 2024, true, "Wild Card Weekend", "Standard", PastLockTime));
+            .Returns(new NflWeekInfo(19, 2024, true, "Wild Card Weekend", "Standard", PastLockTime));
         _repo.GetNflSeasonWeekConfigsAsync(2024).Returns(new List<NflSeasonWeekConfig> { BuildConfig(weekId: 19, season: 2024) });
         _fetcher.FetchForWeekAsync(Arg.Any<NflSeasonWeekConfig>())
                 .Returns(BuildScoreboard(weekNumber: 1, seasonType: (int)TypeOfSeason.PostSeason));
@@ -584,7 +584,7 @@ public class NflSpreadJobTests
     public async Task Execute_LockTimeInFuture_NoForce_SkipsWithoutFetching()
     {
         _nflCurrentWeekService.GetCurrentWeekAsync()
-            .Returns(new NflWeekInfo(5, 5, 2024, false, "Week 5", "Standard", FutureLockTime));
+            .Returns(new NflWeekInfo(5, 2024, false, "Week 5", "Standard", FutureLockTime));
 
         await BuildJob().Execute(_context);
 
@@ -596,7 +596,7 @@ public class NflSpreadJobTests
     public async Task Execute_LockTimeInFuture_Forced_WritesAnyway()
     {
         _nflCurrentWeekService.GetCurrentWeekAsync()
-            .Returns(new NflWeekInfo(5, 5, 2024, false, "Week 5", "Standard", FutureLockTime));
+            .Returns(new NflWeekInfo(5, 2024, false, "Week 5", "Standard", FutureLockTime));
         var forceMap = new JobDataMap();
         forceMap.Put("force", true);
         _context.MergedJobDataMap.Returns(forceMap);

--- a/Server.UnitTests/PicksTests.cs
+++ b/Server.UnitTests/PicksTests.cs
@@ -4,6 +4,7 @@ using FourPlayWebApp.Server.Models.Identity;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models;
+using FourPlayWebApp.Shared.Models.Data;
 using FourPlayWebApp.Shared.Models.Data.Dtos;
 using FourPlayWebApp.Shared.Models.Enum;
 using Microsoft.AspNetCore.Http;
@@ -72,8 +73,16 @@ public class PicksTests
         TestPrincipalFactory.Build(userId);
 
     /// <summary>
+    /// AddPicks's kickoff guard is now a pure NflSpreads.GameTime check (frizat-3nv) — one
+    /// spread row for BUF vs MIA at the given kickoff, scoped to this file's Season/Week.
+    /// </summary>
+    private static List<NflSpreads> MakeSpreads(DateTimeOffset bufMiaKickoff) =>
+        [ new NflSpreads { Season = Season, NflWeek = Week, HomeTeam = "BUF", AwayTeam = "MIA", GameTime = bufMiaKickoff } ];
+
+    /// <summary>
     /// Builds a minimal ESPN scores payload with two games:
     /// BUF vs MIA (at <paramref name="bufMiaKickoff"/>) and DAL vs NYG (in the future).
+    /// Only used by GetLeaguePicks tests below — AddPicks no longer reads ESPN at all.
     /// </summary>
     private static EspnScores BuildScores(DateTimeOffset bufMiaKickoff)
     {
@@ -132,7 +141,7 @@ public class PicksTests
     private static INflCurrentWeekService BuildCurrentWeekService(int week = Week, int season = Season)
     {
         var svc = Substitute.For<INflCurrentWeekService>();
-        svc.GetCurrentWeekAsync().Returns(new NflWeekInfo(week, week, season, false, "Week", "PickAgainstSpread", DateTime.UtcNow.AddDays(-1)));
+        svc.GetCurrentWeekAsync().Returns(new NflWeekInfo(week, season, false, "Week", "PickAgainstSpread", DateTime.UtcNow.AddDays(-1)));
         return svc;
     }
 
@@ -148,11 +157,9 @@ public class PicksTests
         repo.GetNflWeeksAsync(Season).Returns([MakeNflWeek()]);
         repo.UserExistsInLeagueAsync(UserId, LeagueId).Returns(true);
         repo.GetUserNflPicksAsync(UserId, LeagueId, Season, Week).Returns([]);
+        repo.GetNflSpreadsAsync(Season, Week).Returns(MakeSpreads(pastKickoff));
 
-        var espn = Substitute.For<IEspnCacheService>();
-        espn.GetScoresAsync().Returns(BuildScores(pastKickoff));
-
-        var controller = BuildController(repo, espn, BuildPrincipal(UserId));
+        var controller = BuildController(repo, Substitute.For<IEspnCacheService>(), BuildPrincipal(UserId));
         var picks = new[] { MakePick("BUF") };
 
         // Act
@@ -174,11 +181,9 @@ public class PicksTests
         repo.UserExistsInLeagueAsync(UserId, LeagueId).Returns(true);
         repo.GetUserNflPicksAsync(UserId, LeagueId, Season, Week).Returns([]);
         repo.AddNflPicksAsync(Arg.Any<IEnumerable<NflPicks>>()).Returns(Task.CompletedTask);
+        repo.GetNflSpreadsAsync(Season, Week).Returns(MakeSpreads(futureKickoff));
 
-        var espn = Substitute.For<IEspnCacheService>();
-        espn.GetScoresAsync().Returns(BuildScores(futureKickoff));
-
-        var controller = BuildController(repo, espn, BuildPrincipal(UserId));
+        var controller = BuildController(repo, Substitute.For<IEspnCacheService>(), BuildPrincipal(UserId));
         var picks = new[] { MakePick("BUF") };
 
         // Act
@@ -192,13 +197,11 @@ public class PicksTests
     [Fact]
     public async Task AddPicks_TeamNameCollisionInDifferentWeekSeason_DoesNotFalselyReject()
     {
-        // Regression: the kickoff guard used to match a pick's team against ANY cached ESPN
-        // competition by abbreviation alone, ignoring season/week — so a historical pick for
-        // "BUF" in Week 5/2023 got wrongly rejected just because the CURRENTLY cached event
-        // happens to also involve BUF (in an unrelated Week 2/2024 game that already kicked
-        // off). Real-world case: restoring historical picks whose team happened to also be
-        // playing in the live/most-recent cached game.
-        var pastKickoff = DateTimeOffset.UtcNow.AddHours(-2);
+        // Regression (historical, when this guard read a shared live ESPN cache): a pick's team
+        // could get wrongly rejected because an UNRELATED week/season's cached event happened to
+        // involve the same team abbreviation. The guard now fetches NflSpreads scoped to the
+        // pick's own (Season, NflWeek) — Season/Week 2024/2 having an already-kicked-off BUF
+        // game is structurally irrelevant to a 2023/Week 5 pick, since that query is never made.
         const int historicalSeason = 2023;
         const int historicalWeek = 5;
 
@@ -207,45 +210,38 @@ public class PicksTests
         repo.UserExistsInLeagueAsync(UserId, LeagueId).Returns(true);
         repo.GetUserNflPicksAsync(UserId, LeagueId, historicalSeason, historicalWeek).Returns([]);
         repo.AddNflPicksAsync(Arg.Any<IEnumerable<NflPicks>>()).Returns(Task.CompletedTask);
+        // No spreads seeded for (historicalSeason, historicalWeek) — nothing to reject against.
+        repo.GetNflSpreadsAsync(Season, Week).Returns(MakeSpreads(DateTimeOffset.UtcNow.AddHours(-2))); // unrelated week/season, must never be consulted
 
-        var espn = Substitute.For<IEspnCacheService>();
-        espn.GetScoresAsync().Returns(BuildScores(pastKickoff)); // cached: BUF vs MIA, Week 2/2024, already kicked off
-
-        var controller = BuildController(repo, espn, BuildPrincipal(UserId));
+        var controller = BuildController(repo, Substitute.For<IEspnCacheService>(), BuildPrincipal(UserId));
         var picks = new[] { new NflPickDto {
             LeagueId = LeagueId, UserId = UserId, Team = "BUF", Pick = PickType.Spread,
             NflWeek = historicalWeek, Season = historicalSeason,
         } };
 
-        // Act — this pick's own week (2023/Wk5) is what must match "current," not the
-        // unrelated cached ESPN event's week (2024/Wk2, the source of the collision bug).
         var result = await controller.AddPicks(picks, BuildCurrentWeekService(historicalWeek, historicalSeason));
 
-        // Assert — BUF's Week 2/2024 kickoff is irrelevant to this Week 5/2023 pick
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Equal(1, ok.Value);
+        await repo.DidNotReceive().GetNflSpreadsAsync(Season, Week);
     }
 
     [Fact]
-    public async Task AddPicks_WhenEspnCacheIsEmpty_AllowsPicks()
+    public async Task AddPicks_WhenNoSpreadsExistForTheWeek_AllowsPicks()
     {
-        // Arrange — ESPN cache cold / unavailable; should not block picks
+        // Spreads not released yet for this week — nothing to reject against.
         var repo = Substitute.For<ILeagueRepository>();
         repo.GetNflWeeksAsync(Season).Returns([MakeNflWeek()]);
         repo.UserExistsInLeagueAsync(UserId, LeagueId).Returns(true);
         repo.GetUserNflPicksAsync(UserId, LeagueId, Season, Week).Returns([]);
         repo.AddNflPicksAsync(Arg.Any<IEnumerable<NflPicks>>()).Returns(Task.CompletedTask);
+        repo.GetNflSpreadsAsync(Season, Week).Returns((List<NflSpreads>?)null);
 
-        var espn = Substitute.For<IEspnCacheService>();
-        espn.GetScoresAsync().Returns((EspnScores?)null);
-
-        var controller = BuildController(repo, espn, BuildPrincipal(UserId));
+        var controller = BuildController(repo, Substitute.For<IEspnCacheService>(), BuildPrincipal(UserId));
         var picks = new[] { MakePick("BUF") };
 
-        // Act
         var result = await controller.AddPicks(picks, BuildCurrentWeekService());
 
-        // Assert — no ESPN data → fail open, let picks through
         Assert.IsType<OkObjectResult>(result.Result);
     }
 

--- a/Server.UnitTests/SpreadLockScheduleEndpointTests.cs
+++ b/Server.UnitTests/SpreadLockScheduleEndpointTests.cs
@@ -53,7 +53,7 @@ public class SpreadLockScheduleEndpointTests
     {
         var repo = Substitute.For<ILeagueRepository>();
         var svc = Substitute.For<INflCurrentWeekService>();
-        svc.GetCurrentWeekAsync().Returns(new NflWeekInfo(3, 3, 2026, false, "Week 3", "Standard", DateTime.UtcNow));
+        svc.GetCurrentWeekAsync().Returns(new NflWeekInfo(3, 2026, false, "Week 3", "Standard", DateTime.UtcNow));
         repo.GetNflSeasonWeekConfigsAsync().Returns([
             new NflSeasonWeekConfig { Season = 2026, WeekId = 2, WeekLabel = "Week 2", SpreadLockDatetime = new DateTime(2026, 9, 10, 18, 0, 0, DateTimeKind.Utc) },
             new NflSeasonWeekConfig { Season = 2026, WeekId = 1, WeekLabel = "Week 1", SpreadLockDatetime = new DateTime(2026, 9, 3, 18, 0, 0, DateTimeKind.Utc) },

--- a/Server/Controllers/CfbPicksController.cs
+++ b/Server/Controllers/CfbPicksController.cs
@@ -144,9 +144,8 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
 
     // CFB has no live ESPN status feed the way NFL does (see cfbAdapter.ts) — CfbSpreads.GameTime
     // is the source of truth for kickoff time, same as the frontend's own gameIsLocked check.
-    // Returns both home and away team names for started games — a pick can be on either side.
-    private static HashSet<string> StartedTeams(IEnumerable<CfbSpreads> spreads, DateTimeOffset now) =>
-        spreads.Where(s => s.GameTime <= now).SelectMany(s => new[] { s.HomeTeam, s.AwayTeam }).ToHashSet();
+    // GameHelpers.StartedTeams (shared with LeagueController's identical NFL guard) returns both
+    // home and away team names for started games — a pick can be on either side.
 
     [HttpGet("picks/{leagueId}/{cfbSlateId}")]
     public async Task<IActionResult> GetAllPicks(int leagueId, int cfbSlateId) {
@@ -165,7 +164,7 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
         // Hide other users' picks for games that haven't kicked off yet — same rule as NFL's
         // GetLeaguePicks. Admins always see all picks, same as NFL.
         if (!isAdmin) {
-            var startedTeams = StartedTeams(spreadsTask.Result, DateTimeOffset.UtcNow);
+            var startedTeams = GameHelpers.StartedTeams(spreadsTask.Result, DateTimeOffset.UtcNow, s => s.GameTime, s => s.HomeTeam, s => s.AwayTeam);
             allPicks = allPicks
                 .Where(p => p.UserId == callerId || startedTeams.Contains(p.Team))
                 .ToList();
@@ -224,7 +223,7 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
         // Guard: reject picks for any game that has already kicked off. Matched by team name
         // (either side) rather than an ESPN id — a team plays at most one game per slate, so
         // Team alone unambiguously identifies which CfbSpreads row a pick belongs to.
-        var startedTeams = StartedTeams(spreadsTask.Result, DateTimeOffset.UtcNow);
+        var startedTeams = GameHelpers.StartedTeams(spreadsTask.Result, DateTimeOffset.UtcNow, s => s.GameTime, s => s.HomeTeam, s => s.AwayTeam);
 
         // Guard: reject picks for a team we KNOW is excluded from the league (MAC Tue/Wed,
         // unranked, etc. — frizat-9m0). Distinct from "no matching spread at all", which stays

--- a/Server/Controllers/EspnController.cs
+++ b/Server/Controllers/EspnController.cs
@@ -17,11 +17,13 @@ public class EspnController(
     ICfbLiveScoreFetcher cfbFetcher,
     ICfbRepository cfbRepo)
     : ControllerBase {
-    [HttpGet("scores/week/{week:int}/{year:int}")]
+    // Route is our own (season, nflWeek) — NflSeasonWeekConfig.WeekId — never ESPN's own week
+    // numbering, matching GetCfbScoresForSlate's shape below (frizat-3nv).
+    [HttpGet("scores/nfl-week/{season:int}/{nflWeek:int}")]
     [ProducesResponseType(typeof(EspnScores), StatusCodes.Status200OK)]
-    public async Task<ActionResult<EspnScores?>> GetWeekScores(int week, int year, [FromQuery] bool postSeason = false)
+    public async Task<ActionResult<EspnScores?>> GetWeekScores(int season, int nflWeek)
     {
-        var scores = await espnCacheService.GetWeekScoresAsync(week, year, postSeason);
+        var scores = await espnCacheService.GetWeekScoresAsync(season, nflWeek);
         return Ok(scores ?? new EspnScores());
     }
 

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -338,6 +338,9 @@ public class LeagueController(
         // Hide other users' picks for games that haven't kicked off yet.
         // Mirrors revealPicksForStartedGames on the frontend — same "not STATUS_SCHEDULED" rule.
         // Admins always see all picks. Fails open if ESPN cache is unavailable.
+        // Deliberately still ESPN-live, unlike AddPicks's kickoff guard below (frizat-3nv, now DB-
+        // only) — this needs the game's real live status (a delayed/moved kickoff can outlive its
+        // own scheduled NflSpreads.GameTime), not just a scheduled timestamp comparison.
         if (!User.IsInRole(AppRoles.Administrator)) {
             var espnScores = await espnCacheService.GetScoresAsync();
             if (espnScores?.Events is not null) {
@@ -405,16 +408,16 @@ public class LeagueController(
         if (!isMember)
             return Forbid();
 
-        // Fetch weeks, ESPN scores, existing picks, and the current-week guard concurrently —
-        // none of these depend on each other's results.
+        // Fetch weeks, this week's spreads, existing picks, and the current-week guard
+        // concurrently — none of these depend on each other's results.
         var weekTask          = repo.GetNflWeeksAsync(first.Season);
-        var espnTask          = espnCacheService.GetScoresAsync();
+        var spreadsTask       = repo.GetNflSpreadsAsync(first.Season, first.NflWeek);
         var existingPicksTask = repo.GetUserNflPicksAsync(authenticatedUserId, first.LeagueId, first.Season, first.NflWeek);
         var currentWeekTask   = currentWeekService.GetCurrentWeekAsync();
-        await Task.WhenAll(weekTask, espnTask, existingPicksTask, currentWeekTask);
+        await Task.WhenAll(weekTask, spreadsTask, existingPicksTask, currentWeekTask);
 
         var weekId        = weekTask.Result;
-        var espnScores    = espnTask.Result;
+        var spreads       = spreadsTask.Result ?? [];
         var existingPicks = existingPicksTask.Result;
 
         // Guard: picks are only accepted for the currently open week per the control table —
@@ -443,28 +446,15 @@ public class LeagueController(
             });
         }
 
-        // Guard: reject picks for any game that has already kicked off
-        if (espnScores?.Events is null)
+        // Guard: reject picks for any game that has already kicked off. Pure control-table
+        // timestamp check — shares GameHelpers.StartedTeams with CfbPicksController's identical
+        // guard (frizat-3nv). Never trusts live ESPN data as a decision input, and can't fail
+        // open the way the previous ESPN-cache-based version did (a DB read can't be "unavailable").
+        var startedTeams = GameHelpers.StartedTeams(spreads, DateTimeOffset.UtcNow, s => s.GameTime, s => s.HomeTeam, s => s.AwayTeam);
+        foreach (var pick in picksList)
         {
-            logger.LogWarning("AddPicks: ESPN cache is unavailable — kickoff guard skipped for user {UserId} league {LeagueId}", authenticatedUserId, first.LeagueId);
-        }
-        else
-        {
-            var now = DateTimeOffset.UtcNow;
-            foreach (var pick in picksList)
-            {
-                // Scope the match to the SAME season/week as the pick — matching by team
-                // abbreviation alone let a historical pick get falsely rejected whenever that
-                // team also happened to appear in the currently-cached (unrelated) event.
-                var competition = espnScores.Events
-                    .Where(e => e.Season.Year == pick.Season &&
-                                GameHelpers.GetWeekFromEspnWeek(e.Week.Number, (int)e.Season.Year, e.IsPostSeason()) == pick.NflWeek)
-                    .SelectMany(e => e.Competitions)
-                    .FirstOrDefault(c =>
-                        c.Competitors.Any(comp => string.Equals(comp.Team?.Abbreviation, pick.Team, StringComparison.OrdinalIgnoreCase)));
-                if (competition is not null && competition.Date <= now)
-                    return BadRequest($"Pick rejected: {pick.Team}'s game has already kicked off.");
-            }
+            if (startedTeams.Contains(pick.Team))
+                return BadRequest($"Pick rejected: {pick.Team}'s game has already kicked off.");
         }
 
         var existingKeys = existingPicks

--- a/Server/Services/DemoEspnCacheService.cs
+++ b/Server/Services/DemoEspnCacheService.cs
@@ -51,16 +51,14 @@ public class DemoEspnCacheService : IEspnCacheService
     // constructor-injecting the Scoped INflCurrentWeekService into this Singleton — but must use
     // the SAME keyed clock NflCurrentWeekService resolves "current" against (frizat-tf2), or this
     // and NflCurrentWeekService can silently disagree on what "current" is in DEMO_MODE.
-    public async Task<EspnScores?> GetWeekScoresAsync(int week, int year, bool postSeason = false)
+    public async Task<EspnScores?> GetWeekScoresAsync(int season, int nflWeek)
     {
-        var nflWeek = GameHelpers.GetWeekFromEspnWeek(week, year, postSeason);
-
         await using var db = await _dbContextFactory.CreateDbContextAsync();
 
         var configs = await db.NflSeasonWeekConfigs.ToListAsync();
         var windows = configs.Select(c => new SeasonWindowResolver.WeekWindow(c.Season, c.WeekStartDatetime, c.WeekEndDatetime, c.SpreadLockDatetime));
         var resolvedCurrent = SeasonWindowResolver.ResolveCurrentWeek(windows, _timeProvider.GetUtcNow().UtcDateTime);
-        var matchingConfig = configs.FirstOrDefault(c => c.Season == year && c.WeekId == nflWeek);
+        var matchingConfig = configs.FirstOrDefault(c => c.Season == season && c.WeekId == nflWeek);
         var isResolvedCurrentWeek = matchingConfig is not null && resolvedCurrent is not null
             && resolvedCurrent.Value.Season == matchingConfig.Season
             && resolvedCurrent.Value.Start == matchingConfig.WeekStartDatetime
@@ -69,7 +67,7 @@ public class DemoEspnCacheService : IEspnCacheService
         if (isResolvedCurrentWeek) return _scores;
 
         var rows = await db.NflScores
-            .Where(s => s.Season == year && s.NflWeek == nflWeek)
+            .Where(s => s.Season == season && s.NflWeek == nflWeek)
             .ToListAsync();
 
         if (rows.Count == 0) return null;
@@ -77,7 +75,7 @@ public class DemoEspnCacheService : IEspnCacheService
         var games = rows.Select(row => new FinalScoresEspnMapper.FinishedGame(
             row.Id.ToString(), row.HomeTeam, row.AwayTeam, row.HomeTeamScore, row.AwayTeamScore, row.GameTime));
 
-        return FinalScoresEspnMapper.Build(games, year, week, postSeason);
+        return FinalScoresEspnMapper.Build(games, season, nflWeek, matchingConfig?.WeekType == "PostSeason");
     }
 
     // No-op: demo data is a frozen fixture, never refreshed by a live NflScoresJob upsert.

--- a/Server/Services/EspnCacheService.cs
+++ b/Server/Services/EspnCacheService.cs
@@ -61,21 +61,19 @@ public class EspnCacheService : IEspnCacheService, IAsyncDisposable
     // multi-game week finishes and gets persisted, the response is built from only that game and
     // cached forever — every other game in that week, including ones that finish and get
     // persisted later, is permanently dropped from every future response.
-    public async Task<EspnScores?> GetWeekScoresAsync(int week, int year, bool postSeason = false)
+    public async Task<EspnScores?> GetWeekScoresAsync(int season, int nflWeek)
     {
-        var nflWeek = GameHelpers.GetWeekFromEspnWeek(week, year, postSeason);
-
-        // Cache key is the resolved internal (season, WeekId), not the raw incoming ESPN-style
-        // params — matches CfbLiveScoreFetcher's cfb-slate-scores_{slateId} shape and is what
+        // Cache key is the resolved internal (season, WeekId) — matches
+        // CfbLiveScoreFetcher's cfb-slate-scores_{slateId} shape and is what
         // InvalidateWeekCache(season, week) can actually address after an upsert.
-        var cacheKey = $"nfl-week-scores_{year}_{nflWeek}";
+        var cacheKey = $"nfl-week-scores_{season}_{nflWeek}";
         if (_historicalCache.TryGetValue<EspnScores>(cacheKey, out var cached)) return cached;
 
         // One unscoped fetch serves both purposes below — finding this week's own row and
         // resolving which week SeasonWindowResolver currently treats as "current" needs the
         // full set of configs either way.
         var allConfigs = await _leagueRepository.GetNflSeasonWeekConfigsAsync();
-        var matchingConfig = allConfigs.FirstOrDefault(c => c.Season == year && c.WeekId == nflWeek);
+        var matchingConfig = allConfigs.FirstOrDefault(c => c.Season == season && c.WeekId == nflWeek);
 
         // The control-table-resolved CURRENT week is always live-fetched, even if its own
         // calendar window already looks "ended" by the 6-hour buffer below —
@@ -100,11 +98,15 @@ public class EspnCacheService : IEspnCacheService, IAsyncDisposable
         var weekHasEnded = !isResolvedCurrentWeek && matchingConfig is not null && matchingConfig.WeekEndDatetime.AddHours(6) < DateTime.UtcNow;
 
         if (weekHasEnded) {
-            var rows = await _leagueRepository.GetNflScoresAsync(year, nflWeek);
+            var rows = await _leagueRepository.GetNflScoresAsync(season, nflWeek);
             if (rows.Count > 0) {
                 var games = rows.Select(row => new FinalScoresEspnMapper.FinishedGame(
                     row.Id.ToString(), row.HomeTeam, row.AwayTeam, row.HomeTeamScore, row.AwayTeamScore, row.GameTime));
-                var built = FinalScoresEspnMapper.Build(games, year, week, postSeason);
+                // NB: the built EspnScores.Week.Number below holds our internal nflWeek, not
+                // ESPN's real week number the live-fetch path (_fetcher.FetchForWeekAsync) would
+                // have put there — no current consumer reads this field from a live response for
+                // a decision, but it's a real seam the full frizat-3nv GameData DTO would close.
+                var built = FinalScoresEspnMapper.Build(games, season, nflWeek, matchingConfig!.WeekType == "PostSeason");
                 _historicalCache.Set(cacheKey, built);
                 return built;
             }

--- a/Server/Services/Interfaces/IEspnCacheService.cs
+++ b/Server/Services/Interfaces/IEspnCacheService.cs
@@ -4,7 +4,9 @@ namespace FourPlayWebApp.Server.Services.Interfaces;
 public interface IEspnCacheService
 {
     Task<EspnScores?> GetScoresAsync();
-    Task<EspnScores?> GetWeekScoresAsync(int week, int year, bool postSeason = false);
+    // (season, nflWeek) — our own internal NflSeasonWeekConfig.WeekId, never ESPN's own week
+    // numbering (frizat-3nv: the caller no longer needs to know ESPN's numbering exists at all).
+    Task<EspnScores?> GetWeekScoresAsync(int season, int nflWeek);
     // Evicts the cached historical reconstruction for one (season, internal NflWeek) so a fresh
     // NflScoresJob upsert is visible immediately instead of waiting for a process restart —
     // mirrors ICfbLiveScoreFetcher.InvalidateSlateCache.

--- a/Server/Services/Interfaces/INflCurrentWeekService.cs
+++ b/Server/Services/Interfaces/INflCurrentWeekService.cs
@@ -1,6 +1,8 @@
 namespace FourPlayWebApp.Server.Services.Interfaces;
 
-public record NflWeekInfo(int WeekId, int EspnWeek, int Season, bool IsPostSeason, string WeekLabel, string ScoringFormat, DateTime SpreadLockDatetime);
+// No EspnWeek field — every consumer (backend and frontend) now routes purely by WeekId (our
+// own control table), never ESPN's own numbering. See frizat-3nv.
+public record NflWeekInfo(int WeekId, int Season, bool IsPostSeason, string WeekLabel, string ScoringFormat, DateTime SpreadLockDatetime);
 
 public interface INflCurrentWeekService {
     Task<NflWeekInfo> GetCurrentWeekAsync();

--- a/Server/Services/NflCurrentWeekService.cs
+++ b/Server/Services/NflCurrentWeekService.cs
@@ -28,14 +28,6 @@ public class NflCurrentWeekService(ILeagueRepository repo, [FromKeyedServices(Cu
 
     private static NflWeekInfo ToWeekInfo(Models.Data.NflSeasonWeekConfig cfg) {
         var isPostSeason = cfg.WeekId > 18;
-        var espnWeek = cfg.WeekId switch {
-            <= 18 => cfg.WeekId,
-            19    => 1,  // Wild Card
-            20    => 2,  // Divisional
-            21    => 3,  // Conference Championship
-            22    => 5,  // Super Bowl (ESPN skips week 4 = Pro Bowl)
-            _     => cfg.WeekId
-        };
-        return new NflWeekInfo(cfg.WeekId, espnWeek, cfg.Season, isPostSeason, cfg.WeekLabel, cfg.ScoringFormat, cfg.SpreadLockDatetime);
+        return new NflWeekInfo(cfg.WeekId, cfg.Season, isPostSeason, cfg.WeekLabel, cfg.ScoringFormat, cfg.SpreadLockDatetime);
     }
 }

--- a/Server/Services/ReplayCacheService.cs
+++ b/Server/Services/ReplayCacheService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Shared.Helpers;
 using FourPlayWebApp.Shared.Helpers.Extensions;
 using FourPlayWebApp.Shared.Models;
 using Serilog;
@@ -75,10 +76,14 @@ public class ReplayCacheService : IEspnCacheService, ICfbCacheService {
     // Replay mode drives one fixed game through scheduled->final — it has no concept of "other
     // weeks". Only serve a result when the request matches the current snapshot's own week;
     // never fall through to a real ESPN call (that would defeat the point of replay/demo mode).
-    public Task<EspnScores?> GetWeekScoresAsync(int week, int year, bool postSeason = false) {
+    // The snapshot's own Week.Number is real captured ESPN wire data (frizat-703.5 fixtures), so
+    // it's converted to our internal WeekId to compare against the caller's now-internal request.
+    public Task<EspnScores?> GetWeekScoresAsync(int season, int nflWeek) {
         var current = _snapshots[_index];
-        var matches = current.Season?.Year == year && current.Week?.Number == week &&
-                      current.IsPostSeason() == postSeason;
+        var currentNflWeek = current.Week?.Number is { } w
+            ? GameHelpers.GetWeekFromEspnWeek(w, (int)(current.Season?.Year ?? 0), current.IsPostSeason())
+            : (int?)null;
+        var matches = current.Season?.Year == season && currentNflWeek == nflWeek;
         return Task.FromResult(matches ? current : null);
     }
 

--- a/Shared/Helpers/GameHelpers.cs
+++ b/Shared/Helpers/GameHelpers.cs
@@ -193,6 +193,14 @@ public static class GameHelpers {
         var times = gameTimes as ICollection<DateTimeOffset> ?? gameTimes.ToList();
         return times.Count > 0 && times.All(t => t <= now);
     }
+
+    // Shared by LeagueController.AddPicks (NflSpreads) and CfbPicksController.AddPicks
+    // (CfbSpreads) — was two byte-identical private methods, one per controller, differing only
+    // in the spread row's concrete type. Pure control-table timestamp check, no ESPN dependency.
+    public static HashSet<string> StartedTeams<T>(
+        IEnumerable<T> spreads, DateTimeOffset now,
+        Func<T, DateTimeOffset> gameTime, Func<T, string> homeTeam, Func<T, string> awayTeam) =>
+        spreads.Where(s => gameTime(s) <= now).SelectMany(s => new[] { homeTeam(s), awayTeam(s) }).ToHashSet();
     public static bool IsGameOver(Competition competition) => competition.Status.Type.Name == TypeName.StatusFinal;
     public static long GetTeamScore(Competitor competitor) => competitor.Score;
     public static string GetTeamAbbr(Competitor competitor) => competitor.Team.Abbreviation;

--- a/sample_espn_nfl_final.json
+++ b/sample_espn_nfl_final.json
@@ -307,7 +307,7 @@
     }
   ],
   "week": {
-    "number": 5
+    "number": 4
   },
   "events": [
     {
@@ -322,7 +322,7 @@
         "slug": "post-season"
       },
       "week": {
-        "number": 5
+        "number": 4
       },
       "competitions": [
         {

--- a/sample_espn_nfl_halftime.json
+++ b/sample_espn_nfl_halftime.json
@@ -307,7 +307,7 @@
     }
   ],
   "week": {
-    "number": 5
+    "number": 4
   },
   "events": [
     {
@@ -322,7 +322,7 @@
         "slug": "post-season"
       },
       "week": {
-        "number": 5
+        "number": 4
       },
       "competitions": [
         {

--- a/sample_espn_nfl_in_progress.json
+++ b/sample_espn_nfl_in_progress.json
@@ -307,7 +307,7 @@
     }
   ],
   "week": {
-    "number": 5
+    "number": 4
   },
   "events": [
     {
@@ -322,7 +322,7 @@
         "slug": "post-season"
       },
       "week": {
-        "number": 5
+        "number": 4
       },
       "competitions": [
         {

--- a/sample_espn_nfl_scheduled.json
+++ b/sample_espn_nfl_scheduled.json
@@ -307,7 +307,7 @@
     }
   ],
   "week": {
-    "number": 5
+    "number": 4
   },
   "events": [
     {
@@ -322,7 +322,7 @@
         "slug": "post-season"
       },
       "week": {
-        "number": 5
+        "number": 4
       },
       "competitions": [
         {


### PR DESCRIPTION
## Summary
- NFL's public API contract and frontend routing (`EspnController`, `EspnCacheService`, `nflAdapter.ts`) now route by our own `NflSeasonWeekConfig.WeekId` (`(season, nflWeek)`) instead of ESPN's own week numbering — matches CFB's already-correct `(season, slateId)` pattern. `NflWeekInfo.EspnWeek` is removed entirely; nothing on the frontend needs to know ESPN's numbering exists anymore, except one legitimate, isolated exception (interpreting the frozen demo/replay fixture's real captured wire data).
- `LeagueController.AddPicks`'s kickoff guard switched from a live `IEspnCacheService` read (which could fail open on a cache miss) to a pure `NflSpreads.GameTime` check, mirroring `CfbPicksController.StartedTeams` — now a single shared `GameHelpers.StartedTeams<T>` instead of two duplicated private methods.
- **Separate, small fix bundled in**: the admin Job Manager page had one generically-labeled "Run Scores Job"/"Run Spreads Job" button that only ever ran NFL's job — there was no way to trigger CFB's from the page at all. This directly caused a real prod mix-up today (a CFB score investigation stalled for hours because the button silently ran NFL instead). Each sport now gets its own explicitly-labeled button, wired to the `run-cfb-scores`/`run-cfb-spreads` endpoints that already existed on the backend.
- `/simplify` (4-agent pass) applied: deduplicated `StartedTeams`, reused the existing `getWeekName` round-name table instead of re-declaring it, fixed a stale comment, added cross-reference comments where `AddPicks`/`GetLeaguePicks`'s guards deliberately diverge (scheduled-time vs. live-status — different problems, not drift).

## Test plan
- [x] `dotnet test` (excluding live `Contract` category) — 892/892
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm run test -- --run` — 628/628
- [x] `npm run test:e2e -- --project=chromium` — 94/95 (1 known pre-existing flake, confirmed passing in isolation)
- [ ] CI: demo backend + replay e2e (not run locally — a persistent local Postgres container on the standard port made a parallel demo stack risky to start; CI ran this suite clean for the sibling PR #339 minutes earlier on the same pipeline)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs