### PR TITLE
dev → main: per-league configurable season start week

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to IV League, most recent first. For admins — see the version 
 
 Format: `## ` release headings and single-line `- ` bullets only — no bold, links, or multi-line/nested bullets. The admin Changelog page renders this with a small hand-rolled parser (`parseChangelog.ts`), not a full Markdown engine; anything outside this subset renders as literal syntax instead of being formatted. A test guards this file against drifting outside the subset.
 
+## 2026-09-10
+
+- Added: leagues can now set a Start Week (1-5, default 1) on the Juice tab so a league's season can skip early weeks — mainly for CFB leagues that want to skip week 1's often lopsided matchups. Weeks before it require no picks, don't appear on the leaderboard, and aren't billed the weekly cost; the following week settles normally, not as a doubled pot
+
 ## 2026-09-09
 
 - Fixed: a live game's Scores card could show the red "red zone" border while the field position bar below it showed the ball outside any red zone — both now agree, since ESPN's red zone flag can be momentarily inconsistent with the actual yard line

--- a/Client.React/src/__tests__/LeaguePortalPage.test.tsx
+++ b/Client.React/src/__tests__/LeaguePortalPage.test.tsx
@@ -128,6 +128,7 @@ function makeJuice(season: number, overrides?: Partial<Pick<LeagueJuiceMappingDt
     juiceDivisional: 10,
     juiceConference: 6,
     weeklyCost: 5,
+    startWeek: 1,
     dateCreated: '2026-06-29T00:00:00Z',
     teaseLocked: false,
     weeklyCostLocked: false,
@@ -212,6 +213,36 @@ describe('LeaguePortalPage (owner, non-admin)', () => {
     expect(screen.getByLabelText(/Tease Pts \(Conference\)/i)).not.toBeDisabled();
     expect(screen.getByRole('button', { name: /save/i })).not.toBeDisabled();
     expect(screen.getByText(/Weekly Cost is locked once the season's final week has started/i)).toBeInTheDocument();
+  });
+
+  // frizat-o3x: Start Week shares tease points' lock boundary — same rationale as Tease Pts.
+  it('locks Start Week when tease is locked, not when only Weekly Cost is locked', async () => {
+    mockedGetJuice.mockResolvedValue([makeJuice(CURRENT_SEASON, { teaseLocked: true, weeklyCostLocked: false })]);
+    renderPage();
+    await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+
+    await waitFor(() => expect(screen.getByLabelText(/Tease Pts \(Regular Season\)/i)).toHaveValue(13));
+    // MUI Select's displayed value/accessible name isn't reliably queryable in JSDOM (same gotcha
+    // as the Season selector elsewhere in this file) — index into the comboboxes by DOM order
+    // instead: [0] Season, [1] Start Week. aria-disabled reflects the FormControl's disabled state.
+    expect(screen.getAllByRole('combobox')[1]).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('leaves Start Week editable when only Weekly Cost is locked', async () => {
+    mockedGetJuice.mockResolvedValue([makeJuice(CURRENT_SEASON, { teaseLocked: false, weeklyCostLocked: true })]);
+    renderPage();
+    await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+
+    await waitFor(() => expect(screen.getByLabelText(/Cost Per Week/i)).toHaveValue(5));
+    expect(screen.getAllByRole('combobox')[1]).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('shows the season-starts-late explanation once Start Week is set above 1', async () => {
+    mockedGetJuice.mockResolvedValue([{ ...makeJuice(CURRENT_SEASON), startWeek: 3 }]);
+    renderPage();
+    await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+
+    await waitFor(() => expect(screen.getByText(/Weeks 1–2 won't require picks/i)).toBeInTheDocument());
   });
 
   it('shows the server\'s specific rejection message when a save is rejected by a lock, instead of a generic failure toast', async () => {

--- a/Client.React/src/__tests__/leaderboard.test.tsx
+++ b/Client.React/src/__tests__/leaderboard.test.tsx
@@ -45,7 +45,7 @@ beforeEach(() => {
   mockedGetLeagueJuiceForSeason.mockReset();
   mockedGetLeagueJuiceForSeason.mockResolvedValue({
     id: 1, leagueId: 1, leagueName: 'Demo League', season: 2023,
-    juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, dateCreated: '2023-01-01T00:00:00Z',
+    juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, startWeek: 1, dateCreated: '2023-01-01T00:00:00Z',
     teaseLocked: false, weeklyCostLocked: false,
   });
   mockLeagueJuiceEmpty(mockedGetLeagueJuice);
@@ -248,8 +248,8 @@ describe('LeaderboardPage — season selector', () => {
     // constant instead of that league's own history. One shared hook (useLeagueMinSeason) fixes
     // both sports identically.
     mockedGetLeagueJuice.mockResolvedValue([
-      { id: 1, leagueId: 1, leagueName: 'Demo League', season: 2022, juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, dateCreated: '2022-01-01T00:00:00Z', teaseLocked: true, weeklyCostLocked: true },
-      { id: 2, leagueId: 1, leagueName: 'Demo League', season: 2023, juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, dateCreated: '2023-01-01T00:00:00Z', teaseLocked: true, weeklyCostLocked: true },
+      { id: 1, leagueId: 1, leagueName: 'Demo League', season: 2022, juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, startWeek: 1, dateCreated: '2022-01-01T00:00:00Z', teaseLocked: true, weeklyCostLocked: true },
+      { id: 2, leagueId: 1, leagueName: 'Demo League', season: 2023, juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, startWeek: 1, dateCreated: '2023-01-01T00:00:00Z', teaseLocked: true, weeklyCostLocked: true },
     ]);
 
     renderPage();
@@ -406,6 +406,23 @@ describe('LeaderboardPage — week-cell colors', () => {
     const theme = createAppTheme(mode);
     const expected = alpha(theme.palette[paletteKey].main, 0.16);
     expect(cell).toHaveStyle({ backgroundColor: expected });
+  });
+
+  // frizat-o3x: a week before the league's configured StartWeek must not fall into the `default`
+  // (error/red, "Lost") styling branch — it's neither a win, a loss, nor pending.
+  it('does not style an Excluded week cell as a loss (error/red)', async () => {
+    mockedGetLeaderboard.mockResolvedValue([
+      createLeaderboardEntry({
+        userId: '123', userName: 'TestUser', rank: '1', total: 5,
+        weekResults: [createLeaderboardWeekResult({ week: 1, score: 42, weekResult: 'Excluded' })],
+      }),
+    ]);
+
+    renderPage('light');
+    const cell = (await screen.findByText('42')).closest('td');
+    const theme = createAppTheme('light');
+    const lossColor = alpha(theme.palette.error.main, 0.16);
+    expect(cell).not.toHaveStyle({ backgroundColor: lossColor });
   });
 });
 

--- a/Client.React/src/__tests__/useLeagueMinSeason.test.tsx
+++ b/Client.React/src/__tests__/useLeagueMinSeason.test.tsx
@@ -13,7 +13,7 @@ const mockedGetLeagueJuice = vi.mocked(getLeagueJuice);
 function makeJuiceMapping(season: number): LeagueJuiceMappingDto {
   return {
     id: season, leagueId: 1, leagueName: 'Demo League', season,
-    juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, dateCreated: `${season}-01-01T00:00:00Z`,
+    juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5, startWeek: 1, dateCreated: `${season}-01-01T00:00:00Z`,
     teaseLocked: true, weeklyCostLocked: true,
   };
 }

--- a/Client.React/src/pages/LeaderboardPage.tsx
+++ b/Client.React/src/pages/LeaderboardPage.tsx
@@ -172,6 +172,14 @@ export default function LeaderboardPage({ adapter }: LeaderboardPageProps) {
           color: 'info.main',
           fontWeight: 500,
         };
+      // frizat-o3x: a week before the league's configured StartWeek — not a win, loss, or
+      // pending state, so it must not read as a loss (the `default` case below, error/red).
+      case 'Excluded':
+        return {
+          backgroundColor: 'action.hover',
+          color: 'text.disabled',
+          fontWeight: 500,
+        };
       default:
         return {
           backgroundColor: alpha(theme.palette.error.main, 0.16),

--- a/Client.React/src/pages/LeaguePortalPage.tsx
+++ b/Client.React/src/pages/LeaguePortalPage.tsx
@@ -135,7 +135,7 @@ export default function LeaguePortalPage() {
   // Juice settings
   const [juiceMappings, setJuiceMappings] = useState<LeagueJuiceMappingDto[]>([]);
   const [selectedSeason, setSelectedSeason] = useState(CURRENT_SEASON);
-  const [juiceForm, setJuiceForm] = useState({ juice: 0, juiceDivisional: 0, juiceConference: 0, weeklyCost: 0 });
+  const [juiceForm, setJuiceForm] = useState({ juice: 0, juiceDivisional: 0, juiceConference: 0, weeklyCost: 0, startWeek: 1 });
   const [savingJuice, setSavingJuice] = useState(false);
   const [rollingForward, setRollingForward] = useState(false);
 
@@ -225,9 +225,10 @@ export default function LeaguePortalPage() {
         juiceDivisional: mapping.juiceDivisional,
         juiceConference: mapping.juiceConference,
         weeklyCost: mapping.weeklyCost,
+        startWeek: mapping.startWeek,
       });
     } else {
-      setJuiceForm({ juice: 0, juiceDivisional: 0, juiceConference: 0, weeklyCost: 0 });
+      setJuiceForm({ juice: 0, juiceDivisional: 0, juiceConference: 0, weeklyCost: 0, startWeek: 1 });
     }
   }, [selectedSeason]);
 
@@ -969,11 +970,13 @@ function InviteStatusTable({ title, rows, showActions = false }: { title: string
   );
 }
 
+const START_WEEK_OPTIONS = [1, 2, 3, 4, 5];
+
 interface JuiceTabProps {
   availableSeasons: number[];
   selectedSeason: number;
   onSeasonChange: (s: number) => void;
-  juiceForm: { juice: number; juiceDivisional: number; juiceConference: number; weeklyCost: number };
+  juiceForm: { juice: number; juiceDivisional: number; juiceConference: number; weeklyCost: number; startWeek: number };
   onJuiceFormChange: (field: string, value: number) => void;
   hasMappingForSeason: boolean;
   locked: boolean;
@@ -1000,6 +1003,8 @@ function JuiceTab({
   const weeklyCostField = useNumericField(juiceForm.weeklyCost, (n) => onJuiceFormChange('weeklyCost', n), { integerOnly: true });
   const teaseDisabled = locked || teaseLocked;
   const weeklyCostDisabled = locked || weeklyCostLocked;
+  // Start Week shares tease points' lock boundary — see LeagueController.UpdateLeagueJuice.
+  const startWeekDisabled = teaseDisabled;
 
   return (
     <Box>
@@ -1038,8 +1043,25 @@ function JuiceTab({
           Weekly Cost is locked once the season's final week has started.
         </Typography>
       )}
+      {juiceForm.startWeek > 1 && (
+        <Typography color="text.secondary" variant="body2" sx={{ mb: 2 }}>
+          Weeks 1–{juiceForm.startWeek - 1} won't require picks or appear on the leaderboard for this league — Week {juiceForm.startWeek} is treated as a normal first week.
+        </Typography>
+      )}
 
       <Stack spacing={2} sx={{ maxWidth: 400 }}>
+        <FormControl size="small" disabled={startWeekDisabled}>
+          <InputLabel>Start Week</InputLabel>
+          <Select
+            value={juiceForm.startWeek}
+            label="Start Week"
+            onChange={(e) => onJuiceFormChange('startWeek', Number(e.target.value))}
+          >
+            {START_WEEK_OPTIONS.map((w) => (
+              <MenuItem key={w} value={w}>{w === 1 ? '1 (default — full season)' : w}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
         <TextField
           label="Tease Pts (Regular Season)"
           type="number"

--- a/Client.React/src/types/admin.ts
+++ b/Client.React/src/types/admin.ts
@@ -19,8 +19,10 @@ export interface LeagueJuiceMappingDto {
   juiceDivisional: number;
   juiceConference: number;
   weeklyCost: number;
+  /** Which week/slate this league's season effectively starts at (default 1 = no exclusion). Shares teaseLocked below. */
+  startWeek: number;
   dateCreated: string;
-  /** True once the season's first week/slate has started — tease points are no longer editable. */
+  /** True once the season's first week/slate has started — tease points and Start Week are no longer editable. */
   teaseLocked: boolean;
   /** True once the season's final week/slate (Super Bowl / Championship) has started — Weekly Cost is no longer editable. */
   weeklyCostLocked: boolean;
@@ -95,6 +97,7 @@ export interface LeagueJuiceUpdateDto {
   juiceDivisional: number;
   juiceConference: number;
   weeklyCost: number;
+  startWeek: number;
 }
 
 export interface LeagueCreateDto {

--- a/Client.React/src/types/leaderboard.ts
+++ b/Client.React/src/types/leaderboard.ts
@@ -1,4 +1,4 @@
-export type WeekResult = 'Won' | 'Lost' | 'MissingPicks' | 'MissingGameResults';
+export type WeekResult = 'Won' | 'Lost' | 'MissingPicks' | 'MissingGameResults' | 'Excluded';
 
 export interface LeaderboardWeekResults {
   week: number;

--- a/Server.UnitTests/LeaderboardSettlementHelperTests.cs
+++ b/Server.UnitTests/LeaderboardSettlementHelperTests.cs
@@ -156,4 +156,48 @@ public class LeaderboardSettlementHelperTests {
         Assert.Equal(10, result.Single(u => u.User.Id == "c").WeekResults[2].Score);
         Assert.Equal(-20, result.Single(u => u.User.Id == "b").WeekResults[2].Score);
     }
+
+    // frizat-o3x: a league that excludes its early week(s) via StartWeek has every member's
+    // WeekResult for that index set to Excluded (LeaderboardService/CfbLeaderboardService's own
+    // job, not this helper's) AND passes the same startWeek explicitly — SettleWeeks trusts the
+    // parameter, not a scan of the cells, as the source of truth for which weeks to skip. Before
+    // this fix, an all-Excluded week looked exactly like an all-MissingPicks week — zero winners,
+    // zero losers, not "pending" — and fell into the SAME push branch as a genuine all-lost week,
+    // doubling the pot for the league's real first week. That is exactly the bug this bead exists
+    // to prevent ("week 2 would be a normal week").
+    [Fact]
+    public void SettleWeeks_ExcludedWeek_IsSkippedEntirely_NextRealWeekSettlesAtBaseCost() {
+        var leaderboard = new List<LeaderboardModel> {
+            // Week 1 (index 0) excluded for the whole league — nobody was ever asked to pick.
+            MakeUser("w1", WeekResult.Excluded, WeekResult.Won),
+            MakeUser("l1", WeekResult.Excluded, WeekResult.Lost),
+        };
+
+        var result = LeaderboardSettlementHelper.SettleWeeks(leaderboard, baseWeeklyCost: 10, weekCount: 2, startWeek: 2);
+
+        // Excluded week: no score change, not treated as a push.
+        Assert.Equal(0, result.Single(u => u.User.Id == "w1").WeekResults[0].Score);
+        Assert.Equal(0, result.Single(u => u.User.Id == "l1").WeekResults[0].Score);
+        // Week 2 (the league's real first week): settles at the untouched base cost, NOT doubled.
+        Assert.Equal(10, result.Single(u => u.User.Id == "w1").WeekResults[1].Score);
+        Assert.Equal(-10, result.Single(u => u.User.Id == "l1").WeekResults[1].Score);
+    }
+
+    [Fact]
+    public void SettleWeeks_ExcludedWeek_DoesNotSuppressARealPushInTheFollowingWeek() {
+        var leaderboard = new List<LeaderboardModel> {
+            // Week 1 excluded; week 2 is a genuine all-won push; week 3 is decided mixed.
+            MakeUser("a", WeekResult.Excluded, WeekResult.Won, WeekResult.Won),
+            MakeUser("b", WeekResult.Excluded, WeekResult.Won, WeekResult.Lost),
+        };
+
+        var result = LeaderboardSettlementHelper.SettleWeeks(leaderboard, baseWeeklyCost: 10, weekCount: 3, startWeek: 2);
+
+        // Week 2: still a real push — everyone scores 0, pot doubles for week 3.
+        Assert.Equal(0, result.Single(u => u.User.Id == "a").WeekResults[1].Score);
+        Assert.Equal(0, result.Single(u => u.User.Id == "b").WeekResults[1].Score);
+        // Week 3: settles at the doubled $20, proving the excluded week didn't reset/suppress it.
+        Assert.Equal(20, result.Single(u => u.User.Id == "a").WeekResults[2].Score);
+        Assert.Equal(-20, result.Single(u => u.User.Id == "b").WeekResults[2].Score);
+    }
 }

--- a/Server.UnitTests/LeaderboardTests.cs
+++ b/Server.UnitTests/LeaderboardTests.cs
@@ -122,6 +122,32 @@ public class LeaderboardServiceTests {
 
     }
 
+    // frizat-o3x: a league with StartWeek > 1 must mark every week before it Excluded — never
+    // MissingPicks/MissingGameResults, which LeaderboardSettlementHelper would otherwise (before
+    // this feature) risk treating as a false all-lost push and doubling the pot for the league's
+    // real first week.
+    [Fact]
+    public async Task CalculateRegularSeasonPicks_MarksWeeksBeforeStartWeekAsExcluded_NotMissingPicks() {
+        var dbFactory = new DbContextFactoryStub();
+        await dbFactory.PopulateUserTestData();
+        await dbFactory.PopulateScoresTestDataAsync();
+        var dbContext = await dbFactory.CreateDbContextAsync();
+        var juiceMapping = dbContext.LeagueJuiceMapping.Single();
+        juiceMapping.StartWeek = 2;
+        await dbContext.SaveChangesAsync();
+
+        var repository = new LeagueRepository(dbFactory);
+        var spreadCalculatorBuilder =
+            new SpreadCalculatorBuilder(repository, new MemoryCache(new MemoryCacheOptions()));
+        var scopeFactory = BuildScopeFactory(spreadCalculatorBuilder);
+        var service = new LeaderboardService(new LoggerFactory().CreateLogger<LeaderboardService>(), scopeFactory, repository, TimeProvider.System);
+
+        var result = await service.BuildLeaderboard(1, 2024);
+
+        Assert.Equal(WeekResult.Excluded, result.First().WeekResults[0].WeekResult); // week 1
+        Assert.NotEqual(WeekResult.Excluded, result.First().WeekResults[1].WeekResult); // week 2 — real
+    }
+
     [Fact]
     public async Task CalculateUserTotals_ReturnsCorrectTotals_WithMultipleWinnersAndLosers() {
         // Arrange
@@ -509,6 +535,38 @@ public class LeaderboardServiceTests {
 
         Assert.Single(result);
         Assert.Equal(WeekResult.Won, result[0].WeekResults[0].WeekResult);
+    }
+
+    // frizat-o3x: mirrors CalculateRegularSeasonPicks_MarksWeeksBeforeStartWeekAsExcluded on the
+    // CFB side — a league with StartWeek=2 must mark slate 1 Excluded, never MissingPicks.
+    [Fact]
+    public async Task CfbBuildLeaderboard_MarksSlatesBeforeStartWeekAsExcluded_NotMissingPicks() {
+        var userId = Guid.NewGuid().ToString();
+        var (leagueRepo, cfbRepo, picksRepo, currentSlateService) = BuildCfbMocks(userId);
+
+        leagueRepo.GetLeagueJuiceMappingAsync(1, 2025).Returns(
+            new LeagueJuiceMapping { Id = 1, LeagueId = 1, Season = 2025, Juice = 5, JuiceDivisional = 10, JuiceConference = 6, WeeklyCost = 5, StartWeek = 2 });
+
+        var slate1 = new CfbSlates { Id = 1, Season = 2025, SlateNumber = 1, SlateType = "RegularSeason", Label = "Week 1", StartDate = DateOnly.FromDateTime(DateTime.Today), EndDate = DateOnly.FromDateTime(DateTime.Today.AddDays(6)) };
+        var slate2 = new CfbSlates { Id = 2, Season = 2025, SlateNumber = 2, SlateType = "RegularSeason", Label = "Week 2", StartDate = DateOnly.FromDateTime(DateTime.Today), EndDate = DateOnly.FromDateTime(DateTime.Today.AddDays(6)) };
+        cfbRepo.GetSlatesForSeasonAsync(2025).Returns([slate1, slate2]);
+        // Slate 2 needs its own spreads/scores/picks so BuildLeaderboard doesn't just see an empty
+        // slate — reuse the same fixture shape slate 1 already has in BuildCfbMocks.
+        cfbRepo.GetSpreadsForSlateAsync(2).Returns((IEnumerable<CfbSpreads>)[
+            new CfbSpreads { Id = 2, CfbSlateId = 2, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamSpread = -7, AwayTeamSpread = 7, OverUnder = 50, IsLeagueEligible = true }
+        ]);
+        cfbRepo.GetScoresForSlateAsync(2).Returns((IEnumerable<CfbScores>)[
+            new CfbScores { Id = 2, CfbSlateId = 2, HomeTeam = "IU", AwayTeam = "OSU", HomeTeamScore = 28, AwayTeamScore = 14, GameStatus = TypeName.StatusFinal }
+        ]);
+        picksRepo.GetUserPicksAsync(1, 2, userId).Returns((IEnumerable<CfbPicks>)[
+            new CfbPicks { UserId = userId, LeagueId = 1, CfbSlateId = 2, Team = "IU", PickType = PickType.Spread, Season = 2025 }
+        ]);
+
+        var service = new CfbLeaderboardService(new LoggerFactory().CreateLogger<CfbLeaderboardService>(), leagueRepo, cfbRepo, picksRepo, currentSlateService, TimeProvider.System);
+        var result = await service.BuildLeaderboard(1, 2025);
+
+        Assert.Equal(WeekResult.Excluded, result[0].WeekResults[0].WeekResult); // slate 1
+        Assert.NotEqual(WeekResult.Excluded, result[0].WeekResults[1].WeekResult); // slate 2 — real
     }
 
     [Fact]

--- a/Server.UnitTests/LeagueJuiceRollForwardTests.cs
+++ b/Server.UnitTests/LeagueJuiceRollForwardTests.cs
@@ -9,8 +9,8 @@ namespace FourPlayWebApp.Server.UnitTests;
 // mocks needed.
 public class LeagueJuiceRollForwardTests
 {
-    private static LeagueJuiceMapping MakeMapping(int leagueId, int season, int juice = 13, int juiceDivisional = 10, int juiceConference = 6, int weeklyCost = 5) =>
-        new() { LeagueId = leagueId, Season = season, Juice = juice, JuiceDivisional = juiceDivisional, JuiceConference = juiceConference, WeeklyCost = weeklyCost };
+    private static LeagueJuiceMapping MakeMapping(int leagueId, int season, int juice = 13, int juiceDivisional = 10, int juiceConference = 6, int weeklyCost = 5, int startWeek = 1) =>
+        new() { LeagueId = leagueId, Season = season, Juice = juice, JuiceDivisional = juiceDivisional, JuiceConference = juiceConference, WeeklyCost = weeklyCost, StartWeek = startWeek };
 
     // ── FindPriorSeasonMapping ─────────────────────────────────────────────────
 
@@ -45,9 +45,9 @@ public class LeagueJuiceRollForwardTests
     // ── BuildMapping ───────────────────────────────────────────────────────────
 
     [Fact]
-    public void BuildMapping_CopiesAllFourValuesFromPriorSeason_WhenGiven()
+    public void BuildMapping_CopiesAllFiveValuesFromPriorSeason_WhenGiven()
     {
-        var prior = MakeMapping(1, 2025, juice: 20, juiceDivisional: 15, juiceConference: 8, weeklyCost: 12);
+        var prior = MakeMapping(1, 2025, juice: 20, juiceDivisional: 15, juiceConference: 8, weeklyCost: 12, startWeek: 3);
 
         var result = LeagueJuiceRollForward.BuildMapping(1, 2026, prior);
 
@@ -57,12 +57,13 @@ public class LeagueJuiceRollForwardTests
         Assert.Equal(15, result.JuiceDivisional);
         Assert.Equal(8, result.JuiceConference);
         Assert.Equal(12, result.WeeklyCost);
+        Assert.Equal(3, result.StartWeek);
     }
 
     [Fact]
     public void BuildMapping_FallsBackToEntityDefaults_WhenNoPriorSeasonGiven()
     {
-        // Deliberately NOT re-hardcoding 13/10/6/5 here — asserting against the entity's own
+        // Deliberately NOT re-hardcoding 13/10/6/5/1 here — asserting against the entity's own
         // defaults (new LeagueJuiceMapping()) so this test can't silently drift from them.
         var expectedDefaults = new LeagueJuiceMapping();
 
@@ -74,5 +75,6 @@ public class LeagueJuiceRollForwardTests
         Assert.Equal(expectedDefaults.JuiceDivisional, result.JuiceDivisional);
         Assert.Equal(expectedDefaults.JuiceConference, result.JuiceConference);
         Assert.Equal(expectedDefaults.WeeklyCost, result.WeeklyCost);
+        Assert.Equal(expectedDefaults.StartWeek, result.StartWeek);
     }
 }

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -257,6 +257,60 @@ public class LeagueOwnershipTests
         await repo.DidNotReceive().UpdateLeagueJuiceMappingAsync(Arg.Any<LeagueJuiceMapping>());
     }
 
+    // frizat-o3x: StartWeek shares tease points' lock boundary — changing it after the season's
+    // own week 1 has already started is exactly the same "retroactively changes an
+    // already-decided week's terms" hazard that locked Juice/JuiceDivisional/JuiceConference.
+    [Fact]
+    public async Task UpdateJuice_RejectsStartWeekChange_OnceSeasonHasStarted()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L", LeagueType = LeagueType.Nfl });
+        repo.GetLeagueJuiceMappingAsync(1, 2025).Returns(new LeagueJuiceMapping { Id = 5, LeagueId = 1, Season = 2025, Juice = 13, JuiceDivisional = 10, JuiceConference = 6, WeeklyCost = 5, StartWeek = 1 });
+        repo.GetNflSeasonWeekConfigsAsync(2025).Returns(new List<NflSeasonWeekConfig> {
+            new() { Season = 2025, WeekId = 1, WeekLabel = "Week 1", WeekType = "Regular Season", ScoringFormat = "Standard",
+                FirstGameOfWeekStartDatetime = new DateTime(2025, 9, 4, 20, 20, 0, DateTimeKind.Utc) },
+        });
+
+        var result = await ctrl.UpdateLeagueJuice(1, 2025, new LeagueJuiceUpdateDto(13, 10, 6, 5, StartWeek: 2), BuildScheduleSource(repo));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        await repo.DidNotReceive().UpdateLeagueJuiceMappingAsync(Arg.Any<LeagueJuiceMapping>());
+    }
+
+    [Fact]
+    public async Task UpdateJuice_AllowsStartWeekChange_BeforeSeasonHasStarted()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L", LeagueType = LeagueType.Nfl });
+        repo.GetLeagueJuiceMappingAsync(1, 2025).Returns(new LeagueJuiceMapping { Id = 5, LeagueId = 1, Season = 2025, Juice = 13, JuiceDivisional = 10, JuiceConference = 6, WeeklyCost = 5, StartWeek = 1 });
+        // Far-future date, so the season hasn't started yet — no config row needed for this repo
+        // call since GetNflSeasonWeekConfigsAsync isn't stubbed with any matching rows, i.e. the
+        // season genuinely has no known start date yet.
+        repo.GetNflSeasonWeekConfigsAsync(2025).Returns(new List<NflSeasonWeekConfig>());
+
+        var result = await ctrl.UpdateLeagueJuice(1, 2025, new LeagueJuiceUpdateDto(13, 10, 6, 5, StartWeek: 3), BuildScheduleSource(repo));
+
+        Assert.IsType<NoContentResult>(result);
+        await repo.Received(1).UpdateLeagueJuiceMappingAsync(Arg.Is<LeagueJuiceMapping>(m => m.StartWeek == 3));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(6)]
+    [InlineData(-1)]
+    public async Task UpdateJuice_RejectsStartWeek_OutsideOneToFiveRange(int invalidStartWeek)
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L", LeagueType = LeagueType.Nfl });
+        repo.GetLeagueJuiceMappingAsync(1, 2025).Returns(new LeagueJuiceMapping { Id = 5, LeagueId = 1, Season = 2025, Juice = 13, JuiceDivisional = 10, JuiceConference = 6, WeeklyCost = 5, StartWeek = 1 });
+        repo.GetNflSeasonWeekConfigsAsync(2025).Returns(new List<NflSeasonWeekConfig>());
+
+        var result = await ctrl.UpdateLeagueJuice(1, 2025, new LeagueJuiceUpdateDto(13, 10, 6, 5, StartWeek: invalidStartWeek), BuildScheduleSource(repo));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        await repo.DidNotReceive().UpdateLeagueJuiceMappingAsync(Arg.Any<LeagueJuiceMapping>());
+    }
+
     [Fact]
     public async Task UpdateJuice_AllowsWeeklyCostChange_EvenAfterSeasonHasStarted()
     {

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -152,6 +152,7 @@ public class LeagueController(
                 JuiceDivisional = m.JuiceDivisional,
                 JuiceConference = m.JuiceConference,
                 WeeklyCost = m.WeeklyCost,
+                StartWeek = m.StartWeek,
                 DateCreated = m.DateCreated,
                 TeaseLocked = teaseLocked,
                 WeeklyCostLocked = weeklyCostLocked,
@@ -180,6 +181,7 @@ public class LeagueController(
             JuiceDivisional = mapping.JuiceDivisional,
             JuiceConference = mapping.JuiceConference,
             WeeklyCost = mapping.WeeklyCost,
+            StartWeek = mapping.StartWeek,
             DateCreated = mapping.DateCreated,
             TeaseLocked = teaseLocked,
             WeeklyCostLocked = weeklyCostLocked,
@@ -835,10 +837,15 @@ public class LeagueController(
         if (existing is null) return NotFound($"No juice mapping for league {leagueId} season {season}.");
         var (teaseLocked, weeklyCostLocked) = lockStateTask.Result;
 
+        if (dto.StartWeek is < 1 or > 5)
+            return BadRequest("Start Week must be between 1 and 5.");
+
+        // frizat-o3x: StartWeek shares tease points' lock boundary — same "retroactively changes
+        // an already-decided week's terms" hazard as Juice/JuiceDivisional/JuiceConference.
         var teaseChanged = dto.Juice != existing.Juice || dto.JuiceDivisional != existing.JuiceDivisional
-            || dto.JuiceConference != existing.JuiceConference;
+            || dto.JuiceConference != existing.JuiceConference || dto.StartWeek != existing.StartWeek;
         if (teaseLocked && teaseChanged)
-            return BadRequest("Tease points can't be changed once the season has started.");
+            return BadRequest("Tease points and Start Week can't be changed once the season has started.");
         if (weeklyCostLocked && dto.WeeklyCost != existing.WeeklyCost)
             return BadRequest("Weekly Cost can't be changed once the season's final week has started.");
 
@@ -846,6 +853,7 @@ public class LeagueController(
         existing.JuiceDivisional = dto.JuiceDivisional;
         existing.JuiceConference = dto.JuiceConference;
         existing.WeeklyCost = dto.WeeklyCost;
+        existing.StartWeek = dto.StartWeek;
         await repo.UpdateLeagueJuiceMappingAsync(existing);
         return NoContent();
     }

--- a/Server/Data/Configurations/LeagueJuiceMappingConfiguration.cs
+++ b/Server/Data/Configurations/LeagueJuiceMappingConfiguration.cs
@@ -18,6 +18,7 @@ public class LeagueJuiceMappingConfiguration : IEntityTypeConfiguration<LeagueJu
         entity.Property(e => e.Juice).HasDefaultValue(13);
         entity.Property(e => e.JuiceConference).HasDefaultValue(6);
         entity.Property(e => e.JuiceDivisional).HasDefaultValue(10);
+        entity.Property(e => e.StartWeek).HasDefaultValue(1);
 
         entity.HasOne(e => e.League)
             .WithMany(l => l.LeagueJuiceMappings)

--- a/Server/Migrations/20260910134159_AddStartWeekToLeagueJuiceMapping.Designer.cs
+++ b/Server/Migrations/20260910134159_AddStartWeekToLeagueJuiceMapping.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FourPlayWebApp.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FourPlayWebApp.Server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260910134159_AddStartWeekToLeagueJuiceMapping")]
+    partial class AddStartWeekToLeagueJuiceMapping
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/20260910134159_AddStartWeekToLeagueJuiceMapping.cs
+++ b/Server/Migrations/20260910134159_AddStartWeekToLeagueJuiceMapping.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FourPlayWebApp.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStartWeekToLeagueJuiceMapping : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "StartWeek",
+                table: "LeagueJuiceMapping",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StartWeek",
+                table: "LeagueJuiceMapping");
+        }
+    }
+}

--- a/Server/Models/Data/LeagueJuiceMapping.cs
+++ b/Server/Models/Data/LeagueJuiceMapping.cs
@@ -8,6 +8,11 @@ public class LeagueJuiceMapping {
     public int JuiceDivisional { get; set; } = 10;
     public int JuiceConference { get; set; } = 6;
     public int WeeklyCost { get; set; } = 5;
+    // Which week/slate this league's season effectively starts at — weeks before it require no
+    // picks, don't appear on the leaderboard, and aren't billed WeeklyCost. Default 1 = no
+    // exclusion (today's behavior for every existing league). Mainly for CFB leagues that want to
+    // skip the often-lopsided week 1 buy games (frizat-o3x).
+    public int StartWeek { get; set; } = 1;
     public DateTimeOffset DateCreated { get; set; }
     public DateTimeOffset? UpdatedAt { get; set; }
 }

--- a/Server/Services/CfbLeaderboardService.cs
+++ b/Server/Services/CfbLeaderboardService.cs
@@ -66,6 +66,16 @@ public class CfbLeaderboardService(
 
                 for (int i = 0; i < slates.Count; i++) {
                     var slate = slates[i];
+
+                    // frizat-o3x: a slate before the league's configured StartWeek needs no
+                    // spread/score/pick fetch at all — checked here, before any DB call, not
+                    // inside EvaluateSlate, so an excluded slate costs zero round trips per user
+                    // instead of three wasted ones.
+                    if (GameHelpers.IsWeekExcludedFromSeason(slate.SlateNumber, juiceMapping.StartWeek)) {
+                        userModel.WeekResults[i] = new LeaderboardWeekResults { Week = slate.SlateNumber, WeekResult = WeekResult.Excluded };
+                        continue;
+                    }
+
                     // GetSpreadsForSlateAsync now returns the full FBS slate, not just league-eligible
                     // games (frizat-9m0) — scoring/MissingPicks must only ever consider eligible ones.
                     var spreads = (await cfbRepository.GetSpreadsForSlateAsync(slate.Id)).WhereLeagueEligible().ToList();
@@ -156,5 +166,5 @@ public class CfbLeaderboardService(
 
     private static List<LeaderboardModel> CalculateTotals(List<LeaderboardModel> leaderboard,
         LeagueJuiceMapping juiceMapping, int slateCount) =>
-        LeaderboardSettlementHelper.SettleWeeks(leaderboard, juiceMapping.WeeklyCost, slateCount);
+        LeaderboardSettlementHelper.SettleWeeks(leaderboard, juiceMapping.WeeklyCost, slateCount, juiceMapping.StartWeek);
 }

--- a/Server/Services/LeaderboardService.cs
+++ b/Server/Services/LeaderboardService.cs
@@ -27,8 +27,9 @@ public class LeaderboardService(
             var leagueScores = await leagueRepository.GetAllNflScoresForSeasonAsync((int)seasonYear);
             var leagueSpreads = await leagueRepository.GetAllNflSpreadsForSeasonAsync((int)seasonYear);
             var leagueInfo = await leagueRepository.GetLeagueJuiceMappingAsync(leagueId);
+            var seasonJuice = leagueInfo.FirstOrDefault(x => x.Season == seasonYear);
 
-            if (leagueInfo.Count == 0 || leagueInfo.All(x => x.Season != seasonYear)) {
+            if (seasonJuice is null) {
                 logger.LogError("League info not found.");
                 return leaderboard;
             }
@@ -49,7 +50,7 @@ public class LeaderboardService(
                     User = user.User
                 };
                 for (int week = 1; week <= maxWeek; week++) {
-                    var weekResult = await CalculatePicks(leagueId, seasonYear, leagueScores, spreadsByWeek[week], user, week, now);
+                    var weekResult = await CalculatePicks(leagueId, seasonYear, leagueScores, spreadsByWeek[week], user, week, now, seasonJuice.StartWeek);
                     userPoints.WeekResults[week - 1] = weekResult;
                 }
                 leaderboard.Add(userPoints);
@@ -65,10 +66,19 @@ public class LeaderboardService(
 
 
     private async Task<LeaderboardWeekResults> CalculatePicks(int leagueId, long seasonYear,
-        List<NflScores> userScores, IEnumerable<NflSpreads> weekSpreads, LeagueUserMapping user, int week, DateTimeOffset now) {
+        List<NflScores> userScores, IEnumerable<NflSpreads> weekSpreads, LeagueUserMapping user, int week, DateTimeOffset now, int startWeek) {
         var weekResult = new LeaderboardWeekResults {
             Week = week
         };
+
+        // frizat-o3x: a week before the league's configured StartWeek needs no pick/spread
+        // evaluation at all — it's not a win, loss, or pending state, just excluded from the
+        // league's season entirely (see LeaderboardSettlementHelper for why this must never be
+        // confused with MissingPicks/MissingGameResults).
+        if (GameHelpers.IsWeekExcludedFromSeason(week, startWeek)) {
+            weekResult.WeekResult = WeekResult.Excluded;
+            return weekResult;
+        }
 
         await using var scope = scopeFactory.CreateAsyncScope();
         var spreadCalculatorBuilder = scope.ServiceProvider.GetRequiredService<ISpreadCalculatorBuilder>();
@@ -143,7 +153,7 @@ public class LeaderboardService(
             return leaderboard;
         }
 
-        return LeaderboardSettlementHelper.SettleWeeks(leaderboard, leagueJuice.WeeklyCost, maxWeek);
+        return LeaderboardSettlementHelper.SettleWeeks(leaderboard, leagueJuice.WeeklyCost, maxWeek, leagueJuice.StartWeek);
     }
 
 }

--- a/Server/Services/LeaderboardSettlementHelper.cs
+++ b/Server/Services/LeaderboardSettlementHelper.cs
@@ -1,4 +1,5 @@
 using FourPlayWebApp.Server.Models.Data;
+using FourPlayWebApp.Shared.Helpers;
 using FourPlayWebApp.Shared.Models;
 using FourPlayWebApp.Shared.Models.Enum;
 
@@ -20,10 +21,20 @@ public static class LeaderboardSettlementHelper {
     // excluded from both buckets and their Score stays untouched until their own pick resolves.
     // The push-doubling pot roll only ever fires once a week is genuinely fully decided — a
     // provisional split must never trigger, or skip, it.
-    public static List<LeaderboardModel> SettleWeeks(List<LeaderboardModel> leaderboard, long baseWeeklyCost, int weekCount) {
+    public static List<LeaderboardModel> SettleWeeks(List<LeaderboardModel> leaderboard, long baseWeeklyCost, int weekCount, int startWeek = 1) {
         var currentWeeklyCost = baseWeeklyCost;
 
         for (int i = 0; i < weekCount; i++) {
+            // frizat-o3x: a week before the league's configured StartWeek — no bucketing, no Score
+            // change, no pot growth. Takes startWeek explicitly (rather than inferring exclusion
+            // by scanning for WeekResult.Excluded cells) so this boundary can't silently drift if
+            // a future producer ever populates WeekResults a different way — a week/index compare
+            // is exact where a "did every producer mark this cell the same way" scan is inferred.
+            // Without this, an all-excluded week is indistinguishable from an all-MissingPicks
+            // week (zero winners, zero losers, not pending) and would otherwise fall into the push
+            // branch below, doubling the pot for the league's real first week.
+            if (GameHelpers.IsWeekExcludedFromSeason(i + 1, startWeek)) continue;
+
             var weekPending = IsWeekPending(leaderboard, i);
             var winners = new List<LeaderboardWeekResults>();
             var losers = new List<LeaderboardWeekResults>();

--- a/Server/Services/LeagueJuiceRollForward.cs
+++ b/Server/Services/LeagueJuiceRollForward.cs
@@ -10,7 +10,7 @@ public static class LeagueJuiceRollForward {
     public static LeagueJuiceMapping? FindPriorSeasonMapping(int toSeason, IEnumerable<LeagueJuiceMapping> allMappingsForLeague) =>
         allMappingsForLeague.Where(m => m.Season < toSeason).MaxBy(m => m.Season);
 
-    // copyFrom's four values are copied verbatim when given; otherwise the entity's own property
+    // copyFrom's five values are copied verbatim when given; otherwise the entity's own property
     // defaults (Juice=13 etc.) supply the fallback — never re-hardcode those numbers here.
     public static LeagueJuiceMapping BuildMapping(int leagueId, int toSeason, LeagueJuiceMapping? copyFrom) {
         var mapping = new LeagueJuiceMapping { LeagueId = leagueId, Season = toSeason, DateCreated = DateTimeOffset.UtcNow };
@@ -19,6 +19,9 @@ public static class LeagueJuiceRollForward {
             mapping.JuiceDivisional = copyFrom.JuiceDivisional;
             mapping.JuiceConference = copyFrom.JuiceConference;
             mapping.WeeklyCost = copyFrom.WeeklyCost;
+            // frizat-o3x: without this, rolling a league's settings forward to a new season would
+            // silently reset a deliberately-configured StartWeek back to the default (1).
+            mapping.StartWeek = copyFrom.StartWeek;
         }
         return mapping;
     }

--- a/Shared/Helpers/GameHelpers.cs
+++ b/Shared/Helpers/GameHelpers.cs
@@ -197,6 +197,12 @@ public static class GameHelpers {
         return times.Count > 0 && times.All(t => t <= now);
     }
 
+    // Shared by LeaderboardService.CalculatePicks (NFL week) and CfbLeaderboardService.EvaluateSlate
+    // (CFB slate number) — a league's configured StartWeek (LeagueJuiceMapping.StartWeek, frizat-o3x)
+    // excludes every week/slate before it from that league's season entirely. One predicate so both
+    // sides can never drift on the boundary (e.g. off-by-one between "< " and "<=").
+    public static bool IsWeekExcludedFromSeason(int week, int startWeek) => week < startWeek;
+
     // Shared by LeagueController.AddPicks (NflSpreads) and CfbPicksController.AddPicks
     // (CfbSpreads) — was two byte-identical private methods, one per controller, differing only
     // in the spread row's concrete type. Pure control-table timestamp check, no ESPN dependency.

--- a/Shared/Models/Data/Dtos/LeagueCreateDto.cs
+++ b/Shared/Models/Data/Dtos/LeagueCreateDto.cs
@@ -25,4 +25,7 @@ public record AdminLeagueCostDto(
     decimal Cost
 );
 
-public record LeagueJuiceUpdateDto(int Juice, int JuiceDivisional, int JuiceConference, int WeeklyCost);
+// StartWeek defaults to 1 (no exclusion) — existing callers that don't yet know about it keep
+// today's behavior unchanged; a real PUT from the frontend always sends the league's current
+// value, same full-replace contract the other three fields already use.
+public record LeagueJuiceUpdateDto(int Juice, int JuiceDivisional, int JuiceConference, int WeeklyCost, int StartWeek = 1);

--- a/Shared/Models/Data/Dtos/LeagueJuiceMappingDto.cs
+++ b/Shared/Models/Data/Dtos/LeagueJuiceMappingDto.cs
@@ -10,6 +10,10 @@ public class LeagueJuiceMappingDto
     public int JuiceDivisional { get; set; }
     public int JuiceConference { get; set; }
     public int WeeklyCost { get; set; }
+    // Which week/slate this league's season effectively starts at (default 1 = no exclusion,
+    // today's behavior for every existing league) — frizat-o3x. Shares TeaseLocked below: it
+    // locks at the same season-start boundary as Juice/JuiceDivisional/JuiceConference.
+    public int StartWeek { get; set; } = 1;
     public DateTimeOffset DateCreated { get; set; } = DateTimeOffset.UtcNow;
     // Tease points (Juice/JuiceDivisional/JuiceConference) lock once the season's first week/slate
     // has started; WeeklyCost locks separately, once the season's LAST week/slate (Super Bowl /

--- a/Shared/Models/Enum/WeekResult.cs
+++ b/Shared/Models/Enum/WeekResult.cs
@@ -5,5 +5,9 @@ public enum WeekResult
     Won,
     Lost,
     MissingPicks,
-    MissingGameResults
+    MissingGameResults,
+    // This week is before the league's configured StartWeek (frizat-o3x) — no picks were ever
+    // required, so it's neither a win, a loss, nor pending; excluded entirely from settlement
+    // (LeaderboardSettlementHelper must never bucket this into winners/losers or grow the pot).
+    Excluded
 }


### PR DESCRIPTION
## Summary
Promotes dev to main. Includes PR #355 (per-league configurable season start week, frizat-o3x — see that PR for full detail) plus everything already on dev.

## Test plan
- [x] CI green on PR #355
- [x] dev deploy verified via /api/version on both ivleague.xyz and cfb subdomains
- [x] EF migration (AddStartWeekToLeagueJuiceMapping) applied successfully on dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs