### PR TITLE
Centralize NFL Pro-Bowl-week-skip season gate into one shared predicate (frizat-4k9)

### DIFF
--- a/Client.React/src/__tests__/gameHelpers.proBowlWeek.test.ts
+++ b/Client.React/src/__tests__/gameHelpers.proBowlWeek.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { getWeekFromEspnWeek } from '../utils/gameHelpers';
+
+// frizat-4k9: getWeekFromEspnWeek's season gate (through 2025, ESPN's raw postseason week 5 meant
+// the Super Bowl, since week 4 was reserved for the now-discontinued Pro Bowl exhibition) mirrors
+// GameHelpers.LastSeasonEspnSkippedProBowlWeek on the backend. This is the one remaining caller's
+// (nflAdapter.ts's isFrozenWeekMatch) only real decision point, so the boundary itself is what
+// needs covering — not just a happy path.
+describe('getWeekFromEspnWeek', () => {
+  it('regular season: returns the raw week unchanged regardless of season', () => {
+    expect(getWeekFromEspnWeek(10, 2025, false)).toBe(10);
+    expect(getWeekFromEspnWeek(10, 2026, false)).toBe(10);
+  });
+
+  it('postseason, season <= 2025: raw week 5 (Super Bowl) maps to WeekId 22', () => {
+    expect(getWeekFromEspnWeek(5, 2025, true)).toBe(22);
+  });
+
+  it('postseason, season <= 2025: weeks 1-3 map by plain +18 arithmetic, not the week-5 special case', () => {
+    expect(getWeekFromEspnWeek(1, 2025, true)).toBe(19);
+    expect(getWeekFromEspnWeek(2, 2025, true)).toBe(20);
+    expect(getWeekFromEspnWeek(3, 2025, true)).toBe(21);
+  });
+
+  it('postseason, season > 2025: raw week 5 is NOT remapped — resolves to a deliberately nonexistent WeekId 23', () => {
+    // Per docs/ESPNProBowl.md: fails loudly (an unmapped WeekId) rather than silently guessing
+    // wrong if ESPN's Pro-Bowl-week gap doesn't close as expected starting the 2026 season.
+    expect(getWeekFromEspnWeek(5, 2026, true)).toBe(23);
+  });
+
+  it('postseason, season > 2025: raw week 4 (Super Bowl, gap closed) maps to WeekId 22', () => {
+    expect(getWeekFromEspnWeek(4, 2026, true)).toBe(22);
+  });
+});

--- a/Client.React/src/services/nflAdapter.ts
+++ b/Client.React/src/services/nflAdapter.ts
@@ -123,7 +123,7 @@ async function buildSituationMap(events: Event[]): Promise<Map<string, import('.
 function isFrozenWeekMatch(frozenData: Awaited<ReturnType<typeof loadScoresWithRetry>>, season: number, nflWeek: number, isPostSeason: boolean): boolean {
   if (!frozenData?.week || !frozenData.season) return false;
   const frozenIsPostSeason = isPostSeasonHelper(frozenData);
-  const frozenNflWeek = getWeekFromEspnWeek(frozenData.week.number, frozenIsPostSeason);
+  const frozenNflWeek = getWeekFromEspnWeek(frozenData.week.number, frozenData.season.year, frozenIsPostSeason);
   return frozenData.season.year === season && frozenNflWeek === nflWeek && frozenIsPostSeason === isPostSeason;
 }
 

--- a/Client.React/src/utils/gameHelpers.ts
+++ b/Client.React/src/utils/gameHelpers.ts
@@ -18,15 +18,24 @@ export function isGameDecided(status: GameStatusValue): boolean {
   return isGameFinal(status) || isGameLive(status);
 }
 
+// Through the 2025 season, ESPN skipped postseason week 4 for the Pro Bowl (Super Bowl was raw
+// ESPN week 5). Must match the backend's GameHelpers.LastSeasonEspnSkippedProBowlWeek exactly —
+// see docs/ESPNProBowl.md and Shared/Helpers/GameHelpers.cs's identical constant (frizat-4k9).
+const LAST_SEASON_ESPN_SKIPPED_PRO_BOWL_WEEK = 2025;
+
 // Converts ESPN's own raw week numbering into our internal WeekId — legitimately still needed
 // wherever raw ESPN data is genuinely being ingested/interpreted (e.g. the frozen demo/replay
 // fixture, which IS a real captured ESPN wire snapshot) — but never for routing/fetching, which
-// is WeekId-primary everywhere now (frizat-3nv).
-export function getWeekFromEspnWeek(week: number, isPostSeason = false) {
+// is WeekId-primary everywhere now (frizat-3nv). Gated by SEASON, not by the raw week value,
+// mirroring GameHelpers.GetWeekFromEspnWeek exactly: for season <= 2025, raw week 5 remaps to
+// WeekId 22 (Super Bowl); for season >= 2026 no remap happens (the Pro Bowl gap is assumed
+// closed), so a genuine week=5 response for 2026+ fails loudly (WeekId 23, no match) instead of
+// silently coinciding with the right answer by accident.
+export function getWeekFromEspnWeek(week: number, season: number, isPostSeason = false) {
   if (!isPostSeason) return week;
-  // ESPN skips Pro Bowl (week 4); Super Bowl is ESPN week 5.
+  if (season <= LAST_SEASON_ESPN_SKIPPED_PRO_BOWL_WEEK && week === 5) return 22;
   // DB postseason weeks: WC=19, Div=20, CC=21, SB=22.
-  return (week === 5 ? 4 : week) + 18;
+  return week + 18;
 }
 
 // NFL week name/required-picks, keyed by our own internal WeekId (1-18 regular, 19-22

--- a/Server.UnitTests/CfbApiServiceTests.cs
+++ b/Server.UnitTests/CfbApiServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using FourPlayWebApp.Server.Services;
+using FourPlayWebApp.Server.UnitTests.TestHelpers;
 
 namespace FourPlayWebApp.Server.UnitTests;
 
@@ -9,19 +10,6 @@ namespace FourPlayWebApp.Server.UnitTests;
 // own WeekStartDate/WeekEndDate. This is a NEW query shape, not a revert to the old broken
 // groups=80 date approach CfbApiService.GetScoresByWeekAsync's own comment references.
 public class CfbApiServiceTests {
-    private sealed class CapturingHandler : HttpMessageHandler {
-        public Uri? LastRequestUri { get; private set; }
-        public string ResponseBody { get; set; } = "{}";
-        public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.OK;
-
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
-            LastRequestUri = request.RequestUri;
-            return Task.FromResult(new HttpResponseMessage(StatusCode) {
-                Content = new StringContent(ResponseBody),
-            });
-        }
-    }
-
     private static (CfbApiService sut, CapturingHandler handler) Build() {
         var handler = new CapturingHandler();
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://site.api.espn.com") };

--- a/Server.UnitTests/ESPNApiServiceTests.cs
+++ b/Server.UnitTests/ESPNApiServiceTests.cs
@@ -1,0 +1,61 @@
+using FourPlayWebApp.Server.Services;
+using FourPlayWebApp.Server.UnitTests.TestHelpers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+// frizat-4k9: FixEspnProbBowlWeek's week 5->4 postseason rewrite must be gated by
+// GameHelpers.LastSeasonEspnSkippedProBowlWeek — the same season threshold
+// GameHelpers.GetWeekFromEspnWeek already uses — instead of carrying its own
+// independent, unconditional copy of the quirk-correction.
+public class ESPNApiServiceTests {
+    private static (EspnApiService sut, CapturingHandler handler) Build() {
+        var handler = new CapturingHandler();
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://site.api.espn.com") };
+        return (new EspnApiService(httpClient, NullLogger<EspnApiService>.Instance), handler);
+    }
+
+    private static string PostSeasonResponseBody(int seasonYear, int weekNumber) => $$"""
+    {
+      "season": { "type": 3, "year": {{seasonYear}} },
+      "week": { "number": {{weekNumber}} },
+      "events": [
+        {
+          "id": "401547405",
+          "season": { "type": 3, "year": {{seasonYear}} },
+          "week": { "number": {{weekNumber}} },
+          "date": "{{seasonYear}}-02-08T23:30Z",
+          "competitions": [
+            {
+              "id": "401547405",
+              "date": "{{seasonYear}}-02-08T23:30Z",
+              "competitors": [
+                { "id": "1", "homeAway": "home", "score": "0", "team": { "abbreviation": "KC" } },
+                { "id": "2", "homeAway": "away", "score": "0", "team": { "abbreviation": "SF" } }
+              ],
+              "status": {
+                "clock": 0, "displayClock": "0:00", "period": 0,
+                "type": { "id": "1", "name": "STATUS_SCHEDULED", "state": "pre", "completed": false, "description": "Scheduled" }
+              },
+              "odds": []
+            }
+          ]
+        }
+      ]
+    }
+    """;
+
+    [Theory]
+    [InlineData(2025, 4)] // season <= LastSeasonEspnSkippedProBowlWeek: raw week 5 rewritten to 4
+    [InlineData(2026, 5)] // season > LastSeasonEspnSkippedProBowlWeek: raw week 5 left untouched
+    public async Task GetScoresByDateRangeAsync_PostSeasonWeek5_RewrittenOnlyForGatedSeason(int seasonYear, int expectedWeekNumber) {
+        var (sut, handler) = Build();
+        handler.ResponseBody = PostSeasonResponseBody(seasonYear, 5);
+
+        var result = await sut.GetScoresByDateRangeAsync(new DateOnly(seasonYear + 1, 2, 8), new DateOnly(seasonYear + 1, 2, 9), postSeason: true);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedWeekNumber, result!.Week.Number);
+        Assert.Equal(expectedWeekNumber, Assert.Single(result.Events!).Week.Number);
+    }
+}

--- a/Server.UnitTests/TestHelpers/CapturingHandler.cs
+++ b/Server.UnitTests/TestHelpers/CapturingHandler.cs
@@ -1,0 +1,19 @@
+using System.Net;
+
+namespace FourPlayWebApp.Server.UnitTests.TestHelpers;
+
+// Shared by CfbApiServiceTests and ESPNApiServiceTests (frizat-4k9) — both faked ESPN's HTTP
+// response the same way (capture the request, return a settable body/status) as two independent
+// copies before this was pulled out. One fake, reused per sport's API service test file.
+public sealed class CapturingHandler : HttpMessageHandler {
+    public Uri? LastRequestUri { get; private set; }
+    public string ResponseBody { get; set; } = "{}";
+    public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.OK;
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+        LastRequestUri = request.RequestUri;
+        return Task.FromResult(new HttpResponseMessage(StatusCode) {
+            Content = new StringContent(ResponseBody),
+        });
+    }
+}

--- a/Server/Services/ESPNApiService.cs
+++ b/Server/Services/ESPNApiService.cs
@@ -47,20 +47,26 @@ public class EspnApiService(HttpClient httpClient, ILogger<EspnApiService> logge
         if (scores == null || !scores.Events.Any())
             return scores;
 
-        // Remove teams with Abbr "NFC" or "AFC" and fix Pro Bowl
+        // Remove teams with Abbr "NFC" or "AFC" — the old Pro Bowl exhibition's placeholder
+        // competitors. Unconditional, not season-gated: this is data hygiene (an event that
+        // shouldn't be treated as a real game), not the week-number quirk-correction below.
         foreach (var scoreEvent in scores.Events) {
             scoreEvent.Competitions = scoreEvent.Competitions
                 .Where(c => !c.Competitors.Any(team => team.Team.Abbreviation == "NFC" || team.Team.Abbreviation == "AFC"))
                 .ToArray();
         }
 
-        // Move back Super Bowl to a proper week
-        if (scores.IsPostSeason() && scores.Week.Number == 5) {
+        // Move back Super Bowl to a proper week — gated by SEASON, matching
+        // GameHelpers.GetWeekFromEspnWeek's identical condition exactly via the shared
+        // NeedsProBowlWeekFix predicate (frizat-4k9: this used to be an independent,
+        // unconditional copy of the same quirk-correction, which would have silently
+        // mis-relabeled a real 2026+ week 5 game as week 4 instead of failing loudly).
+        if (scores.NeedsProBowlWeekFix()) {
             scores.Week.Number = 4;
         }
         // Update SeasonType and Week number
         foreach (var scoreEvent in scores.Events) {
-            if (scoreEvent.IsPostSeason() && scoreEvent.Week.Number == 5) {
+            if (scoreEvent.NeedsProBowlWeekFix()) {
                 scoreEvent.Week.Number = 4;
             }
         }

--- a/Shared/Helpers/Extensions/ESPNScoresExtensions.cs
+++ b/Shared/Helpers/Extensions/ESPNScoresExtensions.cs
@@ -17,4 +17,14 @@ public static class EspnScoresExtensions {
             return true;
         return false;
     }
+
+    // frizat-4k9: one predicate for the Pro-Bowl-week-skip quirk (ESPN's raw week 5 meaning
+    // "Super Bowl" through season <= GameHelpers.LastSeasonEspnSkippedProBowlWeek), instead of
+    // ESPNApiService.FixEspnProbBowlWeek writing the same three-part condition out twice — once
+    // for EspnScores, once per Event — the same duplication-across-two-ESPN-shapes problem
+    // IsPostSeason above already solves via this file's overload pattern.
+    public static bool NeedsProBowlWeekFix(this EspnScores scores) =>
+        scores.IsPostSeason() && scores.Week.Number == 5 && scores.Season.Year <= GameHelpers.LastSeasonEspnSkippedProBowlWeek;
+    public static bool NeedsProBowlWeekFix(this Event scoreEvent) =>
+        scoreEvent.IsPostSeason() && scoreEvent.Week.Number == 5 && scoreEvent.Season.Year <= GameHelpers.LastSeasonEspnSkippedProBowlWeek;
 }

--- a/Shared/Helpers/GameHelpers.cs
+++ b/Shared/Helpers/GameHelpers.cs
@@ -72,8 +72,11 @@ public static class GameHelpers {
     // bracket actually exists (~Jan 2027) — the NFL discontinued the Pro Bowl GAME starting with
     // the 2026 season (announced 2026-08-26), so ESPN's postseason week numbering is expected to
     // close the old week-4 gap from here on. See docs/ESPNProBowl.md for the full writeup; update
-    // LastSeasonEspnSkippedProBowlWeek there if this guess turns out wrong.
-    private const int LastSeasonEspnSkippedProBowlWeek = 2025;
+    // this value if this guess turns out wrong. Public (not the private it was originally) so
+    // ESPNApiService.FixEspnProbBowlWeek can gate its own identical quirk-correction on the same
+    // threshold instead of carrying an independent, unconditional copy (frizat-4k9) — this and
+    // GetWeekFromEspnWeek below are the only two places this threshold is allowed to live.
+    public const int LastSeasonEspnSkippedProBowlWeek = 2025;
 
     // Through the 2025 season, ESPN skipped postseason week 4 for the Pro Bowl — Super Bowl was
     // raw ESPN week 5 (one slot past Conference Championship=3), not the 4th round it actually is.

--- a/docs/ESPNProBowl.md
+++ b/docs/ESPNProBowl.md
@@ -14,15 +14,38 @@ to raw ESPN week 5 instead of the 4th real playoff round it actually is:
 | Pro Bowl (exhibition, not tracked) | — | 4 |
 | Super Bowl | 4 | **5** |
 
-This is confirmed by three independent, previously-uncoordinated spots in the codebase
-that all separately hardcoded the same workaround before this fix:
+This was, until frizat-4k9 (2026-09-09), encoded independently in **four** separate spots
+with inconsistent (in three of the four cases, missing entirely) season-gating — despite
+this doc's own earlier claim that the rest of the codebase already read through one shared
+function. That claim was false; frizat-4k9 made it true. The four spots, and their status
+now:
 
-- `GameHelpers.GetWeekFromEspnWeek` — the week→`WeekId` translation
-- `GameHelpers.GetEspnRequiredPicks` — `"ESPN Treats Post Season Week 4 as the Pro Bowl - this sucks"`
+- `GameHelpers.GetWeekFromEspnWeek` (`Shared/Helpers/GameHelpers.cs`) — the canonical,
+  correctly season-gated week→`WeekId` translation. Always was correct; this is the one
+  source of truth the other three now route through (or, for spot 2 below, were deleted
+  in favor of).
+- `NflCurrentWeekService.ToWeekInfo` — **fixed as a side effect of PR #341** (frizat-3nv):
+  this was the most dangerous instance, an unconditional non-season-gated `WeekId 22 →
+  EspnWeek 5` switch. It's not "routed through" the shared function — it's gone entirely,
+  since `NflWeekInfo` dropped its `EspnWeek` field outright once the public API/frontend
+  contract became `WeekId`-primary (see "PR #341" below).
 - `Server/Services/ESPNApiService.cs`'s `FixEspnProbBowlWeek` — rewrites a live response's
-  `Week.Number` from 5 back to 4 after fetching, for display/team-matching purposes
-- `nflAdapter.ts`'s `weekLabelFn`/`postSeasonWeekOptions: [1, 2, 3, 5]` — `"Skip week 4
-  (Pro Bowl) — Super Bowl is week 5 in ESPN's 2025 postseason"`
+  `Week.Number` from 5 back to 4 after fetching, for display/team-matching purposes.
+  **Fixed by frizat-4k9**: now gated on `scores.Season.Year <= GameHelpers.LastSeasonEspnSkippedProBowlWeek`,
+  the same constant `GetWeekFromEspnWeek` uses (not a copy of the value — a reference to
+  the same `public const`). The function's separate NFC/AFC placeholder-competitor
+  filtering stays unconditional — that's data hygiene, not part of the season-numbering
+  quirk.
+- `Client.React/src/utils/gameHelpers.ts`'s `getWeekFromEspnWeek` — the TS mirror. Its old
+  routing-decision usage (feeding NFL's page-routing logic) is gone as of PR #341, since
+  the frontend now routes by `WeekId` throughout (`postSeasonWeekOptions` is the plain
+  `[19, 20, 21, 22]`, not ESPN-shaped `[1, 2, 3, 5]`). Its one remaining caller,
+  `nflAdapter.ts`'s `isFrozenWeekMatch`, interprets the frozen demo/replay fixture's *real*
+  captured ESPN wire data (season+week), so the function itself couldn't be deleted — it's
+  season-gated to match the backend (`LAST_SEASON_ESPN_SKIPPED_PRO_BOWL_WEEK = 2025`, with
+  a comment cross-referencing `GameHelpers.cs` so the two values don't drift independently;
+  TypeScript can't share the C# `const` directly, so this is the one place a literal copy
+  of the value is unavoidable).
 
 ## What changed (2026-08-26)
 
@@ -59,7 +82,7 @@ availability question.)
 **season**, not by a raw-week heuristic:
 
 ```csharp
-private const int LastSeasonEspnSkippedProBowlWeek = 2025;
+public const int LastSeasonEspnSkippedProBowlWeek = 2025;
 
 public static int GetWeekFromEspnWeek(long week, int season, bool isPostSeason = false) {
     if (!isPostSeason) return (int)week;
@@ -77,16 +100,42 @@ renumbers differently), a real week=5 postseason response for 2026+ maps to a
 persisted scores, `doOddsExist` empty) instead of silently coinciding with the right
 answer by accident. That's deliberate: better a visible failure than a quiet wrong guess.
 
+`LastSeasonEspnSkippedProBowlWeek` is `public` (not `private`, as it originally was)
+specifically so `ESPNApiService.FixEspnProbBowlWeek` can reference this exact constant
+rather than carrying its own independent copy of the value — see "The fix (2026-09-09)"
+below.
+
+## PR #341 — NFL's public contract went `WeekId`-primary (2026-09-08)
+
+Separately from this quirk's own fix, `frizat-3nv` made NFL's public API/frontend
+contract route by our own `WeekId` throughout (matching how CFB already routed by its own
+`CfbSlates` id) — the frontend, and every controller route, now deal in `WeekId` only;
+ESPN's own week numbering never crosses that boundary except inside the ESPN-ingestion
+code itself. This directly closed spot 2 above (`NflCurrentWeekService.ToWeekInfo` no
+longer computes an `EspnWeek` value at all — nothing to gate) and narrowed spot 4's
+purpose to only the demo/replay fixture-interpretation case.
+
+## The fix (2026-09-09, frizat-4k9)
+
+The two remaining ungated spots (`ESPNApiService.FixEspnProbBowlWeek` and the frontend
+`gameHelpers.ts` mirror) now both gate on the same season threshold `GetWeekFromEspnWeek`
+uses. The backend side references `GameHelpers.LastSeasonEspnSkippedProBowlWeek` directly
+(one constant, two call sites — `Shared/Helpers/GameHelpers.cs` and
+`Server/Services/ESPNApiService.cs`); the frontend can't share a C# `const`, so it carries
+one literal copy (`LAST_SEASON_ESPN_SKIPPED_PRO_BOWL_WEEK = 2025` in
+`Client.React/src/utils/gameHelpers.ts`), commented to cross-reference the backend value.
+
 ## TODO — verify once real 2026 postseason data exists (~January 2027)
 
 - [ ] Hit ESPN's real scoreboard endpoint for a 2026-season postseason week and check
       the actual `week.number` ESPN returns for the Super Bowl (4 or 5?)
 - [ ] If it's still 5 (gap kept for some other reason): bump
       `LastSeasonEspnSkippedProBowlWeek` in `Shared/Helpers/GameHelpers.cs` — that's the
-      only place this needs to change (the rest of the codebase already reads through
-      this one function; `ESPNApiService.FixEspnProbBowlWeek`'s own `Week.Number == 5`
-      check would also need the same season gate applied, or its own version of this fix)
+      only C# place this needs to change (`ESPNApiService.FixEspnProbBowlWeek` already
+      reads the same constant). Also bump the frontend's literal copy in
+      `Client.React/src/utils/gameHelpers.ts`.
 - [ ] If it's 4 (gap closed, as expected): no code change needed — remove this file's
       TODO and the `//TODO` comment above `LastSeasonEspnSkippedProBowlWeek`
 
-Tracked as GitHub issue — see the bead sync for this repo.
+Tracked as GitHub issue — see the bead sync for this repo (frizat-jw7 tracks this
+verification step; frizat-4k9 tracked the centralization fix itself, closed 2026-09-09).


### PR DESCRIPTION
## Summary
- The 2025-and-earlier "ESPN reserves postseason week 4 for the Pro Bowl, Super Bowl is raw week 5" quirk was encoded independently in four places with inconsistent (in most cases missing) season-gating. `GameHelpers.GetWeekFromEspnWeek` was always correct; `NflCurrentWeekService.ToWeekInfo`'s unconditional copy was already removed as a side effect of PR #341's WeekId-primary contract work.
- Closes the two remaining spots: `ESPNApiService.FixEspnProbBowlWeek` now calls new `NeedsProBowlWeekFix` extension method overloads on `ESPNScoresExtensions` (matching that file's existing `IsPostSeason()` overload pattern for `EspnScores`/`Event`) instead of writing the season-gate condition out twice inline; the frontend `gameHelpers.ts` mirror is now season-gated to match (it's still needed — `nflAdapter.ts`'s `isFrozenWeekMatch` interprets the frozen demo/replay fixture's real captured ESPN wire data).
- `docs/ESPNProBowl.md` corrected — it previously claimed the rest of the codebase already read through one shared function, which was false; it now accurately reflects what's centralized and why.
- Also pulled a duplicated `HttpMessageHandler`-faking test helper (`CapturingHandler`) out of `CfbApiServiceTests.cs` into a shared `Server.UnitTests/TestHelpers/CapturingHandler.cs`, now used by both it and the new `ESPNApiServiceTests.cs`.

Internal correctness fix — no user-visible behavior change today (the quirk it guards against doesn't manifest until the 2026 postseason bracket exists, ~Jan 2027), so no CHANGELOG entry per CLAUDE.md's skip rule for internal-only changes.

## Test plan
- [x] `dotnet test --filter "Category!=Contract"` — 894/894 passed
- [x] `npm run test -- --run` — 633/633 passed (includes new `gameHelpers.proBowlWeek.test.ts`)
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `CI=true npm run test:e2e -- --project=chromium` — 94/95 passed; the 1 flaky (`leaguePortal.spec.ts`, unrelated file) passed cleanly in isolation on retry
- [x] `/simplify` (4 parallel review agents: reuse, simplification, efficiency, altitude) — findings applied (predicate extraction, shared test fixture, collapsed near-duplicate tests into one `[Theory]`)
- [x] Code review agent — found one gap (missing frontend unit test for the season-gated `getWeekFromEspnWeek` boundary), fixed by adding `gameHelpers.proBowlWeek.test.ts`
- [x] Functional gate: `grep -rn "LastSeasonEspnSkippedProBowlWeek" --include="*.cs"` confirms exactly one C# constant definition, referenced from two call sites (not four independent copies)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs