### PR TITLE
dev → main: red-zone card border fix

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -6,6 +6,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 
 ## 2026-09-09
 
+- Fixed: a live game's Scores card could show the red "red zone" border while the field position bar below it showed the ball outside any red zone — both now agree, since ESPN's red zone flag can be momentarily inconsistent with the actual yard line
 - Added: real ESPN team logos as an opt-in alternative to the synthetic shield badges on Picks, Scores, and the picks matrix — off by default, no visible change yet
 - Fixed: the admin Job Manager page had one generically-labeled "Run Scores Job" / "Run Spreads Job" button that only ever ran NFL's job, with no way to trigger CFB's scores or spreads jobs at all — each sport now has its own clearly-labeled button
 - Fixed: a league's Tease Pts and Weekly Cost settings could be edited at any point in the season, with no protection against changing already-decided weeks' terms — Tease Pts now lock once the season starts, and Weekly Cost locks once the season's final week (Super Bowl / Championship) starts

--- a/Client.React/src/__tests__/FieldPosition.test.tsx
+++ b/Client.React/src/__tests__/FieldPosition.test.tsx
@@ -38,13 +38,22 @@ describe('FieldPosition', () => {
     expect(screen.getByTestId('possession-arrow')).toHaveTextContent('◀');
   });
 
-  it('applies red zone styling when isRedZone is true', () => {
-    render(<FieldPosition situation={buildSituation({ isRedZone: true })} />);
+  it('applies red zone styling when isRedZone is true and yardLine actually supports it', () => {
+    render(<FieldPosition situation={buildSituation({ isRedZone: true, yardLine: 15 })} />);
     expect(screen.getByTestId('field-position-bar')).toHaveAttribute('data-redzone', 'true');
   });
 
   it('does not apply red zone styling when isRedZone is false', () => {
     render(<FieldPosition situation={buildSituation({ isRedZone: false })} />);
+    expect(screen.getByTestId('field-position-bar')).toHaveAttribute('data-redzone', 'false');
+  });
+
+  // frizat: live bug report — ESPN's own situation.isRedZone was observed true with yardLine=35
+  // (not within 20 of either goal), and this card's red border trusted the raw flag directly while
+  // the stripe below it (correctly) didn't, so the two visually contradicted each other. Both now
+  // go through the same isConsistentRedZone check (utils/gameHelpers.ts).
+  it('does not apply red zone styling when isRedZone is true but yardLine is inconsistent (midfield)', () => {
+    render(<FieldPosition situation={buildSituation({ isRedZone: true, yardLine: 35 })} />);
     expect(screen.getByTestId('field-position-bar')).toHaveAttribute('data-redzone', 'false');
   });
 

--- a/Client.React/src/__tests__/gameHelpers.redZone.test.ts
+++ b/Client.React/src/__tests__/gameHelpers.redZone.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { isConsistentRedZone } from '../utils/gameHelpers';
+
+// frizat: live bug report — ESPN's own situation.isRedZone was observed true with yardLine=35
+// (not within 20 yards of either goal), and ScoresPage's card border trusted the raw flag
+// directly while FieldPosition's stripe (correctly) cross-checked yardLine first, so the two
+// visually contradicted each other for the same game. Both now go through this one helper.
+describe('isConsistentRedZone', () => {
+  it('returns false when isRedZone is false, regardless of yardLine', () => {
+    expect(isConsistentRedZone({ isRedZone: false, yardLine: 5 })).toBe(false);
+  });
+
+  it('returns true when isRedZone is true and yardLine is within 20 of the home goal', () => {
+    expect(isConsistentRedZone({ isRedZone: true, yardLine: 15 })).toBe(true);
+    expect(isConsistentRedZone({ isRedZone: true, yardLine: 20 })).toBe(true);
+  });
+
+  it('returns true when isRedZone is true and yardLine is within 20 of the away goal', () => {
+    expect(isConsistentRedZone({ isRedZone: true, yardLine: 85 })).toBe(true);
+    expect(isConsistentRedZone({ isRedZone: true, yardLine: 80 })).toBe(true);
+  });
+
+  it('returns false when isRedZone is true but yardLine is at midfield (inconsistent upstream data)', () => {
+    expect(isConsistentRedZone({ isRedZone: true, yardLine: 35 })).toBe(false);
+    expect(isConsistentRedZone({ isRedZone: true, yardLine: 50 })).toBe(false);
+  });
+});

--- a/Client.React/src/components/FieldPosition.tsx
+++ b/Client.React/src/components/FieldPosition.tsx
@@ -1,6 +1,7 @@
 import { Box, Typography } from '@mui/material';
 import SportsFootballIcon from '@mui/icons-material/SportsFootball';
 import type { GameSituation } from '../types/liveGame';
+import { isConsistentRedZone } from '../utils/gameHelpers';
 
 interface FieldPositionProps {
   situation: GameSituation | null | undefined;
@@ -11,18 +12,20 @@ const YARD_MARKERS = [10, 20, 30, 40, 50, 60, 70, 80, 90];
 export default function FieldPosition({ situation }: FieldPositionProps) {
   if (!situation) return <Box sx={{ mt: 1, height: 24 + 4 + 20, mx: 1 }} />;
 
-  const { yardLine, isHomePossession, isRedZone, downDistanceText } = situation;
+  const { yardLine, isHomePossession, downDistanceText } = situation;
   // yardLine is a fixed coordinate measured from the HOME team's own goal, regardless of which
   // team currently has the ball (confirmed against a live game: away team with the ball at their
   // own 33 rendered as yardLine=67, i.e. 100 minus their distance from the home team's goal). The
   // home team is always drawn on the right in this layout, so this conversion is unconditional —
   // isHomePossession only decides the arrow's direction, never the position.
   const ballPositionPercent = 100 - yardLine;
+  const isRedZone = isConsistentRedZone(situation);
   // The actual red zone is the 20 yards nearest whichever goal the ball is closest to — not the
   // whole field. yardLine<=20 is near the home goal (right side, local% 80-100); yardLine>=80 is
-  // near the away goal (left side, local% 0-20). These are mutually exclusive by construction. If
-  // isRedZone is true but yardLine falls in neither range (inconsistent upstream data), show no
-  // stripe rather than guessing a side.
+  // near the away goal (left side, local% 0-20). These are mutually exclusive by construction, and
+  // isConsistentRedZone already ruled out the case where isRedZone is true but yardLine falls in
+  // neither range (inconsistent upstream data) — so redZoneStripeLeft is only null when isRedZone
+  // itself is already false here.
   const redZoneStripeLeft = yardLine <= 20 ? 80 : yardLine >= 80 ? 0 : null;
 
   return (
@@ -87,7 +90,9 @@ export default function FieldPosition({ situation }: FieldPositionProps) {
             >
               {isHomePossession ? '◀' : '▶'}
             </Typography>
-            <SportsFootballIcon sx={{ fontSize: 14 }} />
+            {/* frizat: reported as invisible/easy to miss at 14px next to the possession arrow —
+                bumped size and added a shadow so the ball reads clearly against the field. */}
+            <SportsFootballIcon sx={{ fontSize: 20, filter: 'drop-shadow(0 0 1px rgba(0,0,0,0.8))' }} />
           </Box>
         </Box>
 

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -20,7 +20,7 @@ import PickDialog from '../components/PickDialog';
 import FieldPosition from '../components/FieldPosition';
 import { useSession } from '../services/session';
 import { useAuth } from '../services/auth';
-import { isGameDecided, isGameFinal, isGameLive, spreadLabel } from '../utils/gameHelpers';
+import { isGameDecided, isGameFinal, isGameLive, isConsistentRedZone, spreadLabel } from '../utils/gameHelpers';
 import type { SportAdapter, GameView, WeekState, PickType } from '../services/sportAdapter';
 import { sortGamesByTimeThenRank } from '../services/sportAdapter';
 import { useLeagueMinSeason } from '../utils/useLeagueMinSeason';
@@ -282,7 +282,7 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
                 const ac = game.awayCovers ?? null;
                 const ov = game.overWins ?? null;
                 const uv = game.underWins ?? null;
-                const isCardRedZone = isLive && Boolean(game.situation?.isRedZone);
+                const isCardRedZone = isLive && game.situation != null && isConsistentRedZone(game.situation);
 
                 return (
                   <Grid size={{ xs: 12, md: 6, lg: 4 }} key={game.id}>

--- a/Client.React/src/utils/gameHelpers.ts
+++ b/Client.React/src/utils/gameHelpers.ts
@@ -2,6 +2,7 @@ import type { Competition, Competitor, EspnScores, Event, TypeName, HomeAway, Es
 import { toLocalDisplay } from './time';
 import type { PickType } from '../types/picks';
 import type { GameStatusValue } from '../services/sportAdapter';
+import type { GameSituation } from '../types/liveGame';
 
 /** True only once a game has finished — the canonical GameView.gameStatus check. */
 export function isGameFinal(status: GameStatusValue): boolean {
@@ -325,6 +326,16 @@ export function isHomeAway(value: HomeAway, expected: 'home' | 'away') {
     return expected === 'away' ? value === 0 : value === 1;
   }
   return value === expected;
+}
+
+// ESPN's live situation.isRedZone flag has been observed true with a yardLine nowhere near
+// either goal (e.g. yardLine=35 mid-drive, likely a momentarily-stale value right after a play).
+// The actual red zone is the 20 yards nearest whichever goal the ball is closest to, so cross-
+// check the flag against yardLine before trusting it — anything that draws a "red zone" UI
+// element (the ScoresPage card border, FieldPosition's stripe) must use this, not the raw flag,
+// so the two can never visually disagree with each other the way they did before this existed.
+export function isConsistentRedZone(situation: Pick<GameSituation, 'isRedZone' | 'yardLine'>): boolean {
+  return situation.isRedZone && (situation.yardLine <= 20 || situation.yardLine >= 80);
 }
 
 function isRecordType(value: EspnRecordType, expected: 'total' | 'road' | 'home') {


### PR DESCRIPTION
## Summary
Promotes dev to main. Includes PR #353 (fix red-zone card border disagreeing with the field position bar — see that PR for full detail) plus everything already on dev.

## Test plan
- [x] CI green on PR #353
- [x] dev deploy verified via /api/version on both ivleague.xyz and cfb subdomains

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs