### PR TITLE
Unify NFL/CFB settled-score cache reconstruction

### DIFF
--- a/Server.UnitTests/CfbCacheServiceTests.cs
+++ b/Server.UnitTests/CfbCacheServiceTests.cs
@@ -3,18 +3,21 @@ using FourPlayWebApp.Server.Services;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models;
+using FourPlayWebApp.Shared.Models.Data;
 using FourPlayWebApp.Shared.Models.Enum;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 
 namespace FourPlayWebApp.Server.UnitTests;
 
 /// <summary>
-/// Mirrors EspnCacheServiceTests exactly (frizat-703.6 unification) — same PeriodicRefreshCache
-/// engine, same deterministic-wait pattern, only the fetch delegate (current slate + CFP/ranked
-/// filtering) differs. Uses a real IServiceScopeFactory (backed by a minimal ServiceCollection)
-/// since CfbCacheService creates a DI scope per refresh to safely consume the Scoped
-/// ICfbCurrentSlateService/ICfbRepository from a Singleton — see CfbCacheService's own comment.
+/// Mirrors EspnCacheServiceTests exactly (frizat-703.6 unification, frizat-d0t settled-cache
+/// unification) — same PeriodicRefreshCache engine, same deterministic-wait pattern, only the
+/// fetch delegate (current slate + CFP/ranked filtering) differs. Uses a real
+/// IServiceScopeFactory (backed by a minimal ServiceCollection) since CfbCacheService creates a
+/// DI scope per refresh to safely consume the Scoped ICfbCurrentSlateService/ICfbRepository from
+/// a Singleton — see CfbCacheService's own comment.
 /// </summary>
 public class CfbCacheServiceTests
 {
@@ -22,6 +25,7 @@ public class CfbCacheServiceTests
     private readonly ICfbRepository _cfbRepo;
     private readonly ICfbLiveScoreFetcher _fetcher;
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IMemoryCache _memoryCache = new MemoryCache(new MemoryCacheOptions());
 
     // StartDate/EndDate relative to "now" (not a fixed calendar date) so this slate is always
     // "currently active" for the SeasonWindowResolver-based gate CfbCacheService now checks
@@ -39,6 +43,14 @@ public class CfbCacheServiceTests
         EspnWeekNumber = 5, ScoringFormat = "Spread",
     };
 
+    // A separate, already-ENDED slate (fixed past calendar dates) for the settled-cache tests
+    // below — DefaultSlate is deliberately always-active so it can't exercise the DB-first path.
+    private static readonly CfbSlates SettledSlate = new() {
+        Id = 2, Season = 2025, SlateNumber = 4, Label = "Week 4", SlateType = "RegularSeason",
+        StartDate = new DateOnly(2025, 9, 27), EndDate = new DateOnly(2025, 9, 28),
+        EspnWeekNumber = 4, ScoringFormat = "Spread",
+    };
+
     public CfbCacheServiceTests()
     {
         _currentSlateService = Substitute.For<ICfbCurrentSlateService>();
@@ -46,6 +58,11 @@ public class CfbCacheServiceTests
         _fetcher = Substitute.For<ICfbLiveScoreFetcher>();
         _currentSlateService.GetCurrentSlateAsync().Returns(DefaultSlateInfo);
         _cfbRepo.GetSlateByIdAsync(DefaultSlate.Id).Returns(DefaultSlate);
+        _cfbRepo.GetSlateByIdAsync(SettledSlate.Id).Returns(SettledSlate);
+        // Default: no persisted rows for any slate, so existing tests (which never seed the
+        // repo) keep exercising the live-fetch branch exactly as before GetSlateScoresAsync
+        // existed.
+        _cfbRepo.GetScoresForSlateAsync(Arg.Any<int>()).Returns((IEnumerable<CfbScores>)[]);
         // Default: a season is active, so existing tests keep exercising the live-fetch branch
         // unchanged by the new off-season gate.
         _currentSlateService.IsSeasonActiveAsync().Returns(true);
@@ -55,6 +72,9 @@ public class CfbCacheServiceTests
         services.AddSingleton(_cfbRepo);
         _scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
     }
+
+    private CfbCacheService BuildService(TimeSpan? initialDelay = null) =>
+        new(_scopeFactory, _fetcher, _memoryCache, initialDelay);
 
     private static async Task WaitForScoresChangedAsync(CfbCacheService svc, TimeSpan? timeout = null)
     {
@@ -87,19 +107,19 @@ public class CfbCacheServiceTests
     {
         _currentSlateService.GetCurrentSlateAsync().Returns((CfbSlateInfo?)null);
 
-        await using var svc = new CfbCacheService(_scopeFactory, _fetcher);
+        await using var svc = BuildService(TimeSpan.FromMinutes(5));
         await Task.Delay(300);
 
         Assert.Null(await svc.GetScoresAsync());
-        await _fetcher.DidNotReceive().FetchForSlateAsync(Arg.Any<CfbSlates>());
+        await _fetcher.DidNotReceive().FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>());
     }
 
     [Fact]
     public async Task GetScoresAsync_ResolvesFullSlateEntity_ThenFetches()
     {
-        _fetcher.FetchForSlateAsync(Arg.Is<CfbSlates>(s => s.Id == DefaultSlate.Id)).Returns(BuildScoreboard());
+        _fetcher.FetchForSlateAsync(Arg.Is<CfbSlates>(s => s.Id == DefaultSlate.Id), Arg.Any<bool>()).Returns(BuildScoreboard());
 
-        await using var svc = new CfbCacheService(_scopeFactory, _fetcher, initialDelay: TimeSpan.FromMilliseconds(50));
+        await using var svc = BuildService(initialDelay: TimeSpan.FromMilliseconds(50));
         await WaitForScoresChangedAsync(svc);
 
         var result = await svc.GetScoresAsync();
@@ -111,9 +131,9 @@ public class CfbCacheServiceTests
     public async Task ScoresChanged_Fires_WhenLiveScoreChanges()
     {
         int fireCount = 0;
-        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>()).Returns(BuildScoreboard(homeScore: 14, awayScore: 7));
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns(BuildScoreboard(homeScore: 14, awayScore: 7));
 
-        await using var svc = new CfbCacheService(_scopeFactory, _fetcher, initialDelay: TimeSpan.FromMilliseconds(50));
+        await using var svc = BuildService(initialDelay: TimeSpan.FromMilliseconds(50));
         svc.ScoresChanged += () => Interlocked.Increment(ref fireCount);
 
         await WaitForScoresChangedAsync(svc);
@@ -130,21 +150,161 @@ public class CfbCacheServiceTests
     {
         _currentSlateService.IsSeasonActiveAsync().Returns(false);
 
-        await using var svc = new CfbCacheService(_scopeFactory, _fetcher, initialDelay: TimeSpan.FromMilliseconds(50));
+        await using var svc = BuildService(initialDelay: TimeSpan.FromMilliseconds(50));
         await Task.Delay(300);
 
         Assert.Null(await svc.GetScoresAsync());
-        await _fetcher.DidNotReceive().FetchForSlateAsync(Arg.Any<CfbSlates>());
+        await _fetcher.DidNotReceive().FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>());
     }
 
     [Fact]
     public async Task GetScoresAsync_WhenFetcherReturnsNull_ReturnsNull()
     {
-        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>()).Returns((EspnScores?)null);
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns((EspnScores?)null);
 
-        await using var svc = new CfbCacheService(_scopeFactory, _fetcher);
+        await using var svc = BuildService(TimeSpan.FromMinutes(5));
         await Task.Delay(300);
 
         Assert.Null(await svc.GetScoresAsync());
+    }
+
+    // ── GetSlateScoresAsync — settled-slate DB-first cache (migrated from
+    // CfbLiveScoreFetcherTests.cs, frizat-d0t) ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetSlateScoresAsync_WhenDbHasPersistedRowsForTheSlate_ReturnsDbBuiltScores_NeverCallsFetcher()
+    {
+        var rows = new List<CfbScores> {
+            new() { Id = 1, CfbSlateId = SettledSlate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal, GameTime = new DateTimeOffset(2025, 9, 27, 18, 0, 0, TimeSpan.Zero) },
+        };
+        _cfbRepo.GetScoresForSlateAsync(SettledSlate.Id).Returns((IEnumerable<CfbScores>)rows);
+
+        await using var svc = BuildService(TimeSpan.FromMinutes(5));
+        var result = await svc.GetSlateScoresAsync(SettledSlate.Id);
+
+        Assert.NotNull(result);
+        var comp = result!.Events!.Single().Competitions[0];
+        var home = comp.Competitors.Single(c => c.HomeAway == HomeAway.Home);
+        Assert.Equal("OSU", home.Team.Abbreviation);
+        Assert.Equal(28, home.Score);
+        Assert.Equal(TypeName.StatusFinal, comp.Status.Type.Name);
+        await _fetcher.DidNotReceive().FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>());
+    }
+
+    // frizat: cfbAdapter.ts's current-slate path now always calls this endpoint for whichever
+    // slate the control table (ICfbCurrentSlateService) resolves as current — that slate must
+    // always be live-fetched, even if its own calendar window looks "ended" and persisted rows
+    // exist, or the demo's frozen in-progress fixture data never surfaces for it.
+    [Fact]
+    public async Task GetSlateScoresAsync_WhenSlateIsTheResolvedCurrentSlate_AlwaysCallsFetcher_EvenWithPersistedRowsAndEndedWindow()
+    {
+        var rows = new List<CfbScores> {
+            new() { Id = 1, CfbSlateId = SettledSlate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal, GameTime = new DateTimeOffset(2025, 9, 27, 18, 0, 0, TimeSpan.Zero) },
+        };
+        _cfbRepo.GetScoresForSlateAsync(SettledSlate.Id).Returns((IEnumerable<CfbScores>)rows);
+        _currentSlateService.GetCurrentSlateAsync().Returns(new CfbSlateInfo(
+            SettledSlate.Id, SettledSlate.Season, SettledSlate.SlateNumber, SettledSlate.Label, SettledSlate.SlateType,
+            SettledSlate.StartDate, SettledSlate.EndDate, null, DateTime.UtcNow));
+        var espnScores = BuildScoreboard();
+        _fetcher.FetchForSlateAsync(Arg.Is<CfbSlates>(s => s.Id == SettledSlate.Id), Arg.Any<bool>()).Returns(espnScores);
+
+        await using var svc = BuildService(TimeSpan.FromMinutes(5));
+        var result = await svc.GetSlateScoresAsync(SettledSlate.Id);
+
+        Assert.Same(espnScores, result);
+        // isCurrentSlate must be the already-resolved true, not re-derived by the fetcher (which
+        // no longer has the means to — it takes this as a parameter now, frizat-d0t).
+        await _fetcher.Received(1).FetchForSlateAsync(Arg.Is<CfbSlates>(s => s.Id == SettledSlate.Id), isCurrentSlate: true);
+    }
+
+    [Fact]
+    public async Task GetSlateScoresAsync_WhenDbHasNoRowsForTheSlate_FallsBackToFetcher()
+    {
+        var espnScores = BuildScoreboard();
+        _fetcher.FetchForSlateAsync(Arg.Is<CfbSlates>(s => s.Id == DefaultSlate.Id), Arg.Any<bool>()).Returns(espnScores);
+
+        await using var svc = BuildService(TimeSpan.FromMinutes(5));
+        var result = await svc.GetSlateScoresAsync(DefaultSlate.Id);
+
+        Assert.Same(espnScores, result);
+        // DefaultSlate.Id matches the constructor's default GetCurrentSlateAsync() setup — true.
+        await _fetcher.Received(1).FetchForSlateAsync(Arg.Is<CfbSlates>(s => s.Id == DefaultSlate.Id), isCurrentSlate: true);
+    }
+
+    [Fact]
+    public async Task GetSlateScoresAsync_WhenNoSlateMatchesTheRequestedId_ReturnsNull_NeverCallsFetcher()
+    {
+        _cfbRepo.GetSlateByIdAsync(999).Returns((CfbSlates?)null);
+
+        await using var svc = BuildService(TimeSpan.FromMinutes(5));
+        var result = await svc.GetSlateScoresAsync(999);
+
+        Assert.Null(result);
+        await _fetcher.DidNotReceiveWithAnyArgs().FetchForSlateAsync(default!, default!);
+    }
+
+    // /code-review caught the DB-first branch silently defaulting a missing EspnWeekNumber to
+    // week 0 instead of applying the same guard the ESPN-fallback path already used — even with
+    // persisted rows present, a slate with no week number is a data-integrity problem, not
+    // something to paper over.
+    [Fact]
+    public async Task GetSlateScoresAsync_MissingEspnWeekNumber_ReturnsNull_EvenWithPersistedRows()
+    {
+        var slate = new CfbSlates {
+            Id = 3, Season = 2025, SlateNumber = 1, Label = "Week 1", SlateType = "RegularSeason",
+            StartDate = new DateOnly(2025, 12, 19), EndDate = new DateOnly(2025, 12, 20), EspnWeekNumber = null,
+        };
+        _cfbRepo.GetSlateByIdAsync(slate.Id).Returns(slate);
+        var rows = new List<CfbScores> {
+            new() { Id = 1, CfbSlateId = slate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal, GameTime = new DateTimeOffset(2025, 12, 19, 18, 0, 0, TimeSpan.Zero) },
+        };
+        _cfbRepo.GetScoresForSlateAsync(slate.Id).Returns((IEnumerable<CfbScores>)rows);
+
+        await using var svc = BuildService(TimeSpan.FromMinutes(5));
+        var result = await svc.GetSlateScoresAsync(slate.Id);
+
+        Assert.Null(result);
+        await _fetcher.DidNotReceiveWithAnyArgs().FetchForSlateAsync(default!, default!);
+    }
+
+    // A settled slate's DB-built response is immutable (a persisted row is always FINAL) — once
+    // built, repeated requests for the same slate should be served from an in-memory cache instead
+    // of re-querying the DB every time, so concurrent viewers of the same settled slate share one
+    // DB read total, not one DB read each.
+    [Fact]
+    public async Task GetSlateScoresAsync_CachesTheDbBuiltResult_SecondCallForSameSlateNeverHitsDbAgain()
+    {
+        var rows = new List<CfbScores> {
+            new() { Id = 1, CfbSlateId = SettledSlate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal, GameTime = new DateTimeOffset(2025, 9, 27, 18, 0, 0, TimeSpan.Zero) },
+        };
+        _cfbRepo.GetScoresForSlateAsync(SettledSlate.Id).Returns((IEnumerable<CfbScores>)rows);
+
+        await using var svc = BuildService(TimeSpan.FromMinutes(5));
+        var first = await svc.GetSlateScoresAsync(SettledSlate.Id);
+        _cfbRepo.ClearReceivedCalls();
+        var second = await svc.GetSlateScoresAsync(SettledSlate.Id);
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        // The cache-hit fast path skips the slate/current-slate DB resolution entirely on the
+        // second call, not just the settled-rows read — GetSlateByIdAsync is never called again.
+        await _cfbRepo.DidNotReceiveWithAnyArgs().GetSlateByIdAsync(default);
+        await _cfbRepo.DidNotReceiveWithAnyArgs().GetScoresForSlateAsync(default);
+    }
+
+    [Fact]
+    public async Task InvalidateSlateCache_ForcesTheNextRequestToRebuildFromTheDb()
+    {
+        var rows = new List<CfbScores> {
+            new() { Id = 1, CfbSlateId = SettledSlate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal, GameTime = new DateTimeOffset(2025, 9, 27, 18, 0, 0, TimeSpan.Zero) },
+        };
+        _cfbRepo.GetScoresForSlateAsync(SettledSlate.Id).Returns((IEnumerable<CfbScores>)rows);
+
+        await using var svc = BuildService(TimeSpan.FromMinutes(5));
+        await svc.GetSlateScoresAsync(SettledSlate.Id);
+        svc.InvalidateSlateCache(SettledSlate.Id);
+        await svc.GetSlateScoresAsync(SettledSlate.Id);
+
+        await _cfbRepo.Received(2).GetScoresForSlateAsync(SettledSlate.Id);
     }
 }

--- a/Server.UnitTests/CfbLiveScoreFetcherTests.cs
+++ b/Server.UnitTests/CfbLiveScoreFetcherTests.cs
@@ -1,11 +1,9 @@
 using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Services;
 using FourPlayWebApp.Server.Services.Interfaces;
-using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models;
 using FourPlayWebApp.Shared.Models.Data;
 using FourPlayWebApp.Shared.Models.Enum;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 
@@ -13,31 +11,20 @@ namespace FourPlayWebApp.Server.UnitTests;
 
 /// <summary>
 /// frizat-703.6: CFP week=999/date-filter, ranked-team-filter, and legacy date-range branching
-/// extracted from CfbScoresJob into a shared fetcher — both the DB-upsert job and CfbCacheService's
-/// live-serving path use this same implementation instead of duplicating the logic.
+/// extracted from CfbScoresJob into a shared fetcher. frizat-d0t: this fetcher is now a PURE
+/// fetch, no caching — the settled-slate DB-reconstruction + cache that used to live here (with
+/// its own current-slate exemption and window-ended gating) moved to
+/// CfbCacheService.GetSlateScoresAsync (see CfbCacheServiceTests.cs for that coverage), mirroring
+/// where NFL's equivalent already lived (EspnCacheService.GetWeekScoresAsync). This file now only
+/// covers the pure ESPN-call shape — none of it exercises the replay-mode snapshot merge (that
+/// needs a registered ReplayCacheService, which none of these tests set up), so every call below
+/// passes isCurrentSlate: false.
 /// </summary>
 public class CfbLiveScoreFetcherTests {
     private readonly ICfbApiService _cfbApi = Substitute.For<ICfbApiService>();
-    private readonly ICfbRepository _cfbRepo = Substitute.For<ICfbRepository>();
-    private readonly ICfbCurrentSlateService _currentSlateService = Substitute.For<ICfbCurrentSlateService>();
-    private readonly IServiceScopeFactory _scopeFactory;
-    private readonly IMemoryCache _settledCache = new MemoryCache(new MemoryCacheOptions());
+    private readonly IServiceProvider _serviceProvider = new ServiceCollection().BuildServiceProvider();
 
-    public CfbLiveScoreFetcherTests() {
-        // Default: no persisted rows for any slate, so existing tests (which never seed the repo)
-        // keep exercising the live-ESPN branch exactly as before this DB-first check was added.
-        _cfbRepo.GetScoresForSlateAsync(Arg.Any<int>()).Returns((IEnumerable<CfbScores>)[]);
-        // Default: no resolved "current" slate, so existing tests (which never care about the
-        // current-slate exemption) keep exercising slateHasEnded exactly as before that check
-        // was added.
-        _currentSlateService.GetCurrentSlateAsync().Returns((CfbSlateInfo?)null);
-        var services = new ServiceCollection();
-        services.AddSingleton(_cfbRepo);
-        services.AddSingleton(_currentSlateService);
-        _scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
-    }
-
-    private CfbLiveScoreFetcher BuildFetcher() => new(_cfbApi, _scopeFactory, _settledCache);
+    private CfbLiveScoreFetcher BuildFetcher() => new(_cfbApi, _serviceProvider);
 
     private static EspnScores BuildScoreboard(
         string eventId = "401677183",
@@ -100,7 +87,7 @@ public class CfbLiveScoreFetcherTests {
         var slate = BuildRegularSeasonSlate();
         _cfbApi.GetScoresByDateRangeAsync(slate.StartDate, slate.EndDate).Returns(BuildScoreboardWithRanking(homeRank: 99, awayRank: 99));
 
-        var result = await BuildFetcher().FetchForSlateAsync(slate);
+        var result = await BuildFetcher().FetchForSlateAsync(slate, isCurrentSlate: false);
 
         Assert.NotNull(result);
         Assert.Single(result!.Events!);
@@ -111,7 +98,7 @@ public class CfbLiveScoreFetcherTests {
         var slate = BuildRegularSeasonSlate();
         _cfbApi.GetScoresByDateRangeAsync(slate.StartDate, slate.EndDate).Returns(BuildScoreboardWithRanking(homeRank: 5, awayRank: 99));
 
-        var result = await BuildFetcher().FetchForSlateAsync(slate);
+        var result = await BuildFetcher().FetchForSlateAsync(slate, isCurrentSlate: false);
 
         Assert.NotNull(result);
         Assert.Single(result!.Events!);
@@ -140,7 +127,7 @@ public class CfbLiveScoreFetcherTests {
         _cfbApi.GetScoresByDateRangeAsync(new DateOnly(2026, 9, 1), new DateOnly(2026, 9, 7))
             .Returns(BuildScoreboardWithRanking(date: new DateTimeOffset(2026, 9, 5, 1, 0, 0, TimeSpan.Zero)));
 
-        var result = await BuildFetcher().FetchForSlateAsync(slate);
+        var result = await BuildFetcher().FetchForSlateAsync(slate, isCurrentSlate: false);
 
         await _cfbApi.Received(1).GetScoresByDateRangeAsync(new DateOnly(2026, 9, 1), new DateOnly(2026, 9, 7));
         await _cfbApi.DidNotReceiveWithAnyArgs().GetCfpGamesAsync();
@@ -187,7 +174,7 @@ public class CfbLiveScoreFetcherTests {
         };
         _cfbApi.GetScoresByDateRangeAsync(slate.StartDate, slate.EndDate).Returns(scoreboard);
 
-        var result = await BuildFetcher().FetchForSlateAsync(slate);
+        var result = await BuildFetcher().FetchForSlateAsync(slate, isCurrentSlate: false);
 
         Assert.NotNull(result);
         var evt = Assert.Single(result!.Events!);
@@ -209,7 +196,7 @@ public class CfbLiveScoreFetcherTests {
     public async Task FetchForSlateAsync_CfpSlate_UsesCfpGamesAsync_NotWeekQuery() {
         _cfbApi.GetCfpGamesAsync().Returns(BuildScoreboard());
 
-        var result = await BuildFetcher().FetchForSlateAsync(BuildCfpSlate());
+        var result = await BuildFetcher().FetchForSlateAsync(BuildCfpSlate(), isCurrentSlate: false);
 
         await _cfbApi.Received(1).GetCfpGamesAsync();
         await _cfbApi.DidNotReceive().GetScoresByDateRangeAsync(Arg.Any<DateOnly>(), Arg.Any<DateOnly>());
@@ -222,7 +209,7 @@ public class CfbLiveScoreFetcherTests {
         var wrongRound = BuildScoreboard(date: new DateTimeOffset(2026, 1, 1, 18, 0, 0, TimeSpan.Zero));
         _cfbApi.GetCfpGamesAsync().Returns(wrongRound);
 
-        var result = await BuildFetcher().FetchForSlateAsync(BuildCfpSlate());
+        var result = await BuildFetcher().FetchForSlateAsync(BuildCfpSlate(), isCurrentSlate: false);
 
         Assert.Null(result);
     }
@@ -243,137 +230,10 @@ public class CfbLiveScoreFetcherTests {
 
     [Fact]
     public async Task FetchForSlateAsync_MissingEspnWeekNumber_ReturnsNull_NeverCallsEspn() {
-        var result = await BuildFetcher().FetchForSlateAsync(BuildSlateMissingWeekNumber());
+        var result = await BuildFetcher().FetchForSlateAsync(BuildSlateMissingWeekNumber(), isCurrentSlate: false);
 
         Assert.Null(result);
         await _cfbApi.DidNotReceiveWithAnyArgs().GetScoresByDateRangeAsync(default, default);
         await _cfbApi.DidNotReceive().GetCfpGamesAsync();
-    }
-
-    // /code-review caught the DB-first branch silently defaulting a missing EspnWeekNumber to
-    // week 0 instead of applying the same guard the ESPN-fallback path already used — even with
-    // persisted rows present, a slate with no week number is a data-integrity problem, not
-    // something to paper over.
-    [Fact]
-    public async Task FetchForSlateAsync_MissingEspnWeekNumber_ReturnsNull_EvenWithPersistedRows() {
-        var slate = BuildSlateMissingWeekNumber(); // EndDate 2025-12-20 — already ended
-        var rows = new List<CfbScores> {
-            new() { Id = 1, CfbSlateId = slate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal, GameTime = new DateTimeOffset(2025, 12, 19, 18, 0, 0, TimeSpan.Zero) },
-        };
-        _cfbRepo.GetScoresForSlateAsync(slate.Id).Returns((IEnumerable<CfbScores>)rows);
-
-        var result = await BuildFetcher().FetchForSlateAsync(slate);
-
-        Assert.Null(result);
-        await _cfbApi.DidNotReceiveWithAnyArgs().GetScoresByDateRangeAsync(default, default);
-        await _cfbApi.DidNotReceive().GetCfpGamesAsync();
-    }
-
-    // ── DB-first: a slate whose games are already persisted (always FINAL — CfbScoresJob only
-    // writes finished games) is served from CfbScores instead of a live ESPN call, so 100
-    // concurrent viewers of the same past slate share one DB read instead of each hitting ESPN. ──
-
-    [Fact]
-    public async Task FetchForSlateAsync_WhenDbHasPersistedRowsForTheSlate_ReturnsDbBuiltScores_NeverCallsEspn() {
-        var slate = BuildRegularSeasonSlate();
-        var rows = new List<CfbScores> {
-            new() { Id = 1, CfbSlateId = slate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal, GameTime = new DateTimeOffset(2025, 9, 27, 18, 0, 0, TimeSpan.Zero) },
-        };
-        _cfbRepo.GetScoresForSlateAsync(slate.Id).Returns((IEnumerable<CfbScores>)rows);
-
-        var result = await BuildFetcher().FetchForSlateAsync(slate);
-
-        Assert.NotNull(result);
-        var comp = result!.Events!.Single().Competitions[0];
-        var home = comp.Competitors.Single(c => c.HomeAway == HomeAway.Home);
-        Assert.Equal("OSU", home.Team.Abbreviation);
-        Assert.Equal(28, home.Score);
-        Assert.Equal(TypeName.StatusFinal, comp.Status.Type.Name);
-        await _cfbApi.DidNotReceiveWithAnyArgs().GetScoresByDateRangeAsync(default, default);
-        await _cfbApi.DidNotReceive().GetCfpGamesAsync();
-    }
-
-    // frizat: cfbAdapter.ts's current-slate path now always calls this fetcher for whichever
-    // slate the control table (ICfbCurrentSlateService) resolves as current — that slate must
-    // always be live-fetched, even if its own calendar window looks "ended" and persisted rows
-    // exist, or the demo's frozen in-progress fixture data never surfaces for it.
-    [Fact]
-    public async Task FetchForSlateAsync_WhenSlateIsTheResolvedCurrentSlate_AlwaysCallsEspn_EvenWithPersistedRowsAndEndedWindow() {
-        var slate = BuildRegularSeasonSlate();
-        var rows = new List<CfbScores> {
-            new() { Id = 1, CfbSlateId = slate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal, GameTime = new DateTimeOffset(2025, 9, 27, 18, 0, 0, TimeSpan.Zero) },
-        };
-        _cfbRepo.GetScoresForSlateAsync(slate.Id).Returns((IEnumerable<CfbScores>)rows);
-        _currentSlateService.GetCurrentSlateAsync().Returns(new CfbSlateInfo(
-            slate.Id, slate.Season, slate.SlateNumber, slate.Label, slate.SlateType,
-            slate.StartDate, slate.EndDate, null, DateTime.UtcNow));
-        _cfbApi.GetScoresByDateRangeAsync(slate.StartDate, slate.EndDate).Returns(BuildScoreboardWithRanking());
-
-        await BuildFetcher().FetchForSlateAsync(slate);
-
-        await _cfbApi.Received(1).GetScoresByDateRangeAsync(slate.StartDate, slate.EndDate);
-    }
-
-    [Fact]
-    public async Task FetchForSlateAsync_WhenDbHasNoRowsForTheSlate_FallsBackToEspn() {
-        var slate = BuildRegularSeasonSlate();
-        _cfbRepo.GetScoresForSlateAsync(slate.Id).Returns((IEnumerable<CfbScores>)[]);
-        _cfbApi.GetScoresByDateRangeAsync(slate.StartDate, slate.EndDate).Returns(BuildScoreboardWithRanking());
-
-        var result = await BuildFetcher().FetchForSlateAsync(slate);
-
-        Assert.NotNull(result);
-        await _cfbApi.Received(1).GetScoresByDateRangeAsync(slate.StartDate, slate.EndDate);
-    }
-
-    // /code-review caught a real bug: gating DB-first purely on "rows.Count > 0" means the moment
-    // ONE game in a multi-game slate finishes and gets persisted, every subsequent call for that
-    // slate permanently stops calling ESPN — the rest of the slate's still-in-progress games are
-    // never discovered or persisted. This backs BOTH CfbScoresJob (which would then never finish
-    // collecting that slate's scores) AND CfbCacheService's live poll of the CURRENT slate (which
-    // would freeze the Scores page for every other game in progress). DB-first must only kick in
-    // once the slate's own window has fully ended — while a slate is still active, ESPN is always
-    // the source of truth regardless of how many of its games have already been persisted.
-    [Fact]
-    public async Task FetchForSlateAsync_WhenSlateStillActiveWithPartialRows_StillCallsEspn_NotJustDbRows() {
-        var today = DateOnly.FromDateTime(DateTime.UtcNow);
-        var activeSlate = new CfbSlates {
-            Id = 9, Season = 2026, SlateNumber = 3, Label = "Week 3", SlateType = "RegularSeason",
-            StartDate = today.AddDays(-1), EndDate = today.AddDays(1), EspnWeekNumber = 3, ScoringFormat = "Spread",
-        };
-        // One game in this slate already finished and was persisted; the rest are still live.
-        var partialRows = new List<CfbScores> {
-            new() { Id = 1, CfbSlateId = activeSlate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal, GameTime = DateTimeOffset.UtcNow.AddHours(-3) },
-        };
-        _cfbRepo.GetScoresForSlateAsync(activeSlate.Id).Returns((IEnumerable<CfbScores>)partialRows);
-        _cfbApi.GetScoresByDateRangeAsync(activeSlate.StartDate, activeSlate.EndDate)
-            .Returns(BuildScoreboardWithRanking(date: DateTimeOffset.UtcNow));
-
-        var result = await BuildFetcher().FetchForSlateAsync(activeSlate);
-
-        await _cfbApi.Received(1).GetScoresByDateRangeAsync(activeSlate.StartDate, activeSlate.EndDate);
-        Assert.NotNull(result);
-        Assert.Single(result!.Events!);
-    }
-
-    // A settled slate's DB-built response is immutable (a persisted row is always FINAL) — once
-    // built, repeated requests for the same slate should be served from an in-memory cache instead
-    // of re-querying the DB every time, so concurrent viewers of the same settled slate share one
-    // DB read total, not one DB read each.
-    [Fact]
-    public async Task FetchForSlateAsync_CachesTheDbBuiltResult_SecondCallForSameSlateNeverHitsDbAgain() {
-        var slate = BuildRegularSeasonSlate(); // EndDate 2025-9-28 — already ended
-        var rows = new List<CfbScores> {
-            new() { Id = 1, CfbSlateId = slate.Id, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal, GameTime = new DateTimeOffset(2025, 9, 27, 18, 0, 0, TimeSpan.Zero) },
-        };
-        _cfbRepo.GetScoresForSlateAsync(slate.Id).Returns((IEnumerable<CfbScores>)rows);
-
-        var fetcher = BuildFetcher();
-        var first = await fetcher.FetchForSlateAsync(slate);
-        var second = await fetcher.FetchForSlateAsync(slate);
-
-        Assert.NotNull(first);
-        Assert.NotNull(second);
-        await _cfbRepo.Received(1).GetScoresForSlateAsync(slate.Id);
     }
 }

--- a/Server.UnitTests/CfbRankingCaptureJobTests.cs
+++ b/Server.UnitTests/CfbRankingCaptureJobTests.cs
@@ -95,7 +95,7 @@ public class CfbRankingCaptureJobTests
         // unranked sentinel) is not a rank, so it's never persisted at all, not even as a row.
         var slate = BuildSlate();
         _repo.GetSlatesForSeasonAsync(2026).Returns([slate]);
-        _fetcher.FetchForSlateAsync(slate).Returns(BuildScoreboard(homeRank: 3, awayRank: 99));
+        _fetcher.FetchForSlateAsync(slate, Arg.Any<bool>()).Returns(BuildScoreboard(homeRank: 3, awayRank: 99));
 
         IEnumerable<CfbRanking>? saved = null;
         await _repo.AddRankingsAsync(Arg.Do<IEnumerable<CfbRanking>>(r => saved = r));
@@ -113,7 +113,7 @@ public class CfbRankingCaptureJobTests
     {
         var slate = BuildSlate();
         _repo.GetSlatesForSeasonAsync(2026).Returns([slate]);
-        _fetcher.FetchForSlateAsync(slate).Returns(BuildScoreboard());
+        _fetcher.FetchForSlateAsync(slate, Arg.Any<bool>()).Returns(BuildScoreboard());
 
         await BuildJob().Execute(_context);
 
@@ -125,7 +125,7 @@ public class CfbRankingCaptureJobTests
     {
         var slate = BuildSlate();
         _repo.GetSlatesForSeasonAsync(2026).Returns([slate]);
-        _fetcher.FetchForSlateAsync(slate).Returns((EspnScores?)null);
+        _fetcher.FetchForSlateAsync(slate, Arg.Any<bool>()).Returns((EspnScores?)null);
 
         await BuildJob().Execute(_context);
 
@@ -144,7 +144,7 @@ public class CfbRankingCaptureJobTests
 
         await BuildJob().Execute(_context);
 
-        await _fetcher.DidNotReceive().FetchForSlateAsync(Arg.Any<CfbSlates>());
+        await _fetcher.DidNotReceive().FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>());
         await _repo.DidNotReceive().AddRankingsAsync(Arg.Any<IEnumerable<CfbRanking>>());
     }
 
@@ -154,7 +154,7 @@ public class CfbRankingCaptureJobTests
         // This job captures rankings only — no odds/spread concern at all, unlike CfbSpreadJob.
         var slate = BuildSlate();
         _repo.GetSlatesForSeasonAsync(2026).Returns([slate]);
-        _fetcher.FetchForSlateAsync(slate).Returns(BuildScoreboard(homeRank: 3));
+        _fetcher.FetchForSlateAsync(slate, Arg.Any<bool>()).Returns(BuildScoreboard(homeRank: 3));
 
         await BuildJob().Execute(_context);
 

--- a/Server.UnitTests/CfbScoresJobTests.cs
+++ b/Server.UnitTests/CfbScoresJobTests.cs
@@ -21,16 +21,24 @@ public class CfbScoresJobTests
 {
     private readonly ICfbLiveScoreFetcher _fetcher;
     private readonly ICfbRepository _repo;
+    private readonly ICfbCacheService _cfbCacheService;
+    private readonly ICfbCurrentSlateService _currentSlateService;
     private readonly IJobExecutionContext _context;
 
     public CfbScoresJobTests()
     {
         _fetcher = Substitute.For<ICfbLiveScoreFetcher>();
         _repo = Substitute.For<ICfbRepository>();
+        _cfbCacheService = Substitute.For<ICfbCacheService>();
+        _currentSlateService = Substitute.For<ICfbCurrentSlateService>();
         _context = Substitute.For<IJobExecutionContext>();
+        // Default: no resolved current slate, so existing tests (which never set this up) keep
+        // exercising isCurrentSlate: false for every slate, unchanged by this dependency's
+        // addition.
+        _currentSlateService.GetCurrentSlateAsync().Returns((CfbSlateInfo?)null);
     }
 
-    private CfbScoresJob BuildJob() => new(_fetcher, _repo);
+    private CfbScoresJob BuildJob() => new(_fetcher, _repo, _cfbCacheService, _currentSlateService);
 
     // Dates relative to "now" (not a fixed calendar date) so this slate is always "currently
     // active" for the SeasonWindowResolver-based gate CfbScoresJob now checks before fetching —
@@ -105,19 +113,47 @@ public class CfbScoresJobTests
         await _repo.DidNotReceive().UpsertCfbScoresAsync(Arg.Any<IEnumerable<CfbScores>>());
     }
 
-    // /code-review: the fix for today's real production incident (a missed Monday-night game
-    // that a re-run of this job couldn't recover, because the viewer-facing cache/DB-shortcut
-    // permanently stopped calling ESPN for an "ended" slate) is this one bypassCache:true argument
-    // — pin it explicitly so a future refactor can't silently drop it back to the default.
+    // frizat-d0t: the fix for the original production incident (a missed Monday-night game that
+    // a re-run of this job couldn't recover, because the viewer-facing cache/DB-shortcut
+    // permanently stopped calling ESPN for an "ended" slate) is now structural rather than a
+    // bypassCache:true flag to remember to pass — the fetcher this job calls is a pure fetch with
+    // no cache/DB-shortcut branch to accidentally hit (that logic moved to CfbCacheService,
+    // which this job never calls except to invalidate below).
     [Fact]
-    public async Task Execute_AlwaysFetchesWithBypassCacheTrue_SoAnEndedSlateCanStillRecoverAMissedGame()
+    public async Task Execute_AlwaysCallsTheFetcherDirectly_SoAnEndedSlateCanStillRecoverAMissedGame()
     {
         _repo.GetSlatesForSeasonAsync(Arg.Any<int>()).Returns([BuildSlate()]);
         _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns((EspnScores?)null);
 
         await BuildJob().Execute(_context);
 
-        await _fetcher.Received(1).FetchForSlateAsync(Arg.Any<CfbSlates>(), bypassCache: true);
+        await _fetcher.Received(1).FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>());
+    }
+
+    // The viewer-facing settled cache can already hold a stale reconstruction for a slate that
+    // "ended" before this run discovered new/updated finals for it — mirrors NflScoresJob's
+    // identical invalidation of EspnCacheService.
+    [Fact]
+    public async Task Execute_WhenScoresUpserted_InvalidatesTheSlateCache()
+    {
+        var slate = BuildSlate();
+        _repo.GetSlatesForSeasonAsync(Arg.Any<int>()).Returns([slate]);
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns(BuildScoreboard(status: TypeName.StatusFinal));
+
+        await BuildJob().Execute(_context);
+
+        _cfbCacheService.Received(1).InvalidateSlateCache(slate.Id);
+    }
+
+    [Fact]
+    public async Task Execute_WhenNoScoresUpserted_NeverInvalidatesAnySlateCache()
+    {
+        _repo.GetSlatesForSeasonAsync(Arg.Any<int>()).Returns([BuildSlate()]);
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns((EspnScores?)null);
+
+        await BuildJob().Execute(_context);
+
+        _cfbCacheService.DidNotReceiveWithAnyArgs().InvalidateSlateCache(default);
     }
 
     [Fact]

--- a/Server.UnitTests/CfbSpreadJobTests.cs
+++ b/Server.UnitTests/CfbSpreadJobTests.cs
@@ -115,14 +115,14 @@ public class CfbSpreadJobTests
 
         await BuildJob().Execute(_context);
 
-        await _fetcher.DidNotReceive().FetchForSlateAsync(Arg.Any<CfbSlates>());
+        await _fetcher.DidNotReceive().FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>());
     }
 
     [Fact]
     public async Task Execute_WhenFetcherReturnsNull_SavesNoSpreads()
     {
         SetCurrentSlate(BuildSlate());
-        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>()).Returns((EspnScores?)null);
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns((EspnScores?)null);
 
         await BuildJob().Execute(_context);
 
@@ -134,7 +134,7 @@ public class CfbSpreadJobTests
     {
         var slate = BuildSlate();
         SetCurrentSlate(slate);
-        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>()).Returns(BuildScoreboard());
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns(BuildScoreboard());
         _oddsService.GetCfbEventsWithOddsAsync(401677183, 100).Returns(BuildOdds());
 
         await BuildJob().Execute(_context);
@@ -148,7 +148,7 @@ public class CfbSpreadJobTests
     {
         var slate = BuildSlate();
         SetCurrentSlate(slate);
-        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>()).Returns(BuildScoreboard(homeAbbr: "ORE", awayAbbr: "OSU"));
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns(BuildScoreboard(homeAbbr: "ORE", awayAbbr: "OSU"));
         _oddsService.GetCfbEventsWithOddsAsync(401677183, 100).Returns(BuildOdds("-7.5", "+7.5", 52.5));
 
         IEnumerable<CfbSpreads>? saved = null;
@@ -169,7 +169,7 @@ public class CfbSpreadJobTests
     public async Task Execute_WhenOddsUnavailable_SkipsGame()
     {
         SetCurrentSlate(BuildSlate());
-        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>()).Returns(BuildScoreboard());
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns(BuildScoreboard());
         _oddsService.GetCfbEventsWithOddsAsync(Arg.Any<int>(), 100).Returns((EspnCoreOddsItem?)null);
         _oddsService.GetCfbEventsWithOddsAsync(Arg.Any<int>()).Returns((EspnCoreOddsApiResponse?)null);
 
@@ -182,7 +182,7 @@ public class CfbSpreadJobTests
     public async Task Execute_SkipsGame_WhenNotScheduled()
     {
         SetCurrentSlate(BuildSlate());
-        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>()).Returns(BuildScoreboard(status: TypeName.StatusFinal));
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns(BuildScoreboard(status: TypeName.StatusFinal));
 
         await BuildJob().Execute(_context);
 
@@ -203,7 +203,7 @@ public class CfbSpreadJobTests
     public async Task Execute_RegularSeason_RankedAndNotMidweek_SavesEligibleTrue()
     {
         SetCurrentSlate(BuildSlate());
-        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>()).Returns(BuildScoreboard(homeRank: 5, awayRank: 99)); // Friday
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns(BuildScoreboard(homeRank: 5, awayRank: 99)); // Friday
         _oddsService.GetCfbEventsWithOddsAsync(401677183, 100).Returns(BuildOdds());
 
         IEnumerable<CfbSpreads>? saved = null;
@@ -218,7 +218,7 @@ public class CfbSpreadJobTests
     public async Task Execute_RegularSeason_BothUnranked_SavesEligibleFalse()
     {
         SetCurrentSlate(BuildSlate());
-        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>()).Returns(BuildScoreboard(homeRank: 99, awayRank: 99));
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns(BuildScoreboard(homeRank: 99, awayRank: 99));
         _oddsService.GetCfbEventsWithOddsAsync(401677183, 100).Returns(BuildOdds());
 
         IEnumerable<CfbSpreads>? saved = null;
@@ -234,7 +234,7 @@ public class CfbSpreadJobTests
     {
         var tuesdayEt = new DateTimeOffset(2025, 9, 30, 23, 0, 0, TimeSpan.Zero); // Tue 7pm ET
         SetCurrentSlate(BuildSlate());
-        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>()).Returns(BuildScoreboard(homeRank: 5, awayRank: 99, date: tuesdayEt));
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns(BuildScoreboard(homeRank: 5, awayRank: 99, date: tuesdayEt));
         _oddsService.GetCfbEventsWithOddsAsync(401677183, 100).Returns(BuildOdds());
 
         IEnumerable<CfbSpreads>? saved = null;
@@ -249,7 +249,7 @@ public class CfbSpreadJobTests
     public async Task Execute_CfpSlate_BothUnranked_SavesEligibleTrueRegardless()
     {
         SetCurrentSlate(BuildCfpSlate());
-        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>()).Returns(BuildScoreboard(homeRank: 99, awayRank: 99));
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns(BuildScoreboard(homeRank: 99, awayRank: 99));
         _oddsService.GetCfbEventsWithOddsAsync(401677183, 100).Returns(BuildOdds());
 
         IEnumerable<CfbSpreads>? saved = null;
@@ -266,7 +266,7 @@ public class CfbSpreadJobTests
         // "Rankings" now means one row per (season, week, ranked team) — CuratedRank=99 (ESPN's
         // unranked sentinel) is not a rank, so it's never persisted at all, not even as a row.
         SetCurrentSlate(BuildSlate());
-        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>()).Returns(BuildScoreboard(homeAbbr: "ORE", awayAbbr: "OSU", homeRank: 3, awayRank: 99));
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns(BuildScoreboard(homeAbbr: "ORE", awayAbbr: "OSU", homeRank: 3, awayRank: 99));
         _oddsService.GetCfbEventsWithOddsAsync(401677183, 100).Returns(BuildOdds());
 
         IEnumerable<CfbRanking>? saved = null;
@@ -285,7 +285,7 @@ public class CfbSpreadJobTests
     public async Task Execute_PersistsRanking_EvenWhenOddsUnavailable()
     {
         SetCurrentSlate(BuildSlate());
-        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>()).Returns(BuildScoreboard(homeRank: 3, awayRank: 99));
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns(BuildScoreboard(homeRank: 3, awayRank: 99));
         _oddsService.GetCfbEventsWithOddsAsync(Arg.Any<int>(), 100).Returns((EspnCoreOddsItem?)null);
         _oddsService.GetCfbEventsWithOddsAsync(Arg.Any<int>()).Returns((EspnCoreOddsApiResponse?)null);
 
@@ -306,7 +306,7 @@ public class CfbSpreadJobTests
 
         await BuildJob().Execute(_context);
 
-        await _fetcher.DidNotReceive().FetchForSlateAsync(Arg.Any<CfbSlates>());
+        await _fetcher.DidNotReceive().FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>());
         await _repo.DidNotReceive().UpsertAsync(Arg.Any<IEnumerable<CfbSpreads>>());
     }
 
@@ -329,7 +329,7 @@ public class CfbSpreadJobTests
         var forceMap = new JobDataMap();
         forceMap.Put("force", true);
         _context.MergedJobDataMap.Returns(forceMap);
-        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>()).Returns(BuildScoreboard());
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns(BuildScoreboard());
         _oddsService.GetCfbEventsWithOddsAsync(401677183, 100).Returns(BuildOdds());
 
         await BuildJob().Execute(_context);
@@ -342,7 +342,7 @@ public class CfbSpreadJobTests
     {
         var slate = BuildSlate();
         SetCurrentSlate(slate); // defaults to PastLockTime
-        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>()).Returns(BuildScoreboard());
+        _fetcher.FetchForSlateAsync(Arg.Any<CfbSlates>(), Arg.Any<bool>()).Returns(BuildScoreboard());
         _oddsService.GetCfbEventsWithOddsAsync(401677183, 100).Returns(BuildOdds());
 
         await BuildJob().Execute(_context);

--- a/Server.UnitTests/DemoCfbCacheServiceTests.cs
+++ b/Server.UnitTests/DemoCfbCacheServiceTests.cs
@@ -1,4 +1,10 @@
+using FourPlayWebApp.Server.Data;
+using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Services;
+using FourPlayWebApp.Shared.Models;
+using FourPlayWebApp.Shared.Models.Data;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
 using Xunit;
 
 namespace FourPlayWebApp.Server.UnitTests;
@@ -13,13 +19,32 @@ namespace FourPlayWebApp.Server.UnitTests;
 /// an embedded resource, not a loose file resolved via a relative path off ContentRootPath. That
 /// prior approach only worked locally by coincidence and silently returned null on Railway,
 /// where ContentRootPath points at the deployed app's own directory.
+///
+/// frizat-d0t: GetSlateScoresAsync mirrors DemoEspnCacheServiceTests' GetWeekScoresAsync coverage
+/// — same IDbContextFactory/TimeProvider constructor shape, same DB-first-for-non-current-slate
+/// pattern.
 /// </summary>
 public class DemoCfbCacheServiceTests
 {
+    private static ApplicationDbContext BuildDb(string name) =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(name)
+            .Options);
+
+    private static IDbContextFactory<ApplicationDbContext> BuildFactory(ApplicationDbContext db)
+    {
+        var factory = Substitute.For<IDbContextFactory<ApplicationDbContext>>();
+        factory.CreateDbContextAsync().Returns(db);
+        return factory;
+    }
+
+    private static DemoCfbCacheService BuildService(ApplicationDbContext db) =>
+        new(BuildFactory(db), TimeProvider.System);
+
     [Fact]
     public async Task GetScoresAsync_ReturnsRealSituationData_ForChampionshipGame()
     {
-        var service = new DemoCfbCacheService();
+        var service = BuildService(BuildDb(nameof(GetScoresAsync_ReturnsRealSituationData_ForChampionshipGame)));
 
         var scores = await service.GetScoresAsync();
 
@@ -34,7 +59,7 @@ public class DemoCfbCacheServiceTests
     [Fact]
     public async Task GetScoresAsync_ReturnsRealScoreAndTeams_ForChampionshipGame()
     {
-        var service = new DemoCfbCacheService();
+        var service = BuildService(BuildDb(nameof(GetScoresAsync_ReturnsRealScoreAndTeams_ForChampionshipGame)));
 
         var scores = await service.GetScoresAsync();
 
@@ -47,5 +72,62 @@ public class DemoCfbCacheServiceTests
         Assert.Equal("MIA", away.Team.Abbreviation);
         Assert.Equal(7, away.Score);
         Assert.Equal(Shared.Models.TypeName.StatusInProgress, competition.Status.Type.Name);
+    }
+
+    // ── GetSlateScoresAsync ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetSlateScoresAsync_WhenNoSlateMatchesTheRequestedId_ReturnsNull()
+    {
+        var service = BuildService(BuildDb(nameof(GetSlateScoresAsync_WhenNoSlateMatchesTheRequestedId_ReturnsNull)));
+
+        var result = await service.GetSlateScoresAsync(999);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetSlateScoresAsync_ForANonCurrentSlateWithPersistedRows_ReturnsDbBuiltScores()
+    {
+        var db = BuildDb(nameof(GetSlateScoresAsync_ForANonCurrentSlateWithPersistedRows_ReturnsDbBuiltScores));
+        db.CfbSeasonWeekConfigs.Add(new CfbSeasonWeekConfig {
+            Season = 2025, EspnWeekNumber = 4, IvLeagueWeekNumber = 4,
+            WeekStartDate = new DateOnly(2025, 9, 27), WeekEndDate = new DateOnly(2025, 9, 28),
+            InScopeIvLeague = true, SpreadLockDatetime = new DateTime(2025, 9, 25, 0, 0, 0, DateTimeKind.Utc),
+        });
+        db.CfbSlates.Add(new CfbSlates {
+            Id = 42, Season = 2025, SlateNumber = 4, Label = "Week 4", SlateType = "RegularSeason",
+            StartDate = new DateOnly(2025, 9, 27), EndDate = new DateOnly(2025, 9, 28),
+            EspnWeekNumber = 4, ScoringFormat = "Spread",
+        });
+        db.CfbScores.Add(new CfbScores {
+            CfbSlateId = 42, HomeTeam = "OSU", AwayTeam = "NEB", HomeTeamScore = 28, AwayTeamScore = 14,
+            GameStatus = TypeName.StatusFinal, GameTime = new DateTimeOffset(2025, 9, 27, 18, 0, 0, TimeSpan.Zero),
+        });
+        // A later (still real-world-past) slate the resolver treats as "current" — without this,
+        // the Week 4 slate above would trivially resolve as its own "current" slate (nothing
+        // else to compare against), exempting it from the DB-first shortcut this test exists to
+        // verify (mirrors EspnCacheServiceTests' identical NFL fixture-seeding pattern).
+        db.CfbSeasonWeekConfigs.Add(new CfbSeasonWeekConfig {
+            Season = 2025, EspnWeekNumber = 5, IvLeagueWeekNumber = 5,
+            WeekStartDate = new DateOnly(2025, 10, 4), WeekEndDate = new DateOnly(2025, 10, 5),
+            InScopeIvLeague = true, SpreadLockDatetime = new DateTime(2025, 10, 2, 0, 0, 0, DateTimeKind.Utc),
+        });
+        db.CfbSlates.Add(new CfbSlates {
+            Id = 43, Season = 2025, SlateNumber = 5, Label = "Week 5", SlateType = "RegularSeason",
+            StartDate = new DateOnly(2025, 10, 4), EndDate = new DateOnly(2025, 10, 5),
+            EspnWeekNumber = 5, ScoringFormat = "Spread",
+        });
+        await db.SaveChangesAsync();
+        var service = BuildService(db);
+
+        var result = await service.GetSlateScoresAsync(42);
+
+        Assert.NotNull(result);
+        var comp = result!.Events!.Single().Competitions[0];
+        var home = comp.Competitors.Single(c => c.HomeAway == Shared.Models.HomeAway.Home);
+        Assert.Equal("OSU", home.Team.Abbreviation);
+        Assert.Equal(28, home.Score);
+        Assert.Equal(Shared.Models.TypeName.StatusFinal, comp.Status.Type.Name);
     }
 }

--- a/Server.UnitTests/EspnControllerTests.cs
+++ b/Server.UnitTests/EspnControllerTests.cs
@@ -19,18 +19,14 @@ public class EspnControllerTests
 {
     private readonly IEspnCacheService _espnCacheService;
     private readonly ICfbCacheService _cfbCacheService;
-    private readonly ICfbLiveScoreFetcher _cfbFetcher;
-    private readonly ICfbRepository _cfbRepo;
     private readonly EspnController _sut;
 
     public EspnControllerTests()
     {
         _espnCacheService = Substitute.For<IEspnCacheService>();
         _cfbCacheService = Substitute.For<ICfbCacheService>();
-        _cfbFetcher = Substitute.For<ICfbLiveScoreFetcher>();
-        _cfbRepo = Substitute.For<ICfbRepository>();
 
-        _sut = new EspnController(_espnCacheService, _cfbCacheService, _cfbFetcher, _cfbRepo);
+        _sut = new EspnController(_espnCacheService, _cfbCacheService);
         _sut.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext
@@ -129,15 +125,15 @@ public class EspnControllerTests
         Assert.IsType<EspnScores>(ok.Value);
     }
 
-    // ── GetCfbScoresForSlate (direct/uncached, specific slate — mirrors GetWeekScores) ─
+    // ── GetCfbScoresForSlate (settled-or-live for a specific slate — mirrors GetWeekScores;
+    //    frizat-d0t: now delegates to ICfbCacheService.GetSlateScoresAsync instead of resolving
+    //    the slate + calling ICfbLiveScoreFetcher directly) ─
 
     [Fact]
     public async Task GetCfbScoresForSlate_ReturnsOk_WithScores()
     {
-        var slate = new CfbSlates { Id = 7, Season = 2026 };
-        _cfbRepo.GetSlateByIdAsync(7).Returns(slate);
         var scores = new EspnScores();
-        _cfbFetcher.FetchForSlateAsync(slate).Returns(scores);
+        _cfbCacheService.GetSlateScoresAsync(7).Returns(scores);
 
         var result = await _sut.GetCfbScoresForSlate(7);
 
@@ -148,13 +144,12 @@ public class EspnControllerTests
     [Fact]
     public async Task GetCfbScoresForSlate_ReturnsOk_Empty_WhenSlateNotFound()
     {
-        _cfbRepo.GetSlateByIdAsync(999).Returns((CfbSlates?)null);
+        _cfbCacheService.GetSlateScoresAsync(999).Returns((EspnScores?)null);
 
         var result = await _sut.GetCfbScoresForSlate(999);
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         Assert.IsType<EspnScores>(ok.Value);
-        await _cfbFetcher.DidNotReceive().FetchForSlateAsync(Arg.Any<CfbSlates>());
     }
 
     // ── GetLiveGames ─────────────────────────────────────────────────────────

--- a/Server.UnitTests/SettledScoreCacheTests.cs
+++ b/Server.UnitTests/SettledScoreCacheTests.cs
@@ -1,0 +1,126 @@
+using FourPlayWebApp.Server.Services;
+using FourPlayWebApp.Shared.Models;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+// frizat-d0t: the shared cache-or-build orchestration extracted out of EspnCacheService.
+// GetWeekScoresAsync (NFL) and CfbLiveScoreFetcher.FetchForSlateAsync's settled-cache branch
+// (CFB) — window-ended detection, current-item exemption, cache hit/miss, and DB-build-then-cache
+// are each tested once here instead of twice (once per sport). Callers (EspnCacheService,
+// CfbCacheService) still own resolving isCurrentItem/windowEndUtc themselves, AND building an
+// EspnScores from persisted rows (FinalScoresEspnMapper.Build + their own sport-specific row
+// mapping) — this class only orchestrates what happens once those are known, deliberately with
+// no knowledge of FinalScoresEspnMapper/FinishedGame at all.
+public class SettledScoreCacheTests {
+    private readonly IMemoryCache _memoryCache = new MemoryCache(new MemoryCacheOptions());
+    private SettledScoreCache Build() => new(_memoryCache);
+
+    private static EspnScores MakeBuiltScores() => new() { Season = new Season { Year = 2025 } };
+
+    [Fact]
+    public async Task GetOrBuildAsync_CacheHit_ReturnsCachedValue_NeverCallsEitherDelegate() {
+        var cache = Build();
+        var cached = new EspnScores { Season = new Season { Year = 2025 } };
+        _memoryCache.Set("key-1", cached);
+
+        var buildCalled = false;
+        var liveFetchCalled = false;
+        var result = await cache.GetOrBuildAsync(
+            "key-1", isCurrentItem: false, windowEndUtc: DateTime.UtcNow.AddDays(-30),
+            buildFromRowsAsync: () => { buildCalled = true; return Task.FromResult<EspnScores?>(null); },
+            liveFetchAsync: () => { liveFetchCalled = true; return Task.FromResult<EspnScores?>(null); });
+
+        Assert.Same(cached, result);
+        Assert.False(buildCalled);
+        Assert.False(liveFetchCalled);
+    }
+
+    [Fact]
+    public async Task GetOrBuildAsync_WindowNotEnded_CallsLiveFetch_NeverCallsBuild() {
+        var cache = Build();
+        var buildCalled = false;
+        var live = new EspnScores { Season = new Season { Year = 2025 } };
+
+        var result = await cache.GetOrBuildAsync(
+            "key-2", isCurrentItem: false, windowEndUtc: DateTime.UtcNow.AddDays(1),
+            buildFromRowsAsync: () => { buildCalled = true; return Task.FromResult<EspnScores?>(MakeBuiltScores()); },
+            liveFetchAsync: () => Task.FromResult<EspnScores?>(live));
+
+        Assert.Same(live, result);
+        Assert.False(buildCalled);
+    }
+
+    [Fact]
+    public async Task GetOrBuildAsync_WindowEndedWithABuild_CachesIt_NeverCallsLiveFetch() {
+        var cache = Build();
+        var liveFetchCalled = false;
+        var built = MakeBuiltScores();
+
+        var result = await cache.GetOrBuildAsync(
+            "key-3", isCurrentItem: false, windowEndUtc: DateTime.UtcNow.AddDays(-30),
+            buildFromRowsAsync: () => Task.FromResult<EspnScores?>(built),
+            liveFetchAsync: () => { liveFetchCalled = true; return Task.FromResult<EspnScores?>(null); });
+
+        Assert.Same(built, result);
+        Assert.False(liveFetchCalled);
+        Assert.True(_memoryCache.TryGetValue<EspnScores>("key-3", out var cached));
+        Assert.Same(built, cached);
+    }
+
+    [Fact]
+    public async Task GetOrBuildAsync_WindowEndedWithNoBuild_FallsBackToLiveFetch() {
+        var cache = Build();
+        var live = new EspnScores { Season = new Season { Year = 2025 } };
+
+        var result = await cache.GetOrBuildAsync(
+            "key-4", isCurrentItem: false, windowEndUtc: DateTime.UtcNow.AddDays(-30),
+            buildFromRowsAsync: () => Task.FromResult<EspnScores?>(null),
+            liveFetchAsync: () => Task.FromResult<EspnScores?>(live));
+
+        Assert.Same(live, result);
+        // A null build (e.g. zero persisted rows) is never cached — a still-active item that
+        // merely hasn't had any games persisted yet must not freeze an empty response in place
+        // once games actually finish and get persisted.
+        Assert.False(_memoryCache.TryGetValue<EspnScores>("key-4", out _));
+    }
+
+    [Fact]
+    public async Task GetOrBuildAsync_IsCurrentItem_AlwaysCallsLiveFetch_EvenWithEndedWindowAndABuild() {
+        var cache = Build();
+        var buildCalled = false;
+        var live = new EspnScores { Season = new Season { Year = 2025 } };
+
+        var result = await cache.GetOrBuildAsync(
+            "key-5", isCurrentItem: true, windowEndUtc: DateTime.UtcNow.AddDays(-30),
+            buildFromRowsAsync: () => { buildCalled = true; return Task.FromResult<EspnScores?>(MakeBuiltScores()); },
+            liveFetchAsync: () => Task.FromResult<EspnScores?>(live));
+
+        Assert.Same(live, result);
+        Assert.False(buildCalled);
+    }
+
+    [Fact]
+    public void TryGet_ReturnsTrueAndValue_OnlyForAnAlreadyCachedKey() {
+        var cache = Build();
+        var cached = new EspnScores { Season = new Season { Year = 2025 } };
+        _memoryCache.Set("key-6", cached);
+
+        Assert.True(cache.TryGet("key-6", out var hit));
+        Assert.Same(cached, hit);
+        Assert.False(cache.TryGet("key-not-set", out var miss));
+        Assert.Null(miss);
+    }
+
+    [Fact]
+    public void Invalidate_RemovesOnlyTheSpecifiedKey() {
+        var cache = Build();
+        _memoryCache.Set("key-a", new EspnScores());
+        _memoryCache.Set("key-b", new EspnScores());
+
+        cache.Invalidate("key-a");
+
+        Assert.False(_memoryCache.TryGetValue<EspnScores>("key-a", out _));
+        Assert.True(_memoryCache.TryGetValue<EspnScores>("key-b", out _));
+    }
+}

--- a/Server/Controllers/EspnController.cs
+++ b/Server/Controllers/EspnController.cs
@@ -1,6 +1,5 @@
 using FourPlayWebApp.Server.Infrastructure;
 using FourPlayWebApp.Server.Services.Interfaces;
-using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models;
 using FourPlayWebApp.Shared.Models.Data.Dtos;
 using FourPlayWebApp.Shared.Models.Enum;
@@ -13,9 +12,7 @@ namespace FourPlayWebApp.Server.Controllers;
 [Route("api/[controller]")]
 public class EspnController(
     IEspnCacheService espnCacheService,
-    ICfbCacheService cfbCacheService,
-    ICfbLiveScoreFetcher cfbFetcher,
-    ICfbRepository cfbRepo)
+    ICfbCacheService cfbCacheService)
     : ControllerBase {
     // Route is our own (season, nflWeek) — NflSeasonWeekConfig.WeekId — never ESPN's own week
     // numbering, matching GetCfbScoresForSlate's shape below (frizat-3nv).
@@ -48,18 +45,16 @@ public class EspnController(
     }
 
     /// <summary>
-    /// Live CFB scores for a SPECIFIC (typically non-current) slate — direct/uncached, same role
-    /// as GetWeekScores() for NFL. Used when browsing a past or future slate, which isn't repeatedly
-    /// polled the way the current slate is.
+    /// CFB scores for a SPECIFIC (typically non-current) slate — settled slates served from a
+    /// cached DB reconstruction, same role as GetWeekScores() for NFL (frizat-d0t unification).
+    /// Used when browsing a past or future slate, which isn't repeatedly polled the way the
+    /// current slate is.
     /// </summary>
     [HttpGet("cfb/scores/slate/{slateId:int}")]
     [ProducesResponseType(typeof(EspnScores), StatusCodes.Status200OK)]
     public async Task<ActionResult<EspnScores?>> GetCfbScoresForSlate(int slateId)
     {
-        var slate = await cfbRepo.GetSlateByIdAsync(slateId);
-        if (slate is null) return Ok(new EspnScores());
-
-        var scores = await cfbFetcher.FetchForSlateAsync(slate);
+        var scores = await cfbCacheService.GetSlateScoresAsync(slateId);
         return Ok(scores ?? new EspnScores());
     }
 

--- a/Server/Jobs/CfbRankingCaptureJob.cs
+++ b/Server/Jobs/CfbRankingCaptureJob.cs
@@ -37,8 +37,10 @@ public class CfbRankingCaptureJob(ICfbLiveScoreFetcher fetcher, ICfbRepository r
 
         // Each remaining slate's scoreboard fetch is an independent ESPN call — no data dependency
         // between them, so fetch all slates concurrently rather than serializing the round-trips.
+        // isCurrentSlate: false for all of them — this job extracts AP rankings from real ESPN
+        // events, never wants the replay-mode snapshot merged in.
         var scoreboards = await Task.WhenAll(slates.Select(async slate =>
-            (slate, scoreboard: await fetcher.FetchForSlateAsync(slate))));
+            (slate, scoreboard: await fetcher.FetchForSlateAsync(slate, isCurrentSlate: false))));
 
         var rankings = new List<CfbRanking>();
         foreach (var (slate, scoreboard) in scoreboards) {

--- a/Server/Jobs/CfbScoresJob.cs
+++ b/Server/Jobs/CfbScoresJob.cs
@@ -10,7 +10,8 @@ using Serilog;
 namespace FourPlayWebApp.Server.Jobs;
 
 [DisallowConcurrentExecution]
-public class CfbScoresJob(ICfbLiveScoreFetcher fetcher, ICfbRepository repo) : IJob {
+public class CfbScoresJob(ICfbLiveScoreFetcher fetcher, ICfbRepository repo, ICfbCacheService cfbCacheService,
+    ICfbCurrentSlateService currentSlateService) : IJob {
     // CFB seasons run Aug–Jan; the season year is the calendar year the fall games start.
     private static int Season => DateTime.UtcNow.Month >= 8 ? DateTime.UtcNow.Year : DateTime.UtcNow.Year - 1;
 
@@ -36,13 +37,21 @@ public class CfbScoresJob(ICfbLiveScoreFetcher fetcher, ICfbRepository repo) : I
 
         var scores = new List<CfbScores>();
 
+        // Resolved once for the whole loop, not once per slate — isCurrentSlate only matters to
+        // the fetcher for the replay-mode snapshot merge (see ICfbLiveScoreFetcher's own doc
+        // comment), and every slate in this loop can be compared against the same single
+        // resolution instead of each triggering its own GetCurrentSlateAsync() DB round trip.
+        var currentSlate = await currentSlateService.GetCurrentSlateAsync();
+
         foreach (var slate in slates) {
-            // bypassCache: this job's whole purpose is discovering fresh finals — including one
-            // missed before the slate's window "ended" (frizat: exactly what happened to the
-            // 2026 Week 1 Monday-night game before the Tuesday catch-up cron existed). The
-            // viewer-facing shortcut this bypasses exists to spare page loads from re-hitting
-            // ESPN for settled data, not to freeze this job out of ever seeing new data.
-            var scoreboard = await fetcher.FetchForSlateAsync(slate, bypassCache: true);
+            // This job's whole purpose is discovering fresh finals — including one missed before
+            // the slate's window "ended" (frizat: exactly what happened to the 2026 Week 1
+            // Monday-night game before the Tuesday catch-up cron existed). fetcher is now a pure
+            // fetch with no caching (frizat-d0t) — the viewer-facing settled-cache shortcut this
+            // used to need to bypass now lives one layer up in CfbCacheService, which this job
+            // never calls except to invalidate below, mirroring NflScoresJob calling
+            // INflLiveScoreFetcher directly.
+            var scoreboard = await fetcher.FetchForSlateAsync(slate, isCurrentSlate: slate.Id == currentSlate?.Id);
             if (scoreboard?.Events is null) continue;
             AppendScores(scores, slate, scoreboard.Events);
         }
@@ -54,7 +63,7 @@ public class CfbScoresJob(ICfbLiveScoreFetcher fetcher, ICfbRepository repo) : I
             // The viewer-facing cache can already hold a stale reconstruction for a slate that
             // "ended" before this run discovered new/updated finals for it.
             foreach (var slateId in scores.Select(s => s.CfbSlateId).Distinct()) {
-                fetcher.InvalidateSlateCache(slateId);
+                cfbCacheService.InvalidateSlateCache(slateId);
             }
         }
         Log.Information("CfbScoresJob: complete at {Time}", DateTime.UtcNow);

--- a/Server/Jobs/CfbSpreadJob.cs
+++ b/Server/Jobs/CfbSpreadJob.cs
@@ -43,7 +43,8 @@ public class CfbSpreadJob(
         var spreads = new List<CfbSpreads>();
         var rankings = new List<CfbRanking>();
 
-        var scoreboard = await fetcher.FetchForSlateAsync(slate);
+        // slate was resolved from slateInfo.Id above, i.e. it IS the current slate.
+        var scoreboard = await fetcher.FetchForSlateAsync(slate, isCurrentSlate: true);
         if (scoreboard?.Events is not null) {
             rankings.AddRange(CfbRankingExtractor.ExtractFrom(scoreboard.Events, slate));
             await ProcessEventsForSpreads(spreads, slate, scoreboard.Events);

--- a/Server/Services/CfbCacheService.cs
+++ b/Server/Services/CfbCacheService.cs
@@ -1,7 +1,10 @@
+using FourPlayWebApp.Server.Jobs;
 using FourPlayWebApp.Server.Services.Interfaces;
 using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Models;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
+using Serilog;
 
 namespace FourPlayWebApp.Server.Services;
 
@@ -17,6 +20,9 @@ namespace FourPlayWebApp.Server.Services;
 // instead, the standard pattern for a singleton background service consuming scoped dependencies.
 public class CfbCacheService : ICfbCacheService, IAsyncDisposable
 {
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ICfbLiveScoreFetcher _fetcher;
+    private readonly SettledScoreCache _settledCache;
     private readonly PeriodicRefreshCache<EspnScores> _cache;
 
     public event Action? ScoresChanged
@@ -28,8 +34,12 @@ public class CfbCacheService : ICfbCacheService, IAsyncDisposable
     public CfbCacheService(
         IServiceScopeFactory scopeFactory,
         ICfbLiveScoreFetcher fetcher,
+        IMemoryCache settledCache,
         TimeSpan? initialDelay = null)
     {
+        _scopeFactory = scopeFactory;
+        _fetcher = fetcher;
+        _settledCache = new SettledScoreCache(settledCache);
         _cache = new PeriodicRefreshCache<EspnScores>(
             fetch: async () => {
                 using var scope = scopeFactory.CreateScope();
@@ -46,7 +56,7 @@ public class CfbCacheService : ICfbCacheService, IAsyncDisposable
                 if (currentSlate is null) return null;
 
                 var slate = await cfbRepo.GetSlateByIdAsync(currentSlate.Id);
-                return slate is null ? null : await fetcher.FetchForSlateAsync(slate);
+                return slate is null ? null : await fetcher.FetchForSlateAsync(slate, isCurrentSlate: true);
             },
             fingerprint: EspnScoresFingerprint.Compute,
             interval: TimeSpan.FromMinutes(5),
@@ -54,6 +64,51 @@ public class CfbCacheService : ICfbCacheService, IAsyncDisposable
     }
 
     public Task<EspnScores?> GetScoresAsync() => Task.FromResult(_cache.Current);
+
+    // Settled/live CFB scores for a SPECIFIC (typically non-current) slate — mirrors
+    // EspnCacheService.GetWeekScoresAsync(season, nflWeek) exactly (frizat-d0t unification).
+    // Fresh scope for the same reason the periodic-poll fetch above needs one — Scoped
+    // dependencies consumed from a Singleton.
+    public async Task<EspnScores?> GetSlateScoresAsync(int slateId) {
+        var cacheKey = $"cfb-slate-scores_{slateId}";
+        // Fast path: skip the slate/current-slate DB resolution entirely on a cache hit — a
+        // settled slate's response never changes, so repeat requests for it shouldn't pay for
+        // any of the lookups below just to re-derive a cache key it turns out we already have.
+        if (_settledCache.TryGet(cacheKey, out var cached)) return cached;
+
+        using var scope = _scopeFactory.CreateScope();
+        var cfbRepo = scope.ServiceProvider.GetRequiredService<ICfbRepository>();
+        var currentSlateService = scope.ServiceProvider.GetRequiredService<ICfbCurrentSlateService>();
+
+        var slate = await cfbRepo.GetSlateByIdAsync(slateId);
+        if (slate is null) return null;
+
+        // A missing EspnWeekNumber is a control-table seeding bug, not a case to fall back on —
+        // mirrors CfbLiveScoreFetcher's identical guard, needed here too since FinalScoresEspnMapper.
+        // Build requires a real week number for the DB-first branch below.
+        if (!slate.EspnWeekNumber.HasValue) {
+            Log.Warning("CfbCacheService: slate {SlateId} has no EspnWeekNumber — skipping", slate.Id);
+            return null;
+        }
+
+        var currentSlate = await currentSlateService.GetCurrentSlateAsync();
+        var isCurrentSlate = currentSlate?.Id == slate.Id;
+
+        return await _settledCache.GetOrBuildAsync(
+            cacheKey, isCurrentSlate, slate.EndDate.ToDateTime(TimeOnly.MaxValue),
+            buildFromRowsAsync: async () => {
+                var rows = (await cfbRepo.GetScoresForSlateAsync(slate.Id)).ToList();
+                if (rows.Count == 0) return null;
+                var games = rows.Select(FinalScoresEspnMapper.FromCfbScores);
+                return FinalScoresEspnMapper.Build(games, slate.Season, slate.EspnWeekNumber.Value, CfbSlateHelpers.IsCfpSlate(slate.ScoringFormat));
+            },
+            // isCurrentSlate is already resolved above — pass it through instead of letting the
+            // fetcher re-derive it via a second ICfbCurrentSlateService.GetCurrentSlateAsync()
+            // call (a second full-table DB round trip for the identical fact every live fetch).
+            liveFetchAsync: () => _fetcher.FetchForSlateAsync(slate, isCurrentSlate));
+    }
+
+    public void InvalidateSlateCache(int slateId) => _settledCache.Invalidate($"cfb-slate-scores_{slateId}");
 
     public ValueTask DisposeAsync() => _cache.DisposeAsync();
 }

--- a/Server/Services/CfbCurrentSlateService.cs
+++ b/Server/Services/CfbCurrentSlateService.cs
@@ -8,7 +8,30 @@ public class CfbCurrentSlateService(ICfbRepository repo, [FromKeyedServices(Curr
     public async Task<CfbSlateInfo?> GetCurrentSlateAsync() {
         var now = timeProvider.GetUtcNow().UtcDateTime;
         var slates = (await repo.GetAllSlatesAsync()).ToList();
+        var configs = await repo.GetAllWeekConfigsAsync();
+        var slateWindows = BuildSlateWindows(slates, configs);
 
+        // frizat-9xg: most recent slate whose own spread grab has passed, unless we're within
+        // 2 days of the next slate's spread grab — see SeasonWindowResolver for the shared
+        // NFL/CFB logic (applies identically across a season boundary, no special case here).
+        var resolved = SeasonWindowResolver.ResolveCurrentWeek(slateWindows.Select(sw => sw.Window), now);
+        if (resolved is null) return null;
+
+        var (active, activeWindow) = slateWindows.First(sw => sw.Window.Season == resolved.Value.Season
+            && sw.Window.Start == resolved.Value.Start && sw.Window.End == resolved.Value.End);
+
+        return new CfbSlateInfo(active.Id, active.Season, active.SlateNumber, active.Label,
+            active.SlateType, active.StartDate, active.EndDate, active.FirstGameUtc, activeWindow.SpreadLockDatetime);
+    }
+
+    // frizat-d0t: extracted so DemoCfbCacheService.GetSlateScoresAsync can resolve "is this the
+    // current slate" the SAME way this class does — including the fail-loud throw below —
+    // instead of a second, independently-derived copy that could silently disagree (a prior
+    // version of that demo-mode copy defaulted a missing config to DateTime.MaxValue instead of
+    // throwing, which would have let demo/e2e "current slate" resolution silently diverge from
+    // real prod behavior for the exact data-integrity case this throw exists to catch).
+    public static List<(CfbSlates Slate, SeasonWindowResolver.WeekWindow Window)> BuildSlateWindows(
+        IEnumerable<CfbSlates> slates, IEnumerable<CfbSeasonWeekConfig> configs) {
         // Every CfbSlates row is seeded FROM a CfbSeasonWeekConfig row (CfbSlateSeederJob sets
         // SlateNumber = cfg.IvLeagueWeekNumber), which is where SpreadLockDatetime actually
         // lives — one query for every season's configs (same pattern as
@@ -19,34 +42,22 @@ public class CfbCurrentSlateService(ICfbRepository repo, [FromKeyedServices(Curr
         // within the same season (see CfbSeasonWeekConfigConfiguration's filtered unique index
         // and DemoDataSeeder's CfbDemoSeason rows) — keying a dictionary on it unfiltered throws
         // on the very first season with more than one such row.
-        var configsByKey = (await repo.GetAllWeekConfigsAsync())
+        var configsByKey = configs
             .Where(c => c.InScopeIvLeague && c.IvLeagueWeekNumber != 99)
             .ToDictionary(c => (c.Season, c.IvLeagueWeekNumber));
 
-        CfbSeasonWeekConfig ConfigFor(CfbSlates s) =>
+        DateTime SpreadLockFor(CfbSlates s) =>
             configsByKey.TryGetValue((s.Season, s.SlateNumber), out var cfg)
-                ? cfg
+                ? cfg.SpreadLockDatetime
                 // A slate with no matching config is a broken data-integrity invariant, not an
                 // expected "not configured yet" state (SpreadLockDatetime can no longer be
                 // null), so this fails loudly rather than silently skipping.
                 : throw new InvalidOperationException(
                     $"CfbSlates {s.Id} (Season {s.Season}, SlateNumber {s.SlateNumber}) has no matching CfbSeasonWeekConfig row — data integrity issue, not a normal state.");
 
-        // frizat-9xg: most recent slate whose own spread grab has passed, unless we're within
-        // 2 days of the next slate's spread grab — see SeasonWindowResolver for the shared
-        // NFL/CFB logic (applies identically across a season boundary, no special case here).
-        var windows = slates.Select(s => new SeasonWindowResolver.WeekWindow(
+        return slates.Select(s => (s, new SeasonWindowResolver.WeekWindow(
             s.Season, s.StartDate.ToDateTime(TimeOnly.MinValue), s.EndDate.ToDateTime(TimeOnly.MaxValue),
-            ConfigFor(s).SpreadLockDatetime));
-        var resolved = SeasonWindowResolver.ResolveCurrentWeek(windows, now);
-        if (resolved is null) return null;
-
-        var active = slates.First(s => s.Season == resolved.Value.Season
-            && s.StartDate.ToDateTime(TimeOnly.MinValue) == resolved.Value.Start
-            && s.EndDate.ToDateTime(TimeOnly.MaxValue) == resolved.Value.End);
-
-        return new CfbSlateInfo(active.Id, active.Season, active.SlateNumber, active.Label,
-            active.SlateType, active.StartDate, active.EndDate, active.FirstGameUtc, ConfigFor(active).SpreadLockDatetime);
+            SpreadLockFor(s)))).ToList();
     }
 
     public async Task<bool> IsSeasonActiveAsync() {

--- a/Server/Services/CfbLiveScoreFetcher.cs
+++ b/Server/Services/CfbLiveScoreFetcher.cs
@@ -1,20 +1,24 @@
 using FourPlayWebApp.Server.Jobs;
 using FourPlayWebApp.Server.Models.Data;
 using FourPlayWebApp.Server.Services.Interfaces;
-using FourPlayWebApp.Server.Services.Repositories.Interfaces;
 using FourPlayWebApp.Shared.Helpers;
 using FourPlayWebApp.Shared.Models;
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 
 namespace FourPlayWebApp.Server.Services;
 
-// ICfbRepository is registered Scoped, but this fetcher is a Singleton — resolving it directly in
-// the constructor would be a captive-dependency DI violation (same pattern CfbCacheService already
-// uses for the identical problem; see its own comment).
-public class CfbLiveScoreFetcher(ICfbApiService cfbApi, IServiceScopeFactory scopeFactory, IMemoryCache settledCache) : ICfbLiveScoreFetcher {
-    public async Task<EspnScores?> FetchForSlateAsync(CfbSlates slate, bool bypassCache = false) {
+// Pure ESPN fetch, no caching (frizat-d0t) — mirrors NflLiveScoreFetcher's shape exactly. The
+// settled-slate DB-reconstruction + cache that used to live here moved to
+// CfbCacheService.GetSlateScoresAsync, matching where NFL's equivalent already lived
+// (EspnCacheService.GetWeekScoresAsync) — this fetcher is now called directly by CfbScoresJob
+// (no bypassCache flag needed anymore, since there's no cache here to bypass) and by
+// CfbCacheService as the live-fallback delegate.
+//
+// ReplayCacheService is a Singleton, registered only when DEMO_REPLAY_MODE=true — resolved via
+// IServiceProvider.GetService (returns null gracefully when unregistered) rather than a DI scope,
+// since a Singleton needs no scope to resolve safely from a Singleton caller.
+public class CfbLiveScoreFetcher(ICfbApiService cfbApi, IServiceProvider serviceProvider) : ICfbLiveScoreFetcher {
+    public async Task<EspnScores?> FetchForSlateAsync(CfbSlates slate, bool isCurrentSlate) {
         // CfbSeasonWeekConfig.EspnWeekNumber is non-nullable, and both known producers of CfbSlates
         // rows (CfbSlateSeederJob, DemoDataSeeder) always copy a real week number through — so every
         // slate in practice carries one. frizat-11t: the regular-season ESPN fetch itself no longer
@@ -23,78 +27,25 @@ public class CfbLiveScoreFetcher(ICfbApiService cfbApi, IServiceScopeFactory sco
         // date window and can return a team's game from an entirely different slate). EspnWeekNumber
         // is still required here as the natural key CfbRanking rows and CfbPicksController's ranking
         // lookup are keyed on (Season, EspnWeekNumber, TeamAbbreviation) — a missing value still means
-        // the control table wasn't seeded correctly, not a case to silently paper over. CfbSlates.
-        // EspnWeekNumber itself is still nullable at the model/DB level though, so a future producer
-        // could leave it unset. Checked up front so it applies uniformly to the DB-first branch below
-        // too — /code-review caught that branch silently defaulting a missing value to week 0
-        // instead of applying this same guard.
+        // the control table wasn't seeded correctly, not a case to silently paper over.
         if (!slate.EspnWeekNumber.HasValue) {
             Log.Warning("CfbLiveScoreFetcher: slate {SlateId} has no EspnWeekNumber — skipping", slate.Id);
             return null;
-        }
-
-        // DB-first: only once the slate's own window has fully ended — while a slate is still
-        // active, ESPN is always the source of truth regardless of how many of its games have
-        // already been persisted. /code-review caught a real bug in an earlier version of this
-        // check that gated purely on "any row persisted": the instant ONE game in a multi-game
-        // slate finished, every subsequent call permanently stopped calling ESPN, so the rest of
-        // that slate's still-in-progress games were never discovered or persisted — this backs
-        // both CfbScoresJob (which would never finish collecting that slate) and CfbCacheService's
-        // live poll of the CURRENT slate (which would freeze the Scores page mid-slate). Once the
-        // window has ended, a slate whose games are all persisted is always FINAL (CfbScoresJob
-        // only writes finished games), so 100 concurrent viewers of the same past slate share one
-        // DB read instead of each triggering its own ESPN call — mirrors EspnCacheService's
-        // identical fix for NFL's historical-week endpoint.
-        //
-        // EndDate is a DateOnly with no time component, but a late game (common for CFB evening
-        // kickoffs) can still be in progress after UTC midnight on that calendar date — a straight
-        // date compare would flip to "ended" mid-game. The 6-hour buffer past the end of EndDate
-        // covers that crossover; this now gets cached forever once true (see the caching layer
-        // below), so getting this boundary right matters more than it used to.
-        //
-        // The control-table-resolved CURRENT slate is exempt from this shortcut, same reasoning
-        // as EspnCacheService.GetWeekScoresAsync's identical NFL fix: SeasonWindowResolver can
-        // legitimately keep an old slate as "current" well past its nominal end (the off-season
-        // bootstrap case), and cfbAdapter.ts's current-slate path now always calls this fetcher
-        // for that resolved slate — it needs the slate's real live/final ESPN state, not a DB
-        // reconstruction with no live situation/clock data.
-        using var scope = scopeFactory.CreateScope();
-        var currentSlateService = scope.ServiceProvider.GetRequiredService<ICfbCurrentSlateService>();
-        var currentSlate = await currentSlateService.GetCurrentSlateAsync();
-        var isCurrentSlate = currentSlate?.Id == slate.Id;
-
-        var slateHasEnded = !bypassCache && !isCurrentSlate && slate.EndDate.ToDateTime(TimeOnly.MaxValue).AddHours(6) < DateTime.UtcNow;
-        if (slateHasEnded) {
-            var cacheKey = $"cfb-slate-scores_{slate.Id}";
-            if (settledCache.TryGetValue<EspnScores>(cacheKey, out var cached)) return cached;
-
-            var cfbRepo = scope.ServiceProvider.GetRequiredService<ICfbRepository>();
-            var rows = (await cfbRepo.GetScoresForSlateAsync(slate.Id)).ToList();
-            if (rows.Count > 0) {
-                var games = rows.Select(row => new FinalScoresEspnMapper.FinishedGame(
-                    row.Id.ToString(), row.HomeTeam, row.AwayTeam, row.HomeTeamScore, row.AwayTeamScore, row.GameTime,
-                    row.WeatherDisplayValue is null && row.WeatherConditionId is null && row.WeatherTemperatureF is null
-                        ? null
-                        : new FinalScoresEspnMapper.WeatherInfo(row.WeatherDisplayValue, row.WeatherConditionId, row.WeatherTemperatureF)));
-                var built = FinalScoresEspnMapper.Build(games, slate.Season, slate.EspnWeekNumber.Value, CfbSlateHelpers.IsCfpSlate(slate.ScoringFormat));
-                settledCache.Set(cacheKey, built);
-                return built;
-            }
         }
 
         var result = CfbSlateHelpers.IsCfpSlate(slate.ScoringFormat)
             ? await FetchCfpAsync(slate)
             : await FetchRegularSeasonAsync(slate);
 
-        // Replay mode only (DEMO_REPLAY_MODE=true) — ReplayCacheService is a Singleton registered
-        // only then, so this resolves null (a no-op) in every other environment. The replay
-        // game (IND @ ATL) is seeded as a second game inside this real slate specifically so it
-        // can be surfaced through CFB's normal slate-based flow (see
-        // DemoDataSeeder.SeedReplayCfbSlateAsync) — but cfbApi above has no knowledge of it (it
-        // only ever calls the real ESPN endpoints), so it has to be merged in here rather than
-        // fetched as part of the real ESPN response.
+        // Replay mode only (DEMO_REPLAY_MODE=true) — ReplayCacheService resolves null (a no-op)
+        // in every other environment. The replay game (IND @ ATL) is seeded as a second game
+        // inside this real slate specifically so it can be surfaced through CFB's normal
+        // slate-based flow (see DemoDataSeeder.SeedReplayCfbSlateAsync) — but cfbApi above has no
+        // knowledge of it (it only ever calls the real ESPN endpoints), so it has to be merged in
+        // here rather than fetched as part of the real ESPN response. Only merged for the
+        // CURRENT slate — a historical/other slate has no business surfacing the replay fixture.
         if (isCurrentSlate) {
-            var replayService = scope.ServiceProvider.GetService<ReplayCacheService>();
+            var replayService = serviceProvider.GetService<ReplayCacheService>();
             var replaySnapshot = replayService is null ? null : await replayService.GetScoresAsync();
             if (replaySnapshot?.Events is { Length: > 0 } replayEvents) {
                 result = result is null
@@ -145,6 +96,4 @@ public class CfbLiveScoreFetcher(ICfbApiService cfbApi, IServiceScopeFactory sco
 
         return events.Length == 0 ? null : GameHelpers.WithEvents(scoreboard, events);
     }
-
-    public void InvalidateSlateCache(int slateId) => settledCache.Remove($"cfb-slate-scores_{slateId}");
 }

--- a/Server/Services/DemoCfbCacheService.cs
+++ b/Server/Services/DemoCfbCacheService.cs
@@ -1,5 +1,9 @@
+using FourPlayWebApp.Server.Data;
+using FourPlayWebApp.Server.Jobs;
 using FourPlayWebApp.Server.Services.Interfaces;
+using FourPlayWebApp.Shared.Helpers;
 using FourPlayWebApp.Shared.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace FourPlayWebApp.Server.Services;
 
@@ -13,13 +17,57 @@ namespace FourPlayWebApp.Server.Services;
 public class DemoCfbCacheService : ICfbCacheService
 {
     private readonly EspnScores? _scores;
+    private readonly IDbContextFactory<ApplicationDbContext> _dbContextFactory;
+    private readonly TimeProvider _timeProvider;
 
-    public DemoCfbCacheService()
+    public DemoCfbCacheService(IDbContextFactory<ApplicationDbContext> dbContextFactory,
+        [FromKeyedServices(CurrentWeekClock.Key)] TimeProvider timeProvider)
     {
+        _dbContextFactory = dbContextFactory;
+        _timeProvider = timeProvider;
         _scores = DemoFixtureLoader.Load("sample_espn_cfb.json");
     }
 
     public event Action? ScoresChanged; // never fired — demo data is static
 
     public Task<EspnScores?> GetScoresAsync() => Task.FromResult(_scores);
+
+    // Backs the "browse a non-current slate" path on the Scores page (GetCfbScoresForSlate in
+    // EspnController) — mirrors DemoEspnCacheService.GetWeekScoresAsync's NFL pattern exactly,
+    // adapted to CFB's slate model (frizat-d0t). Resolves "current slate" inline via
+    // CfbCurrentSlateService.BuildSlateWindows (the SAME shared helper that class itself uses,
+    // including its fail-loud throw on a slate with no matching config — an earlier version of
+    // this method inlined its own copy that silently fell back to DateTime.MaxValue instead,
+    // which could have let demo's "current slate" resolution silently disagree with prod's for
+    // the exact data-integrity case that throw exists to catch) rather than
+    // constructor-injecting that Scoped service into this Singleton — same captive-dependency
+    // reasoning DemoEspnCacheService's own comment explains, and must use the same keyed clock
+    // CfbCurrentSlateService resolves "current" against (frizat-tf2) so the two don't disagree.
+    public async Task<EspnScores?> GetSlateScoresAsync(int slateId)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync();
+
+        var slate = await db.CfbSlates.FirstOrDefaultAsync(s => s.Id == slateId);
+        if (slate is null || !slate.EspnWeekNumber.HasValue) return null;
+
+        var allSlates = await db.CfbSlates.ToListAsync();
+        var configs = await db.CfbSeasonWeekConfigs.ToListAsync();
+        var slateWindows = CfbCurrentSlateService.BuildSlateWindows(allSlates, configs);
+        var resolvedCurrent = SeasonWindowResolver.ResolveCurrentWeek(slateWindows.Select(sw => sw.Window), _timeProvider.GetUtcNow().UtcDateTime);
+        var isCurrentSlate = resolvedCurrent is not null
+            && resolvedCurrent.Value.Season == slate.Season
+            && resolvedCurrent.Value.Start == slate.StartDate.ToDateTime(TimeOnly.MinValue)
+            && resolvedCurrent.Value.End == slate.EndDate.ToDateTime(TimeOnly.MaxValue);
+
+        if (isCurrentSlate) return _scores;
+
+        var rows = await db.CfbScores.Where(s => s.CfbSlateId == slateId).ToListAsync();
+        if (rows.Count == 0) return null;
+
+        var games = rows.Select(FinalScoresEspnMapper.FromCfbScores);
+        return FinalScoresEspnMapper.Build(games, slate.Season, slate.EspnWeekNumber.Value, CfbSlateHelpers.IsCfpSlate(slate.ScoringFormat));
+    }
+
+    // No-op: demo data is a frozen fixture, never refreshed by a live CfbScoresJob upsert.
+    public void InvalidateSlateCache(int slateId) { }
 }

--- a/Server/Services/EspnCacheService.cs
+++ b/Server/Services/EspnCacheService.cs
@@ -14,7 +14,7 @@ public class EspnCacheService : IEspnCacheService, IAsyncDisposable
 {
     private readonly INflLiveScoreFetcher _fetcher;
     private readonly ILeagueRepository _leagueRepository;
-    private readonly IMemoryCache _historicalCache;
+    private readonly SettledScoreCache _settledCache;
     private readonly PeriodicRefreshCache<EspnScores> _cache;
 
     public event Action? ScoresChanged
@@ -27,7 +27,7 @@ public class EspnCacheService : IEspnCacheService, IAsyncDisposable
     {
         _fetcher = fetcher;
         _leagueRepository = leagueRepository;
-        _historicalCache = historicalCache;
+        _settledCache = new SettledScoreCache(historicalCache);
         _cache = new PeriodicRefreshCache<EspnScores>(
             fetch: async () => {
                 // NflCurrentWeekService always resolves *something* now (most-recently-completed
@@ -64,19 +64,26 @@ public class EspnCacheService : IEspnCacheService, IAsyncDisposable
     public async Task<EspnScores?> GetWeekScoresAsync(int season, int nflWeek)
     {
         // Cache key is the resolved internal (season, WeekId) — matches
-        // CfbLiveScoreFetcher's cfb-slate-scores_{slateId} shape and is what
+        // CfbCacheService's cfb-slate-scores_{slateId} shape and is what
         // InvalidateWeekCache(season, week) can actually address after an upsert.
         var cacheKey = $"nfl-week-scores_{season}_{nflWeek}";
-        if (_historicalCache.TryGetValue<EspnScores>(cacheKey, out var cached)) return cached;
+        // Fast path: skip the config/current-week resolution entirely on a cache hit — a
+        // settled week's response never changes, so repeat requests for it shouldn't pay for an
+        // unfiltered NflSeasonWeekConfigs read just to re-derive a cache key we already have.
+        if (_settledCache.TryGet(cacheKey, out var cached)) return cached;
 
         // One unscoped fetch serves both purposes below — finding this week's own row and
         // resolving which week SeasonWindowResolver currently treats as "current" needs the
         // full set of configs either way.
         var allConfigs = await _leagueRepository.GetNflSeasonWeekConfigsAsync();
         var matchingConfig = allConfigs.FirstOrDefault(c => c.Season == season && c.WeekId == nflWeek);
+        // Never trust ESPN's own week=N bucketing (frizat-11t's NFL mirror) — only fetch when we
+        // have a real control-table row to scope the date-range query to. No matching config
+        // means there's nothing to ask ESPN for, and nothing to have ever cached either.
+        if (matchingConfig is null) return null;
 
         // The control-table-resolved CURRENT week is always live-fetched, even if its own
-        // calendar window already looks "ended" by the 6-hour buffer below —
+        // calendar window already looks "ended" by SettledScoreCache's own buffer below —
         // SeasonWindowResolver can legitimately keep an old window as "current" well past its
         // nominal end (e.g. the off-season bootstrap case: showing last season's Super Bowl
         // until 2 days before the next season's first spread grab), and the frontend's
@@ -86,40 +93,29 @@ public class EspnCacheService : IEspnCacheService, IAsyncDisposable
         // actively treating as current, instead of its real live/final ESPN state.
         var windows = allConfigs.Select(c => new SeasonWindowResolver.WeekWindow(c.Season, c.WeekStartDatetime, c.WeekEndDatetime, c.SpreadLockDatetime));
         var resolvedCurrent = SeasonWindowResolver.ResolveCurrentWeek(windows, DateTime.UtcNow);
-        var isResolvedCurrentWeek = matchingConfig is not null && resolvedCurrent is not null
+        var isResolvedCurrentWeek = resolvedCurrent is not null
             && resolvedCurrent.Value.Season == matchingConfig.Season
             && resolvedCurrent.Value.Start == matchingConfig.WeekStartDatetime
             && resolvedCurrent.Value.End == matchingConfig.WeekEndDatetime;
 
-        // 6-hour buffer past the configured end, mirroring CfbLiveScoreFetcher's identical
-        // safety margin — this now gets cached forever once true, so a week whose config end
-        // time turns out to be a little too tight against its actual last kickoff shouldn't
-        // permanently freeze a still-in-progress game out of every future response.
-        var weekHasEnded = !isResolvedCurrentWeek && matchingConfig is not null && matchingConfig.WeekEndDatetime.AddHours(6) < DateTime.UtcNow;
-
-        if (weekHasEnded) {
-            var rows = await _leagueRepository.GetNflScoresAsync(season, nflWeek);
-            if (rows.Count > 0) {
+        return await _settledCache.GetOrBuildAsync(
+            cacheKey, isResolvedCurrentWeek, matchingConfig.WeekEndDatetime,
+            buildFromRowsAsync: async () => {
+                var rows = await _leagueRepository.GetNflScoresAsync(season, nflWeek);
+                if (rows.Count == 0) return null;
                 var games = rows.Select(row => new FinalScoresEspnMapper.FinishedGame(
                     row.Id.ToString(), row.HomeTeam, row.AwayTeam, row.HomeTeamScore, row.AwayTeamScore, row.GameTime));
-                // NB: the built EspnScores.Week.Number below holds our internal nflWeek, not
-                // ESPN's real week number the live-fetch path (_fetcher.FetchForWeekAsync) would
-                // have put there — no current consumer reads this field from a live response for
-                // a decision, but it's a real seam the full frizat-3nv GameData DTO would close.
-                var built = FinalScoresEspnMapper.Build(games, season, nflWeek, matchingConfig!.WeekType == "PostSeason");
-                _historicalCache.Set(cacheKey, built);
-                return built;
-            }
-        }
-
-        // Never trust ESPN's own week=N bucketing (frizat-11t's NFL mirror) — only fetch when we
-        // have a real control-table row to scope the date-range query to. No matching config
-        // means there's nothing to ask ESPN for.
-        return matchingConfig is null ? null : await _fetcher.FetchForWeekAsync(matchingConfig);
+                // NB: the built EspnScores.Week.Number holds our internal nflWeek, not ESPN's
+                // real week number the live-fetch path below would have put there — no current
+                // consumer reads this field from a live response for a decision, but it's a real
+                // seam the full frizat-3nv GameData DTO would close.
+                return FinalScoresEspnMapper.Build(games, season, nflWeek, matchingConfig.WeekType == "PostSeason");
+            },
+            liveFetchAsync: () => _fetcher.FetchForWeekAsync(matchingConfig));
     }
 
     public void InvalidateWeekCache(int season, int week) =>
-        _historicalCache.Remove($"nfl-week-scores_{season}_{week}");
+        _settledCache.Invalidate($"nfl-week-scores_{season}_{week}");
 
     public ValueTask DisposeAsync() => _cache.DisposeAsync();
 }

--- a/Server/Services/FinalScoresEspnMapper.cs
+++ b/Server/Services/FinalScoresEspnMapper.cs
@@ -1,4 +1,5 @@
 using FourPlayWebApp.Shared.Models;
+using FourPlayWebApp.Shared.Models.Data;
 
 namespace FourPlayWebApp.Server.Services;
 
@@ -14,6 +15,15 @@ public static class FinalScoresEspnMapper {
         string Id, string HomeTeam, string AwayTeam,
         int HomeScore, int AwayScore, DateTimeOffset GameTime,
         WeatherInfo? Weather = null);
+
+    // frizat-d0t: CfbScores -> FinishedGame (including the optional weather fields NFL's
+    // NflScores has no equivalent of) — one implementation shared by CfbCacheService and
+    // DemoCfbCacheService, previously copy-pasted identically in both.
+    public static FinishedGame FromCfbScores(CfbScores row) =>
+        new(row.Id.ToString(), row.HomeTeam, row.AwayTeam, row.HomeTeamScore, row.AwayTeamScore, row.GameTime,
+            row.WeatherDisplayValue is null && row.WeatherConditionId is null && row.WeatherTemperatureF is null
+                ? null
+                : new WeatherInfo(row.WeatherDisplayValue, row.WeatherConditionId, row.WeatherTemperatureF));
 
     public static EspnScores Build(IEnumerable<FinishedGame> games, int season, int week, bool postSeason) {
         var events = games.Select(g => BuildEvent(g, season, week, postSeason)).ToArray();

--- a/Server/Services/Interfaces/ICfbCacheService.cs
+++ b/Server/Services/Interfaces/ICfbCacheService.cs
@@ -10,5 +10,13 @@ namespace FourPlayWebApp.Server.Services.Interfaces;
 public interface ICfbCacheService
 {
     Task<EspnScores?> GetScoresAsync();
+    // Live/settled CFB scores for a SPECIFIC (typically non-current) slate — mirrors
+    // IEspnCacheService.GetWeekScoresAsync(season, nflWeek) exactly (frizat-d0t unification):
+    // settled slates are served from a cached DB reconstruction, everything else live-fetched.
+    Task<EspnScores?> GetSlateScoresAsync(int slateId);
+    // Evicts the cached settled-slate reconstruction so a fresh CfbScoresJob upsert is visible
+    // immediately instead of waiting for a process restart — mirrors
+    // IEspnCacheService.InvalidateWeekCache.
+    void InvalidateSlateCache(int slateId);
     event Action? ScoresChanged;
 }

--- a/Server/Services/Interfaces/ICfbLiveScoreFetcher.cs
+++ b/Server/Services/Interfaces/ICfbLiveScoreFetcher.cs
@@ -12,17 +12,19 @@ namespace FourPlayWebApp.Server.Services.Interfaces;
 /// CfbScoresJob (frizat-703.6) so the DB-upsert jobs (CfbScoresJob, CfbSpreadJob) and
 /// CfbCacheService's live-serving path share one implementation instead of maintaining the
 /// CFP/ranked branching three times.
+///
+/// Pure fetch — no caching (frizat-d0t). The settled-slate DB-reconstruction + cache that used to
+/// live here (with a bypassCache flag CfbScoresJob set to skip it) moved to
+/// CfbCacheService.GetSlateScoresAsync, mirroring where NFL's equivalent already lived
+/// (EspnCacheService.GetWeekScoresAsync) — CfbScoresJob now calls this fetcher directly, the same
+/// way NflScoresJob already calls INflLiveScoreFetcher directly.
 /// </summary>
 public interface ICfbLiveScoreFetcher {
-    // bypassCache: true skips the "slate has ended → replay whatever's already in the DB,
-    // cached forever" viewer-facing shortcut and always hits ESPN — CfbScoresJob's whole
-    // purpose is to discover NEW finals for a slate, including one that was missed before the
-    // slate "ended" (e.g. a scheduling-cron gap); the viewer shortcut exists to spare 100
-    // concurrent page loads from re-hitting ESPN for settled data, not to freeze a background
-    // catch-up job out of ever seeing fresh data for that slate again.
-    Task<EspnScores?> FetchForSlateAsync(CfbSlates slate, bool bypassCache = false);
-
-    // Evicts the cached settled-slate reconstruction so a fresh CfbScoresJob upsert is visible
-    // immediately instead of waiting for a process restart.
-    void InvalidateSlateCache(int slateId);
+    // isCurrentSlate: callers already need to know this themselves (CfbCacheService, to decide
+    // whether to bypass its settled cache; CfbScoresJob, resolved once before its slate loop) —
+    // passed in rather than re-resolved here, which used to mean a second
+    // ICfbCurrentSlateService.GetCurrentSlateAsync() DB round trip on every live fetch just to
+    // re-derive a fact the caller already had. Only used here to decide whether to merge in the
+    // replay-mode snapshot (see FetchForSlateAsync's own comment).
+    Task<EspnScores?> FetchForSlateAsync(CfbSlates slate, bool isCurrentSlate);
 }

--- a/Server/Services/ReplayCacheService.cs
+++ b/Server/Services/ReplayCacheService.cs
@@ -108,4 +108,15 @@ public class ReplayCacheService : IEspnCacheService, ICfbCacheService {
 
     // No-op: replay mode drives fixed captured snapshots, never a live NflScoresJob upsert.
     public void InvalidateWeekCache(int season, int week) { }
+
+    // Replay mode drives one fixed game/slate through scheduled->final — it has no concept of
+    // "other slates" (mirrors GetWeekScoresAsync's identical NFL constraint). Always returns the
+    // current snapshot regardless of which slateId was requested — the CFB Scores/Picks page
+    // (cfbAdapter.ts's loadScoresForSlate) always asks for the one real slate the replay game
+    // was seeded into (frizat-d0t: this endpoint now goes through ICfbCacheService.
+    // GetSlateScoresAsync instead of ICfbLiveScoreFetcher.FetchForSlateAsync directly).
+    public Task<EspnScores?> GetSlateScoresAsync(int slateId) => Task.FromResult<EspnScores?>(_snapshots[_index]);
+
+    // No-op: replay mode drives fixed captured snapshots, never a live CfbScoresJob upsert.
+    public void InvalidateSlateCache(int slateId) { }
 }

--- a/Server/Services/SettledScoreCache.cs
+++ b/Server/Services/SettledScoreCache.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Caching.Memory;
+using FourPlayWebApp.Shared.Models;
+
+namespace FourPlayWebApp.Server.Services;
+
+// frizat-d0t: EspnCacheService.GetWeekScoresAsync (NFL) and CfbLiveScoreFetcher.
+// FetchForSlateAsync's settled-cache branch (CFB) independently implemented the identical
+// algorithm — check an IMemoryCache, else read persisted rows once the item's own window has
+// ended and build a response, cache it forever, else fall through to a live fetch. One shared
+// orchestration instead of two hand-copied ones.
+//
+// Callers still own resolving isCurrentItem (NFL: SeasonWindowResolver.ResolveCurrentWeek; CFB:
+// ICfbCurrentSlateService.GetCurrentSlateAsync()?.Id == slate.Id — genuinely different mechanisms
+// today, not unified here), windowEndUtc, and how to build a response from persisted rows
+// (FinalScoresEspnMapper.Build with sport-specific row-mapping — this class deliberately doesn't
+// know that type exists, only that a build attempt returns null on nothing-to-build). Not
+// DI-registered itself — each cache service constructs one directly over its own
+// already-injected IMemoryCache, mirroring how EspnCacheService already constructs its
+// PeriodicRefreshCache<EspnScores> inline.
+public class SettledScoreCache(IMemoryCache cache) {
+    // 6-hour buffer past the item's own configured end — a late kickoff (CFB evening games
+    // crossing UTC midnight, NFL Monday Night Football) can still be in progress after the
+    // calendar window "ends"; this now gets cached forever once true, so the buffer matters more
+    // than it would for a short-lived cache.
+    private static readonly TimeSpan EndOfWindowBuffer = TimeSpan.FromHours(6);
+
+    // Cheap fast-path exit for callers to check BEFORE doing any DB work to resolve the
+    // config/slate needed for GetOrBuildAsync's other parameters — a cache hit needs none of
+    // that. GetOrBuildAsync repeats this same check internally (a plain dictionary lookup, not
+    // I/O — negligible) so it stays correct and usable standalone.
+    public bool TryGet(string cacheKey, out EspnScores? cached) => cache.TryGetValue(cacheKey, out cached);
+
+    public async Task<EspnScores?> GetOrBuildAsync(
+        string cacheKey, bool isCurrentItem, DateTime windowEndUtc,
+        Func<Task<EspnScores?>> buildFromRowsAsync,
+        Func<Task<EspnScores?>> liveFetchAsync) {
+        if (cache.TryGetValue<EspnScores>(cacheKey, out var cached)) return cached;
+
+        // The control-table-resolved CURRENT item is always live-fetched, even if its own
+        // calendar window already looks "ended" — SeasonWindowResolver/ICfbCurrentSlateService
+        // can legitimately keep an old window as "current" well past its nominal end (e.g. the
+        // off-season bootstrap case), and the frontend's current-item path always asks for
+        // exactly that item's real live/final ESPN state, not a DB reconstruction with no live
+        // situation/clock data.
+        var windowHasEnded = !isCurrentItem && windowEndUtc + EndOfWindowBuffer < DateTime.UtcNow;
+
+        if (windowHasEnded) {
+            // Caller's own delegate returns null when there's nothing to build (e.g. zero
+            // persisted rows) — a still-active item that merely hasn't had any games persisted
+            // yet must not freeze an empty response in place once games actually finish and get
+            // persisted, so only a real build gets cached.
+            var built = await buildFromRowsAsync();
+            if (built is not null) {
+                cache.Set(cacheKey, built);
+                return built;
+            }
+        }
+
+        return await liveFetchAsync();
+    }
+
+    public void Invalidate(string cacheKey) => cache.Remove(cacheKey);
+}


### PR DESCRIPTION
## Summary
- NFL's settled-score cache (EspnCacheService) and CFB's (buried inside CfbLiveScoreFetcher, gated by a `bypassCache` flag) independently implemented the identical window-ended/cache/DB-rebuild/live-fallback algorithm — a structural asymmetry, not just duplication. Extracts the shared orchestration into `SettledScoreCache`, used by both `EspnCacheService.GetWeekScoresAsync` and a new `CfbCacheService.GetSlateScoresAsync`.
- `CfbLiveScoreFetcher` is now a pure fetch (mirrors `NflLiveScoreFetcher`) — `CfbScoresJob` calls it directly instead of a `bypassCache: true` flag, closing off the original production incident (a missed Monday-night game an ended-slate's cache shortcut couldn't recover) at the structural level instead of a flag to remember.
- `CfbCurrentSlateService.BuildSlateWindows` extracted as a shared static method so `DemoCfbCacheService` reuses the same fail-loud slate/config-mismatch behavior as prod instead of a diverging inline copy.
- `FinalScoresEspnMapper.FromCfbScores` added to remove a duplicated CFB row-mapping projection.

## Test plan
- [x] `dotnet test` — 917/917 passing
- [x] `npm run test -- --run` — 636/636 passing
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `CI=true npm run test:e2e -- --project=chromium` — 93 passed (2 known-flaky dev-server-startup retries, unrelated to this backend-only diff)
- [x] `/simplify` (4 parallel review agents) run and all findings applied
- No CHANGELOG entry — internal refactor only, no user-facing behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs