### PR TITLE
dev -> main: Lock Juice tease points at season start, Weekly Cost at season end

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -7,6 +7,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 ## 2026-09-09
 
 - Fixed: the admin Job Manager page had one generically-labeled "Run Scores Job" / "Run Spreads Job" button that only ever ran NFL's job, with no way to trigger CFB's scores or spreads jobs at all — each sport now has its own clearly-labeled button
+- Fixed: a league's Tease Pts and Weekly Cost settings could be edited at any point in the season, with no protection against changing already-decided weeks' terms — Tease Pts now lock once the season starts, and Weekly Cost locks once the season's final week (Super Bowl / Championship) starts
 
 ## 2026-09-07
 

--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -60,6 +60,7 @@ import {
   getLeagueUserMappings,
   getLeagueJuice,
   getLeagueCost,
+  updateLeagueJuice,
   getAllLeagues,
   getUsers,
   createLeague,
@@ -79,6 +80,7 @@ import {
 const mockedGetMappings = vi.mocked(getLeagueUserMappings);
 const mockedGetJuice = vi.mocked(getLeagueJuice);
 const mockedGetCost = vi.mocked(getLeagueCost);
+const mockedUpdateJuice = vi.mocked(updateLeagueJuice);
 const mockedGetAllLeagues = vi.mocked(getAllLeagues);
 const mockedGetCurrentInviteLink = vi.mocked(getCurrentInviteLink);
 const mockedGetLeagueInvitations = vi.mocked(getLeagueInvitations);
@@ -116,7 +118,7 @@ function makeMember(): LeagueUserMappingDto {
   };
 }
 
-function makeJuice(season: number): LeagueJuiceMappingDto {
+function makeJuice(season: number, overrides?: Partial<Pick<LeagueJuiceMappingDto, 'teaseLocked' | 'weeklyCostLocked'>>): LeagueJuiceMappingDto {
   return {
     id: 1,
     leagueId: 1,
@@ -127,6 +129,9 @@ function makeJuice(season: number): LeagueJuiceMappingDto {
     juiceConference: 6,
     weeklyCost: 5,
     dateCreated: '2026-06-29T00:00:00Z',
+    teaseLocked: false,
+    weeklyCostLocked: false,
+    ...overrides,
   };
 }
 
@@ -145,6 +150,7 @@ beforeEach(() => {
   mockedGetMappings.mockResolvedValue([makeMember()]);
   mockedGetCost.mockResolvedValue(cost);
   mockedGetJuice.mockResolvedValue([makeJuice(CURRENT_SEASON - 1)]);
+  mockedUpdateJuice.mockResolvedValue(undefined);
   mockedGetAllLeagues.mockResolvedValue([]);
   mockedGetUsers.mockResolvedValue([makeUser()]);
   mockedCreateLeague.mockResolvedValue(makeLeague({ id: 99, leagueName: 'New League' }));
@@ -178,6 +184,52 @@ describe('LeaguePortalPage (owner, non-admin)', () => {
 
     await waitFor(() => expect(screen.getByLabelText(/Tease Pts \(Regular Season\)/i)).not.toBeDisabled());
     expect(screen.getByRole('button', { name: /save/i })).not.toBeDisabled();
+  });
+
+  it('locks only the tease fields, not Weekly Cost, once the season has started', async () => {
+    mockedGetJuice.mockResolvedValue([makeJuice(CURRENT_SEASON, { teaseLocked: true, weeklyCostLocked: false })]);
+    renderPage();
+    await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+
+    await waitFor(() => expect(screen.getByLabelText(/Tease Pts \(Regular Season\)/i)).toHaveValue(13));
+    expect(screen.getByLabelText(/Tease Pts \(Regular Season\)/i)).toBeDisabled();
+    expect(screen.getByLabelText(/Tease Pts \(Divisional\)/i)).toBeDisabled();
+    expect(screen.getByLabelText(/Tease Pts \(Conference\)/i)).toBeDisabled();
+    expect(screen.getByLabelText(/Cost Per Week/i)).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /save/i })).not.toBeDisabled();
+    expect(screen.getByText(/Tease points are locked once the season has started/i)).toBeInTheDocument();
+  });
+
+  it('locks only Weekly Cost, not the tease fields, once the season\'s final week has started', async () => {
+    mockedGetJuice.mockResolvedValue([makeJuice(CURRENT_SEASON, { teaseLocked: false, weeklyCostLocked: true })]);
+    renderPage();
+    await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+
+    await waitFor(() => expect(screen.getByLabelText(/Cost Per Week/i)).toHaveValue(5));
+    expect(screen.getByLabelText(/Cost Per Week/i)).toBeDisabled();
+    expect(screen.getByLabelText(/Tease Pts \(Regular Season\)/i)).not.toBeDisabled();
+    expect(screen.getByLabelText(/Tease Pts \(Divisional\)/i)).not.toBeDisabled();
+    expect(screen.getByLabelText(/Tease Pts \(Conference\)/i)).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /save/i })).not.toBeDisabled();
+    expect(screen.getByText(/Weekly Cost is locked once the season's final week has started/i)).toBeInTheDocument();
+  });
+
+  it('shows the server\'s specific rejection message when a save is rejected by a lock, instead of a generic failure toast', async () => {
+    mockedGetJuice.mockResolvedValue([makeJuice(CURRENT_SEASON)]);
+    mockedUpdateJuice.mockRejectedValue(
+      Object.assign(new Error('Bad Request'), {
+        isAxiosError: true,
+        response: { status: 400, data: "Tease points can't be changed once the season has started." },
+      }),
+    );
+
+    renderPage();
+    await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+    await waitFor(() => expect(screen.getByLabelText(/Tease Pts \(Regular Season\)/i)).not.toBeDisabled());
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() =>
+      expect(toastPush).toHaveBeenCalledWith("Tease points can't be changed once the season has started.", 'error'));
   });
 
   it('lets the owner clear and retype a Tease Pts value without it snapping back mid-edit', async () => {

--- a/Client.React/src/__tests__/leaderboard.test.tsx
+++ b/Client.React/src/__tests__/leaderboard.test.tsx
@@ -46,6 +46,7 @@ beforeEach(() => {
   mockedGetLeagueJuiceForSeason.mockResolvedValue({
     id: 1, leagueId: 1, leagueName: 'Demo League', season: 2023,
     juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, dateCreated: '2023-01-01T00:00:00Z',
+    teaseLocked: false, weeklyCostLocked: false,
   });
   mockLeagueJuiceEmpty(mockedGetLeagueJuice);
 });
@@ -247,8 +248,8 @@ describe('LeaderboardPage — season selector', () => {
     // constant instead of that league's own history. One shared hook (useLeagueMinSeason) fixes
     // both sports identically.
     mockedGetLeagueJuice.mockResolvedValue([
-      { id: 1, leagueId: 1, leagueName: 'Demo League', season: 2022, juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, dateCreated: '2022-01-01T00:00:00Z' },
-      { id: 2, leagueId: 1, leagueName: 'Demo League', season: 2023, juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, dateCreated: '2023-01-01T00:00:00Z' },
+      { id: 1, leagueId: 1, leagueName: 'Demo League', season: 2022, juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, dateCreated: '2022-01-01T00:00:00Z', teaseLocked: true, weeklyCostLocked: true },
+      { id: 2, leagueId: 1, leagueName: 'Demo League', season: 2023, juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, dateCreated: '2023-01-01T00:00:00Z', teaseLocked: true, weeklyCostLocked: true },
     ]);
 
     renderPage();

--- a/Client.React/src/__tests__/useLeagueMinSeason.test.tsx
+++ b/Client.React/src/__tests__/useLeagueMinSeason.test.tsx
@@ -14,6 +14,7 @@ function makeJuiceMapping(season: number): LeagueJuiceMappingDto {
   return {
     id: season, leagueId: 1, leagueName: 'Demo League', season,
     juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, dateCreated: `${season}-01-01T00:00:00Z`,
+    teaseLocked: true, weeklyCostLocked: true,
   };
 }
 

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -297,8 +297,8 @@ export default function LeaguePortalPage() {
       await updateLeagueJuice(selectedLeague.id, selectedSeason, juiceForm);
       toast.push('Juice settings saved', 'success');
       await loadJuice(selectedLeague.id);
-    } catch {
-      toast.push('Failed to save juice settings', 'error');
+    } catch (error) {
+      toast.push(extractApiErrorMessage(error, 'Failed to save juice settings'), 'error');
     } finally {
       setSavingJuice(false);
     }
@@ -532,6 +532,8 @@ export default function LeaguePortalPage() {
               onJuiceFormChange={(field, value) => setJuiceForm((f) => ({ ...f, [field]: value }))}
               hasMappingForSeason={!!currentJuiceMapping}
               locked={selectedSeason < CURRENT_SEASON}
+              teaseLocked={!!currentJuiceMapping?.teaseLocked}
+              weeklyCostLocked={!!currentJuiceMapping?.weeklyCostLocked}
               onSave={handleSaveJuice}
               onRollForward={handleRollForward}
               saving={savingJuice}
@@ -975,6 +977,10 @@ interface JuiceTabProps {
   onJuiceFormChange: (field: string, value: number) => void;
   hasMappingForSeason: boolean;
   locked: boolean;
+  /** Tease points (Juice/JuiceDivisional/JuiceConference) — locked once the season's first week/slate has started. */
+  teaseLocked: boolean;
+  /** Weekly Cost — locked separately, once the season's final week/slate (Super Bowl / Championship) has started. */
+  weeklyCostLocked: boolean;
   onSave: () => void;
   onRollForward: () => void;
   saving: boolean;
@@ -983,7 +989,7 @@ interface JuiceTabProps {
 
 function JuiceTab({
   availableSeasons, selectedSeason, onSeasonChange, juiceForm, onJuiceFormChange,
-  hasMappingForSeason, locked, onSave, onRollForward, saving, rollingForward,
+  hasMappingForSeason, locked, teaseLocked, weeklyCostLocked, onSave, onRollForward, saving, rollingForward,
 }: JuiceTabProps) {
   // All 4 fields are backend `int` DTOs (Shared/Models/Data/Dtos/LeagueCreateDto.cs) — teaser
   // points and weekly cost are always whole numbers in this domain, so integerOnly strips a
@@ -992,6 +998,8 @@ function JuiceTab({
   const juiceDivisionalField = useNumericField(juiceForm.juiceDivisional, (n) => onJuiceFormChange('juiceDivisional', n), { integerOnly: true });
   const juiceConferenceField = useNumericField(juiceForm.juiceConference, (n) => onJuiceFormChange('juiceConference', n), { integerOnly: true });
   const weeklyCostField = useNumericField(juiceForm.weeklyCost, (n) => onJuiceFormChange('weeklyCost', n), { integerOnly: true });
+  const teaseDisabled = locked || teaseLocked;
+  const weeklyCostDisabled = locked || weeklyCostLocked;
 
   return (
     <Box>
@@ -1020,13 +1028,23 @@ function JuiceTab({
           {selectedSeason} has already been played — juice settings are locked to protect past results.
         </Typography>
       )}
+      {!locked && teaseLocked && (
+        <Typography color="text.secondary" variant="body2" sx={{ mb: 1 }}>
+          Tease points are locked once the season has started.
+        </Typography>
+      )}
+      {!locked && weeklyCostLocked && (
+        <Typography color="text.secondary" variant="body2" sx={{ mb: 2 }}>
+          Weekly Cost is locked once the season's final week has started.
+        </Typography>
+      )}
 
       <Stack spacing={2} sx={{ maxWidth: 400 }}>
         <TextField
           label="Tease Pts (Regular Season)"
           type="number"
           size="small"
-          disabled={locked}
+          disabled={teaseDisabled}
           slotProps={{ htmlInput: { inputMode: 'numeric' } }}
           {...juiceField}
         />
@@ -1034,7 +1052,7 @@ function JuiceTab({
           label="Tease Pts (Divisional)"
           type="number"
           size="small"
-          disabled={locked}
+          disabled={teaseDisabled}
           slotProps={{ htmlInput: { inputMode: 'numeric' } }}
           {...juiceDivisionalField}
         />
@@ -1042,7 +1060,7 @@ function JuiceTab({
           label="Tease Pts (Conference)"
           type="number"
           size="small"
-          disabled={locked}
+          disabled={teaseDisabled}
           slotProps={{ htmlInput: { inputMode: 'numeric' } }}
           {...juiceConferenceField}
         />
@@ -1050,7 +1068,7 @@ function JuiceTab({
           label="Cost Per Week ($)"
           type="number"
           size="small"
-          disabled={locked}
+          disabled={weeklyCostDisabled}
           slotProps={{ htmlInput: { inputMode: 'numeric' } }}
           {...weeklyCostField}
         />

--- a/Client.React/src/types/admin.ts
+++ b/Client.React/src/types/admin.ts
@@ -20,6 +20,10 @@ export interface LeagueJuiceMappingDto {
   juiceConference: number;
   weeklyCost: number;
   dateCreated: string;
+  /** True once the season's first week/slate has started — tease points are no longer editable. */
+  teaseLocked: boolean;
+  /** True once the season's final week/slate (Super Bowl / Championship) has started — Weekly Cost is no longer editable. */
+  weeklyCostLocked: boolean;
 }
 
 export interface CreateLeagueModel {

--- a/Server.UnitTests/LeagueJuiceScheduleSourceTests.cs
+++ b/Server.UnitTests/LeagueJuiceScheduleSourceTests.cs
@@ -40,15 +40,17 @@ public class LeagueJuiceScheduleSourceTests
         LeagueJuiceMappings = mappings,
     };
 
-    private static NflSeasonWeekConfig MakeNflWeek1(int season, DateTime firstGameUtc) => new() {
-        Season = season, WeekId = 1, WeekLabel = "Week 1", WeekType = "Regular Season", ScoringFormat = "Standard",
+    private static NflSeasonWeekConfig MakeNflWeek(int season, int weekId, DateTime firstGameUtc) => new() {
+        Season = season, WeekId = weekId, WeekLabel = $"Week {weekId}", WeekType = "Regular Season", ScoringFormat = "Standard",
         FirstGameOfWeekStartDatetime = firstGameUtc,
     };
+    private static NflSeasonWeekConfig MakeNflWeek1(int season, DateTime firstGameUtc) => MakeNflWeek(season, 1, firstGameUtc);
 
-    private static CfbSeasonWeekConfig MakeCfbSlate1(int season, DateOnly startDate) => new() {
-        Season = season, EspnWeekNumber = 1, IvLeagueWeekNumber = 1, WeekStartDate = startDate,
+    private static CfbSeasonWeekConfig MakeCfbSlate(int season, int slateNumber, DateOnly startDate) => new() {
+        Season = season, EspnWeekNumber = slateNumber, IvLeagueWeekNumber = slateNumber, WeekStartDate = startDate,
         WeekEndDate = startDate.AddDays(6), InScopeIvLeague = true,
     };
+    private static CfbSeasonWeekConfig MakeCfbSlate1(int season, DateOnly startDate) => MakeCfbSlate(season, 1, startDate);
 
     // ── No hardcoded year ──────────────────────────────────────────────────────
 
@@ -271,6 +273,78 @@ public class LeagueJuiceScheduleSourceTests
 
         Assert.Empty(reminders);
         Assert.Empty(locks);
+    }
+
+    // ── GetWeekLockTimeUtc / GetSeasonStartLockTimeUtc / GetSeasonEndLockTimeUtc ─────
+    // frizat: extracted for LeagueController.UpdateLeagueJuice to reuse the identical
+    // "when does this week/slate start" boundary the scheduler above already computes — tease
+    // points lock at season start (week/slate 1), WeeklyCost locks at season end (NFL WeekId 22
+    // Super Bowl / CFB slate 18 Championship). Pure, no I/O.
+
+    [Fact]
+    public void GetSeasonStartLockTimeUtc_Nfl_ResolvesWeek1LockTime() {
+        var nflConfigs = new[] { MakeNflWeek(2025, 1, new DateTime(2025, 9, 4, 20, 20, 0, DateTimeKind.Utc)) };
+
+        var lockTime = LeagueJuiceScheduleSource.GetSeasonStartLockTimeUtc(LeagueType.Nfl, 2025, nflConfigs, []);
+
+        Assert.Equal(new DateTime(2025, 9, 4, 19, 0, 0, DateTimeKind.Utc), lockTime); // 2pm CDT = 19:00 UTC
+    }
+
+    [Fact]
+    public void GetSeasonEndLockTimeUtc_Nfl_ResolvesWeek22_NotWeek1() {
+        var nflConfigs = new[] {
+            MakeNflWeek(2025, 1, new DateTime(2025, 9, 4, 20, 20, 0, DateTimeKind.Utc)),
+            MakeNflWeek(2025, 22, new DateTime(2026, 2, 8, 23, 30, 0, DateTimeKind.Utc)),
+        };
+
+        var lockTime = LeagueJuiceScheduleSource.GetSeasonEndLockTimeUtc(LeagueType.Nfl, 2025, nflConfigs, []);
+
+        Assert.Equal(new DateTime(2026, 2, 8, 20, 0, 0, DateTimeKind.Utc), lockTime); // 2pm CST = 20:00 UTC
+    }
+
+    [Fact]
+    public void GetSeasonStartLockTimeUtc_Cfb_ResolvesSlate1LockTime() {
+        var cfbConfigs = new[] { MakeCfbSlate(2025, 1, new DateOnly(2025, 8, 23)) };
+
+        var lockTime = LeagueJuiceScheduleSource.GetSeasonStartLockTimeUtc(LeagueType.Cfb, 2025, [], cfbConfigs);
+
+        Assert.Equal(new DateTime(2025, 8, 23, 19, 0, 0, DateTimeKind.Utc), lockTime); // 2pm CDT = 19:00 UTC
+    }
+
+    [Fact]
+    public void GetSeasonEndLockTimeUtc_Cfb_ResolvesSlate18_NotSlate1() {
+        var cfbConfigs = new[] {
+            MakeCfbSlate(2025, 1, new DateOnly(2025, 8, 23)),
+            MakeCfbSlate(2025, 18, new DateOnly(2026, 1, 12)),
+        };
+
+        var lockTime = LeagueJuiceScheduleSource.GetSeasonEndLockTimeUtc(LeagueType.Cfb, 2025, [], cfbConfigs);
+
+        Assert.Equal(new DateTime(2026, 1, 12, 20, 0, 0, DateTimeKind.Utc), lockTime); // 2pm CST = 20:00 UTC
+    }
+
+    [Fact]
+    public void GetWeekLockTimeUtc_ReturnsNull_WhenNoMatchingConfigRowExists() {
+        var startLock = LeagueJuiceScheduleSource.GetSeasonStartLockTimeUtc(LeagueType.Nfl, 2031, [], []);
+        var endLock = LeagueJuiceScheduleSource.GetSeasonEndLockTimeUtc(LeagueType.Cfb, 2031, [], []);
+
+        Assert.Null(startLock);
+        Assert.Null(endLock);
+    }
+
+    [Fact]
+    public void GetWeekLockTimeUtc_Cfb_IgnoresRowNotInScopeIvLeague() {
+        var cfbConfigs = new[] {
+            new CfbSeasonWeekConfig {
+                Season = 2025, EspnWeekNumber = 18, IvLeagueWeekNumber = 18,
+                WeekStartDate = new DateOnly(2026, 1, 12), WeekEndDate = new DateOnly(2026, 1, 18),
+                InScopeIvLeague = false,
+            },
+        };
+
+        var lockTime = LeagueJuiceScheduleSource.GetSeasonEndLockTimeUtc(LeagueType.Cfb, 2025, [], cfbConfigs);
+
+        Assert.Null(lockTime);
     }
 
     // ── JobData ────────────────────────────────────────────────────────────────────

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -1,5 +1,6 @@
 using FourPlayWebApp.Server.Auth;
 using FourPlayWebApp.Server.Controllers;
+using FourPlayWebApp.Server.Jobs;
 using FourPlayWebApp.Server.Models;
 using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Models.Identity;
@@ -182,13 +183,30 @@ public class LeagueOwnershipTests
         return (ctrl, repo);
     }
 
+    // No NflSeasonWeekConfigs/CfbSeasonWeekConfigs rows configured for the season under test —
+    // GetSeasonStartLockTimeUtc/GetSeasonEndLockTimeUtc resolve to null, so neither lock ever
+    // fires. Used by tests that don't care about the season-boundary locks themselves.
+    private static ICfbRepository EmptyCfbRepo() {
+        var cfbRepo = Substitute.For<ICfbRepository>();
+        cfbRepo.GetAllWeekConfigsAsync().Returns((IEnumerable<CfbSeasonWeekConfig>)new List<CfbSeasonWeekConfig>());
+        cfbRepo.GetWeekConfigsForSeasonAsync(Arg.Any<int>()).Returns((IEnumerable<CfbSeasonWeekConfig>)new List<CfbSeasonWeekConfig>());
+        return cfbRepo;
+    }
+
+    // UpdateLeagueJuice/GetLeagueJuiceForSeason take a real (non-substituted) LeagueJuiceScheduleSource
+    // — its lock-time methods aren't virtual, so NSubstitute can't override them; constructing the
+    // real thing over the test's own repo mocks (already set up with whatever config rows the test
+    // needs) exercises the actual lock logic instead of re-mocking it a second, parallel way.
+    private static LeagueJuiceScheduleSource BuildScheduleSource(ILeagueRepository repo, ICfbRepository? cfbRepo = null) =>
+        new(repo, cfbRepo ?? EmptyCfbRepo(), TimeProvider.System);
+
     [Fact]
     public async Task UpdateJuice_ReturnsForbid_WhenCallerIsNotOwnerOrAdmin()
     {
         var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId));
         repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
 
-        var result = await ctrl.UpdateLeagueJuice(1, 2025, new LeagueJuiceUpdateDto(13, 10, 6, 5));
+        var result = await ctrl.UpdateLeagueJuice(1, 2025, new LeagueJuiceUpdateDto(13, 10, 6, 5), BuildScheduleSource(repo));
 
         Assert.IsType<ForbidResult>(result);
     }
@@ -199,8 +217,9 @@ public class LeagueOwnershipTests
         var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
         repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
         repo.GetLeagueJuiceMappingAsync(1, 2025).Returns(new LeagueJuiceMapping { Id = 5, LeagueId = 1, Season = 2025, Juice = 13, JuiceDivisional = 10, JuiceConference = 6, WeeklyCost = 5 });
+        repo.GetNflSeasonWeekConfigsAsync(2025).Returns(new List<NflSeasonWeekConfig>());
 
-        var result = await ctrl.UpdateLeagueJuice(1, 2025, new LeagueJuiceUpdateDto(14, 11, 7, 10));
+        var result = await ctrl.UpdateLeagueJuice(1, 2025, new LeagueJuiceUpdateDto(14, 11, 7, 10), BuildScheduleSource(repo));
 
         Assert.IsType<NoContentResult>(result);
         await repo.Received(1).UpdateLeagueJuiceMappingAsync(Arg.Is<LeagueJuiceMapping>(m => m.Juice == 14 && m.JuiceDivisional == 11));
@@ -212,8 +231,95 @@ public class LeagueOwnershipTests
         var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId, isAdmin: true));
         repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L" });
         repo.GetLeagueJuiceMappingAsync(1, 2025).Returns(new LeagueJuiceMapping { Id = 5, LeagueId = 1, Season = 2025 });
+        repo.GetNflSeasonWeekConfigsAsync(2025).Returns(new List<NflSeasonWeekConfig>());
 
-        var result = await ctrl.UpdateLeagueJuice(1, 2025, new LeagueJuiceUpdateDto(13, 10, 6, 5));
+        var result = await ctrl.UpdateLeagueJuice(1, 2025, new LeagueJuiceUpdateDto(13, 10, 6, 5), BuildScheduleSource(repo));
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    // ── Season-boundary locks: tease points at season start, WeeklyCost at season end ──────────
+
+    [Fact]
+    public async Task UpdateJuice_RejectsTeaseChange_OnceSeasonHasStarted()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L", LeagueType = LeagueType.Nfl });
+        repo.GetLeagueJuiceMappingAsync(1, 2025).Returns(new LeagueJuiceMapping { Id = 5, LeagueId = 1, Season = 2025, Juice = 13, JuiceDivisional = 10, JuiceConference = 6, WeeklyCost = 5 });
+        repo.GetNflSeasonWeekConfigsAsync(2025).Returns(new List<NflSeasonWeekConfig> {
+            new() { Season = 2025, WeekId = 1, WeekLabel = "Week 1", WeekType = "Regular Season", ScoringFormat = "Standard",
+                FirstGameOfWeekStartDatetime = new DateTime(2025, 9, 4, 20, 20, 0, DateTimeKind.Utc) },
+        });
+
+        var result = await ctrl.UpdateLeagueJuice(1, 2025, new LeagueJuiceUpdateDto(14, 10, 6, 5), BuildScheduleSource(repo));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        await repo.DidNotReceive().UpdateLeagueJuiceMappingAsync(Arg.Any<LeagueJuiceMapping>());
+    }
+
+    [Fact]
+    public async Task UpdateJuice_AllowsWeeklyCostChange_EvenAfterSeasonHasStarted()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L", LeagueType = LeagueType.Nfl });
+        repo.GetLeagueJuiceMappingAsync(1, 2025).Returns(new LeagueJuiceMapping { Id = 5, LeagueId = 1, Season = 2025, Juice = 13, JuiceDivisional = 10, JuiceConference = 6, WeeklyCost = 5 });
+        repo.GetNflSeasonWeekConfigsAsync(2025).Returns(new List<NflSeasonWeekConfig> {
+            new() { Season = 2025, WeekId = 1, WeekLabel = "Week 1", WeekType = "Regular Season", ScoringFormat = "Standard",
+                FirstGameOfWeekStartDatetime = new DateTime(2025, 9, 4, 20, 20, 0, DateTimeKind.Utc) },
+        });
+
+        // Tease values resubmitted unchanged; only WeeklyCost differs — the season has started
+        // (fixed 2025 dates, always in the past), but WeeklyCost isn't locked until the season's
+        // LAST week, which has no config row here, so it's still open.
+        var result = await ctrl.UpdateLeagueJuice(1, 2025, new LeagueJuiceUpdateDto(13, 10, 6, 10), BuildScheduleSource(repo));
+
+        Assert.IsType<NoContentResult>(result);
+        await repo.Received(1).UpdateLeagueJuiceMappingAsync(Arg.Is<LeagueJuiceMapping>(m => m.WeeklyCost == 10));
+    }
+
+    [Fact]
+    public async Task UpdateJuice_RejectsWeeklyCostChange_OnceFinalWeekHasStarted()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L", LeagueType = LeagueType.Nfl });
+        repo.GetLeagueJuiceMappingAsync(1, 2025).Returns(new LeagueJuiceMapping { Id = 5, LeagueId = 1, Season = 2025, Juice = 13, JuiceDivisional = 10, JuiceConference = 6, WeeklyCost = 5 });
+        repo.GetNflSeasonWeekConfigsAsync(2025).Returns(new List<NflSeasonWeekConfig> {
+            new() { Season = 2025, WeekId = 22, WeekLabel = "Super Bowl", WeekType = "PostSeason", ScoringFormat = "Standard",
+                FirstGameOfWeekStartDatetime = new DateTime(2026, 2, 8, 23, 30, 0, DateTimeKind.Utc) },
+        });
+
+        var result = await ctrl.UpdateLeagueJuice(1, 2025, new LeagueJuiceUpdateDto(13, 10, 6, 10), BuildScheduleSource(repo));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        await repo.DidNotReceive().UpdateLeagueJuiceMappingAsync(Arg.Any<LeagueJuiceMapping>());
+    }
+
+    [Fact]
+    public async Task UpdateJuice_AllowsTeaseChange_BeforeFinalWeekHasStarted_EvenWithConfigRowSeeded()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L", LeagueType = LeagueType.Nfl });
+        repo.GetLeagueJuiceMappingAsync(1, 2025).Returns(new LeagueJuiceMapping { Id = 5, LeagueId = 1, Season = 2025, Juice = 13, JuiceDivisional = 10, JuiceConference = 6, WeeklyCost = 5 });
+        // Super Bowl config row exists but is set far in the future — WeeklyCost lock hasn't hit
+        // yet either way, and Season 2025's WEEK 1 has no config row at all here, so tease is open.
+        repo.GetNflSeasonWeekConfigsAsync(2025).Returns(new List<NflSeasonWeekConfig> {
+            new() { Season = 2025, WeekId = 22, WeekLabel = "Super Bowl", WeekType = "PostSeason", ScoringFormat = "Standard",
+                FirstGameOfWeekStartDatetime = new DateTime(2099, 2, 8, 23, 30, 0, DateTimeKind.Utc) },
+        });
+
+        var result = await ctrl.UpdateLeagueJuice(1, 2025, new LeagueJuiceUpdateDto(14, 10, 6, 5), BuildScheduleSource(repo));
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdateJuice_AllowsAnyChange_WhenSeasonHasNoConfigRowsAtAll()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L", LeagueType = LeagueType.Cfb });
+        repo.GetLeagueJuiceMappingAsync(1, 2031).Returns(new LeagueJuiceMapping { Id = 5, LeagueId = 1, Season = 2031, Juice = 13, JuiceDivisional = 10, JuiceConference = 6, WeeklyCost = 5 });
+
+        var result = await ctrl.UpdateLeagueJuice(1, 2031, new LeagueJuiceUpdateDto(20, 15, 9, 15), BuildScheduleSource(repo));
 
         Assert.IsType<NoContentResult>(result);
     }
@@ -388,7 +494,7 @@ public class LeagueOwnershipTests
         var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
         repo.GetLeagueInfoAsync(999).Returns(Task.FromException<LeagueInfo>(new InvalidOperationException("Sequence contains no elements")));
 
-        var result = await ctrl.UpdateLeagueJuice(999, 2025, new LeagueJuiceUpdateDto(13, 10, 6, 5));
+        var result = await ctrl.UpdateLeagueJuice(999, 2025, new LeagueJuiceUpdateDto(13, 10, 6, 5), BuildScheduleSource(repo));
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -1144,7 +1250,7 @@ public class LeagueOwnershipTests
         var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId));
         repo.UserExistsInLeagueAsync(AttackerId, 1).Returns(false);
 
-        var result = await ctrl.GetLeagueJuice(1);
+        var result = await ctrl.GetLeagueJuice(1, EmptyCfbRepo());
 
         Assert.IsType<ForbidResult>(result.Result);
     }
@@ -1157,7 +1263,7 @@ public class LeagueOwnershipTests
         repo.UserExistsInLeagueAsync(memberId, 1).Returns(true);
         repo.GetLeagueJuiceMappingAsync(1).Returns([]);
 
-        var result = await ctrl.GetLeagueJuice(1);
+        var result = await ctrl.GetLeagueJuice(1, EmptyCfbRepo());
 
         Assert.IsType<OkObjectResult>(result.Result);
     }
@@ -1168,7 +1274,7 @@ public class LeagueOwnershipTests
         var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId, isAdmin: true));
         repo.GetLeagueJuiceMappingAsync(1).Returns([]);
 
-        var result = await ctrl.GetLeagueJuice(1);
+        var result = await ctrl.GetLeagueJuice(1, EmptyCfbRepo());
 
         Assert.IsType<OkObjectResult>(result.Result);
     }
@@ -1181,7 +1287,7 @@ public class LeagueOwnershipTests
         var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId));
         repo.UserExistsInLeagueAsync(AttackerId, 1).Returns(false);
 
-        var result = await ctrl.GetLeagueJuiceForSeason(1, 2025);
+        var result = await ctrl.GetLeagueJuiceForSeason(1, 2025, BuildScheduleSource(repo));
 
         Assert.IsType<ForbidResult>(result.Result);
     }
@@ -1194,7 +1300,7 @@ public class LeagueOwnershipTests
         repo.UserExistsInLeagueAsync(memberId, 1).Returns(true);
         repo.GetLeagueJuiceMappingAsync(1, 2025).Returns((LeagueJuiceMapping?)null);
 
-        var result = await ctrl.GetLeagueJuiceForSeason(1, 2025);
+        var result = await ctrl.GetLeagueJuiceForSeason(1, 2025, BuildScheduleSource(repo));
 
         Assert.IsType<OkObjectResult>(result.Result);
     }
@@ -1205,7 +1311,7 @@ public class LeagueOwnershipTests
         var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(AttackerId, isAdmin: true));
         repo.GetLeagueJuiceMappingAsync(1, 2025).Returns((LeagueJuiceMapping?)null);
 
-        var result = await ctrl.GetLeagueJuiceForSeason(1, 2025);
+        var result = await ctrl.GetLeagueJuiceForSeason(1, 2025, BuildScheduleSource(repo));
 
         Assert.IsType<OkObjectResult>(result.Result);
     }

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -1,4 +1,5 @@
 ﻿using FourPlayWebApp.Server.Auth;
+using FourPlayWebApp.Server.Jobs;
 using FourPlayWebApp.Server.Models;
 using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Models.Identity;
@@ -111,34 +112,65 @@ public class LeagueController(
     */
 
     // ---------- League Juice ----------
+
+    // Used only by GetLeagueJuice below, which needs every season's lock state at once from one
+    // already-fetched full config table (not the season-scoped LeagueJuiceScheduleSource.
+    // GetJuiceLockStateAsync instance method GetLeagueJuiceForSeason/UpdateLeagueJuice use —
+    // those look up exactly one season, so a per-season DB round trip there is the cheaper
+    // fetch; here, fetching per-row instead of once would be N round trips for N seasons).
+    private static (bool TeaseLocked, bool WeeklyCostLocked) GetJuiceLockState(LeagueType leagueType, int season,
+        IEnumerable<NflSeasonWeekConfig> nflConfigs, IEnumerable<CfbSeasonWeekConfig> cfbConfigs) {
+        var now = DateTimeOffset.UtcNow.UtcDateTime;
+        var teaseLockTime = LeagueJuiceScheduleSource.GetSeasonStartLockTimeUtc(leagueType, season, nflConfigs, cfbConfigs);
+        var weeklyCostLockTime = LeagueJuiceScheduleSource.GetSeasonEndLockTimeUtc(leagueType, season, nflConfigs, cfbConfigs);
+        return (teaseLockTime is not null && now >= teaseLockTime, weeklyCostLockTime is not null && now >= weeklyCostLockTime);
+    }
+
     [HttpGet("{leagueId:int}/juice")]
     [ProducesResponseType(typeof(List<LeagueJuiceMappingDto>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<List<LeagueJuiceMappingDto>>> GetLeagueJuice(int leagueId) {
+    public async Task<ActionResult<List<LeagueJuiceMappingDto>>> GetLeagueJuice(int leagueId,
+            [FromServices] ICfbRepository cfbRepo) {
         var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (!User.IsInRole(AppRoles.Administrator) && !await repo.UserExistsInLeagueAsync(callerId!, leagueId))
             return Forbid();
         var mappings = await repo.GetLeagueJuiceMappingAsync(leagueId);
-        var dtoMappings = mappings.Select(m => new LeagueJuiceMappingDto {
-            LeagueId = m.LeagueId,
-            LeagueName = m.League.LeagueName,
-            Season = m.Season,
-            Juice = m.Juice,
-            JuiceDivisional = m.JuiceDivisional,
-            JuiceConference = m.JuiceConference,
-            WeeklyCost = m.WeeklyCost,
-            DateCreated = m.DateCreated
+        if (mappings.Count == 0) return Ok(new List<LeagueJuiceMappingDto>());
+
+        // All mappings belong to the same league, so the same sport's config table serves every
+        // one of them — fetched once, not once per season row.
+        var leagueType = mappings[0].League.LeagueType;
+        var nflConfigs = leagueType == LeagueType.Cfb ? [] : await repo.GetNflSeasonWeekConfigsAsync();
+        var cfbConfigs = leagueType == LeagueType.Cfb ? await cfbRepo.GetAllWeekConfigsAsync() : [];
+
+        var dtoMappings = mappings.Select(m => {
+            var (teaseLocked, weeklyCostLocked) = GetJuiceLockState(leagueType, m.Season, nflConfigs, cfbConfigs);
+            return new LeagueJuiceMappingDto {
+                LeagueId = m.LeagueId,
+                LeagueName = m.League.LeagueName,
+                Season = m.Season,
+                Juice = m.Juice,
+                JuiceDivisional = m.JuiceDivisional,
+                JuiceConference = m.JuiceConference,
+                WeeklyCost = m.WeeklyCost,
+                DateCreated = m.DateCreated,
+                TeaseLocked = teaseLocked,
+                WeeklyCostLocked = weeklyCostLocked,
+            };
         }).ToList();
         return Ok(dtoMappings);
     }
 
     [HttpGet("{leagueId:int}/juice/{season:int}")]
     [ProducesResponseType(typeof(LeagueJuiceMappingDto), StatusCodes.Status200OK)]
-    public async Task<ActionResult<LeagueJuiceMappingDto?>> GetLeagueJuiceForSeason(int leagueId, int season) {
+    public async Task<ActionResult<LeagueJuiceMappingDto?>> GetLeagueJuiceForSeason(int leagueId, int season,
+            [FromServices] LeagueJuiceScheduleSource scheduleSource) {
         var callerId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (!User.IsInRole(AppRoles.Administrator) && !await repo.UserExistsInLeagueAsync(callerId!, leagueId))
             return Forbid();
         var mapping = await repo.GetLeagueJuiceMappingAsync(leagueId, season);
         if (mapping == null) return Ok(null);
+
+        var (teaseLocked, weeklyCostLocked) = await scheduleSource.GetJuiceLockStateAsync(mapping.League.LeagueType, season);
 
         var dtoMapping = new LeagueJuiceMappingDto {
             LeagueId = mapping.LeagueId,
@@ -148,7 +180,9 @@ public class LeagueController(
             JuiceDivisional = mapping.JuiceDivisional,
             JuiceConference = mapping.JuiceConference,
             WeeklyCost = mapping.WeeklyCost,
-            DateCreated = mapping.DateCreated
+            DateCreated = mapping.DateCreated,
+            TeaseLocked = teaseLocked,
+            WeeklyCostLocked = weeklyCostLocked,
         };
         return Ok(dtoMapping);
     }
@@ -784,13 +818,30 @@ public class LeagueController(
 
     [HttpPut("{leagueId:int}/juice/{season:int}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> UpdateLeagueJuice(int leagueId, int season, [FromBody] LeagueJuiceUpdateDto dto) {
-        var (_, error) = await LoadOwnedLeagueAsync(leagueId);
+    public async Task<IActionResult> UpdateLeagueJuice(int leagueId, int season, [FromBody] LeagueJuiceUpdateDto dto,
+            [FromServices] LeagueJuiceScheduleSource scheduleSource) {
+        var (league, error) = await LoadOwnedLeagueAsync(leagueId);
         if (error is not null) return error;
-        var existing = await repo.GetLeagueJuiceMappingAsync(leagueId, season);
+
+        // Independent of each other — kick both off before awaiting instead of paying for two
+        // sequential round trips.
+        var existingTask = repo.GetLeagueJuiceMappingAsync(leagueId, season);
+        var lockStateTask = scheduleSource.GetJuiceLockStateAsync(league!.LeagueType, season);
+        await Task.WhenAll(existingTask, lockStateTask);
+        var existing = existingTask.Result;
         if (existing is null) return NotFound($"No juice mapping for league {leagueId} season {season}.");
+        var (teaseLocked, weeklyCostLocked) = lockStateTask.Result;
+
+        var teaseChanged = dto.Juice != existing.Juice || dto.JuiceDivisional != existing.JuiceDivisional
+            || dto.JuiceConference != existing.JuiceConference;
+        if (teaseLocked && teaseChanged)
+            return BadRequest("Tease points can't be changed once the season has started.");
+        if (weeklyCostLocked && dto.WeeklyCost != existing.WeeklyCost)
+            return BadRequest("Weekly Cost can't be changed once the season's final week has started.");
+
         existing.Juice = dto.Juice;
         existing.JuiceDivisional = dto.JuiceDivisional;
         existing.JuiceConference = dto.JuiceConference;

--- a/Server/Jobs/LeagueJuiceScheduleSource.cs
+++ b/Server/Jobs/LeagueJuiceScheduleSource.cs
@@ -30,29 +30,37 @@ public class LeagueJuiceScheduleSource(ILeagueRepository leagueRepo, ICfbReposit
 
         var now = timeProvider.GetUtcNow().UtcDateTime;
         var remindersSent = remindersSentTask.Result;
+        var nflConfigs = nflConfigsTask.Result;
+        var cfbConfigs = cfbConfigsTask.Result;
 
         // WeekId/IvLeagueWeekNumber == 1 is each sport's canonical "first week of the season" —
-        // both are unique per (Season, *) via DB constraint, so no duplicate-key risk. Only the
-        // DATE is used below (FirstGameOfWeekStartDatetime's time-of-day component comes from a
-        // hand-curated control-table spreadsheet, not a live/precise UTC source).
-        var nflSeasonStarts = nflConfigsTask.Result
-            .Where(c => c.WeekId == 1 && c.FirstGameOfWeekStartDatetime.HasValue)
-            .Select(c => (c.Season, Date: DateOnly.FromDateTime(c.FirstGameOfWeekStartDatetime!.Value)))
-            .Where(x => LockTimeUtc(x.Date) > now - StaleSeasonCutoff)
-            .ToDictionary(x => x.Season, x => x.Date);
-        var cfbSeasonStarts = cfbConfigsTask.Result
-            .Where(c => c.IvLeagueWeekNumber == 1 && c.InScopeIvLeague)
-            .Select(c => (c.Season, c.WeekStartDate))
-            .Where(x => LockTimeUtc(x.WeekStartDate) > now - StaleSeasonCutoff)
-            .ToDictionary(x => x.Season, x => x.WeekStartDate);
+        // both are unique per (Season, *) via DB constraint, so no duplicate-key risk. Lock time
+        // is computed once per DISTINCT season here (an O(1) dictionary lookup per league below),
+        // not once per (league, season) pair — the result only depends on (sport, season), and
+        // many leagues share a sport.
+        var nflLockTimes = nflConfigs.Where(c => c.WeekId == 1 && c.FirstGameOfWeekStartDatetime.HasValue)
+            .Select(c => c.Season).Distinct()
+            .ToDictionary(s => s, s => GetSeasonStartLockTimeUtc(LeagueType.Nfl, s, nflConfigs, cfbConfigs)!.Value);
+        var cfbLockTimes = cfbConfigs.Where(c => c.IvLeagueWeekNumber == 1 && c.InScopeIvLeague)
+            .Select(c => c.Season).Distinct()
+            .ToDictionary(s => s, s => GetSeasonStartLockTimeUtc(LeagueType.Cfb, s, nflConfigs, cfbConfigs)!.Value);
 
         var reminders = new List<TimedTriggerCandidate>();
         var locks = new List<TimedTriggerCandidate>();
 
         foreach (var league in leaguesTask.Result) {
-            var seasonStarts = league.LeagueType == LeagueType.Cfb ? cfbSeasonStarts : nflSeasonStarts;
-            foreach (var (season, startDate) in seasonStarts) {
-                var lockTimeUtc = LockTimeUtc(startDate);
+            var lockTimes = league.LeagueType == LeagueType.Cfb ? cfbLockTimes : nflLockTimes;
+            foreach (var (season, lockTimeUtc) in lockTimes) {
+                // /code-review: a season row that predates a league's creation looks
+                // "unconfigured" forever (the league simply never had a mapping for it) — without
+                // this cutoff, a brand-new league would get retroactive reminder emails and bogus
+                // auto-filled rows for every already-settled past season on record. A season is
+                // only ever a real candidate within this window of its lock time — long enough to
+                // cover any realistic app-downtime catch-up, nowhere near long enough to mistake a
+                // genuinely historical season for a current one. See StaleSeasonCutoff's own doc
+                // comment above for the full rationale.
+                if (lockTimeUtc <= now - StaleSeasonCutoff) continue;
+
                 var reminderTimeUtc = lockTimeUtc.AddDays(-2);
                 var hasJuice = league.LeagueJuiceMappings.Any(m => m.Season == season);
                 var identitySuffix = $"{league.Id}-{season}";
@@ -84,7 +92,51 @@ public class LeagueJuiceScheduleSource(ILeagueRepository leagueRepo, ICfbReposit
         return (reminders, locks);
     }
 
-    private static DateTime LockTimeUtc(DateOnly seasonStartDate) {
+    // frizat: LeagueController.UpdateLeagueJuice/GetLeagueJuiceForSeason's single-season lock
+    // check — season-scoped repo calls (not GetCandidatesAsync's own full-table fetch above,
+    // which genuinely needs every season at once for the batch scheduler) so a single request
+    // only pulls the 1-2 config rows it actually needs.
+    public async Task<(bool TeaseLocked, bool WeeklyCostLocked)> GetJuiceLockStateAsync(LeagueType leagueType, int season) {
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        IEnumerable<NflSeasonWeekConfig> nflConfigs = leagueType == LeagueType.Cfb ? [] : await leagueRepo.GetNflSeasonWeekConfigsAsync(season);
+        IEnumerable<CfbSeasonWeekConfig> cfbConfigs = leagueType == LeagueType.Cfb ? await cfbRepo.GetWeekConfigsForSeasonAsync(season) : [];
+
+        var teaseLockTime = GetSeasonStartLockTimeUtc(leagueType, season, nflConfigs, cfbConfigs);
+        var weeklyCostLockTime = GetSeasonEndLockTimeUtc(leagueType, season, nflConfigs, cfbConfigs);
+        return (teaseLockTime is not null && now >= teaseLockTime, weeklyCostLockTime is not null && now >= weeklyCostLockTime);
+    }
+
+    // frizat: single source of truth for "when does a given week/slate start" (2pm
+    // America/Chicago on its own start date) — shared by GetCandidatesAsync above (drives the
+    // Juice Reminder/Lock Quartz triggers off week/slate 1) and
+    // LeagueController.UpdateLeagueJuice (blocks editing tease points once week/slate 1 has
+    // started, and WeeklyCost once the season's final week/slate has started). Pure, no I/O —
+    // callers pass in whatever config rows they already have. Null means no matching config row
+    // exists yet for that (season, weekOrSlateNumber) — never a reason to block anything.
+    public static DateTime? GetWeekLockTimeUtc(LeagueType leagueType, int season, int weekOrSlateNumber,
+        IEnumerable<NflSeasonWeekConfig> nflConfigs, IEnumerable<CfbSeasonWeekConfig> cfbConfigs) {
+        if (leagueType == LeagueType.Cfb) {
+            var slate = cfbConfigs.FirstOrDefault(c =>
+                c.Season == season && c.IvLeagueWeekNumber == weekOrSlateNumber && c.InScopeIvLeague);
+            return slate is null ? null : LockTimeUtc(slate.WeekStartDate);
+        }
+        var week = nflConfigs.FirstOrDefault(c =>
+            c.Season == season && c.WeekId == weekOrSlateNumber && c.FirstGameOfWeekStartDatetime.HasValue);
+        return week is null ? null : LockTimeUtc(DateOnly.FromDateTime(week.FirstGameOfWeekStartDatetime!.Value));
+    }
+
+    // Tease points (Juice/JuiceDivisional/JuiceConference) lock here — week/slate 1's own start.
+    public static DateTime? GetSeasonStartLockTimeUtc(LeagueType leagueType, int season,
+        IEnumerable<NflSeasonWeekConfig> nflConfigs, IEnumerable<CfbSeasonWeekConfig> cfbConfigs) =>
+        GetWeekLockTimeUtc(leagueType, season, 1, nflConfigs, cfbConfigs);
+
+    // WeeklyCost locks here — the season's final week (NFL WeekId 22 Super Bowl) or slate (CFB
+    // slate 18 Championship), per CLAUDE.md's pick-count tables (/pick-rules).
+    public static DateTime? GetSeasonEndLockTimeUtc(LeagueType leagueType, int season,
+        IEnumerable<NflSeasonWeekConfig> nflConfigs, IEnumerable<CfbSeasonWeekConfig> cfbConfigs) =>
+        GetWeekLockTimeUtc(leagueType, season, leagueType == LeagueType.Cfb ? 18 : 22, nflConfigs, cfbConfigs);
+
+    public static DateTime LockTimeUtc(DateOnly seasonStartDate) {
         var wallClockCentral = seasonStartDate.ToDateTime(new TimeOnly(14, 0));
         return TimeZoneInfo.ConvertTimeToUtc(wallClockCentral, AppTimeZones.Central);
     }

--- a/Shared/Models/Data/Dtos/LeagueJuiceMappingDto.cs
+++ b/Shared/Models/Data/Dtos/LeagueJuiceMappingDto.cs
@@ -11,4 +11,10 @@ public class LeagueJuiceMappingDto
     public int JuiceConference { get; set; }
     public int WeeklyCost { get; set; }
     public DateTimeOffset DateCreated { get; set; } = DateTimeOffset.UtcNow;
+    // Tease points (Juice/JuiceDivisional/JuiceConference) lock once the season's first week/slate
+    // has started; WeeklyCost locks separately, once the season's LAST week/slate (Super Bowl /
+    // Championship) has started — see LeagueController.UpdateLeagueJuice and
+    // LeagueJuiceScheduleSource.GetSeasonStartLockTimeUtc/GetSeasonEndLockTimeUtc.
+    public bool TeaseLocked { get; set; }
+    public bool WeeklyCostLocked { get; set; }
 }


### PR DESCRIPTION
## Summary
Promotes PR #345 from `dev` to `main`.

- Adds two independent server-side edit locks to a league's Juice settings: tease points (Juice/JuiceDivisional/JuiceConference) lock once the season's first week/slate starts; Weekly Cost locks separately once the season's final week/slate (Super Bowl/Championship) starts.
- Closes a real gap found live: nothing previously prevented editing these fields at any point in a season, including retroactively affecting already-decided weeks' totals.

Already verified on `dev.ivleague.xyz`/`cfb.dev.ivleague.xyz` after PR #345 merged.

## Test plan
- [x] Full backend/frontend/e2e suites green (see PR #345 for details)
- [x] `/simplify` + code review applied
- [x] Will verify `ivleague.xyz`/`cfb.ivleague.xyz` `/api/version` after merge

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs