### PR TITLE
Excluded-week empty state + backend guard for league Start Week (frizat-u66)

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -7,6 +7,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 ## 2026-09-10
 
 - Added: leagues can now set a Start Week (1-5, default 1) on the Juice tab so a league's season can skip early weeks — mainly for CFB leagues that want to skip week 1's often lopsided matchups. Weeks before it require no picks, don't appear on the leaderboard, and aren't billed the weekly cost; the following week settles normally, not as a doubled pot
+- Added: Picks and Scores now show a clear "Week Not Scored" notice instead of an ordinary pick grid for any week before a league's configured Start Week, so members don't submit picks that silently don't count; the server also rejects a direct pick submission for those weeks
 
 ## 2026-09-09
 

--- a/Client.React/src/__tests__/gameHelpers.startWeek.test.ts
+++ b/Client.React/src/__tests__/gameHelpers.startWeek.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { isWeekExcludedFromSeason } from '../utils/gameHelpers';
+
+// frizat-u66: mirrors Shared/Helpers/GameHelpers.cs's IsWeekExcludedFromSeason exactly — the
+// frontend and backend must agree on which weeks a league's configured StartWeek (frizat-o3x)
+// excludes from scoring.
+describe('isWeekExcludedFromSeason', () => {
+  it('a week before StartWeek is excluded', () => {
+    expect(isWeekExcludedFromSeason(1, 3)).toBe(true);
+    expect(isWeekExcludedFromSeason(2, 3)).toBe(true);
+  });
+
+  it('the StartWeek itself is not excluded', () => {
+    expect(isWeekExcludedFromSeason(3, 3)).toBe(false);
+  });
+
+  it('a week after StartWeek is not excluded', () => {
+    expect(isWeekExcludedFromSeason(4, 3)).toBe(false);
+  });
+
+  it('default StartWeek of 1 excludes nothing', () => {
+    expect(isWeekExcludedFromSeason(1, 1)).toBe(false);
+  });
+});

--- a/Client.React/src/__tests__/picks.test.tsx
+++ b/Client.React/src/__tests__/picks.test.tsx
@@ -168,6 +168,39 @@ describe('PicksPage', () => {
     expect(screen.getByTestId('week-year-selector-container')).toBeInTheDocument();
   });
 
+  // frizat-u66: a league with StartWeek > 1 excludes weeks before it from scoring
+  // (LeaderboardService.CalculatePicks / CfbLeaderboardService.BuildLeaderboard short-circuit
+  // to WeekResult.Excluded) — the Picks page must say so clearly instead of showing an
+  // ordinary, fully-pickable grid whose submissions are silently discarded.
+  it('shows the excluded-week notice, not pick buttons, for a week before the league StartWeek', async () => {
+    await setupDefaults({ week: 2 });
+    mockedGetLeagueJuice.mockResolvedValue([{
+      id: 1, leagueId: 1, leagueName: 'Test League', season: 2024,
+      juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5,
+      startWeek: 3, dateCreated: '', teaseLocked: false, weeklyCostLocked: false,
+    }]);
+    renderWithClient(<PicksPage adapter={createNflAdapter()} />);
+    await screen.findByText(/Week Not Scored/i);
+    expect(screen.getByText(/starts scoring at Week 3/i)).toBeInTheDocument();
+    expect(screen.queryAllByRole('button', { name: /^Pick /i })).toHaveLength(0);
+    // Decision (frizat-u66): excluded weeks stay navigable rather than hidden/disabled in the
+    // selector — spreads are still real for these weeks, the empty-state message is what
+    // communicates exclusion, not a restricted selector range.
+    expect(screen.getByTestId('week-year-selector-container')).toBeInTheDocument();
+  });
+
+  it('shows the ordinary pick grid, not the excluded-week notice, for a week at or after the league StartWeek', async () => {
+    await setupDefaults({ week: 2 });
+    mockedGetLeagueJuice.mockResolvedValue([{
+      id: 1, leagueId: 1, leagueName: 'Test League', season: 2024,
+      juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5,
+      startWeek: 2, dateCreated: '', teaseLocked: false, weeklyCostLocked: false,
+    }]);
+    await renderPage();
+    expect(screen.queryByText(/Week Not Scored/i)).toBeNull();
+    expect(screen.getAllByRole('button', { name: /^Pick /i }).length).toBeGreaterThan(0);
+  });
+
   it('shows picks remaining for week 2 with no existing picks', async () => {
     await setupDefaults({ week: 2 });
     await renderPage();

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -150,6 +150,34 @@ describe('ScoresPage', () => {
     expect(screen.getByTestId('week-year-selector-container')).toBeInTheDocument();
   });
 
+  // frizat-u66: a league with StartWeek > 1 excludes weeks before it from scoring — the Scores
+  // page must say so clearly instead of showing an ordinary score grid that implies the week
+  // counts toward standings when it doesn't.
+  it('shows the excluded-week notice, not the score grid, for a week before the league StartWeek', async () => {
+    await setupDefaults({ week: 2 });
+    mockedGetLeagueJuice.mockResolvedValue([{
+      id: 1, leagueId: 1, leagueName: 'Test League', season: 2024,
+      juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5,
+      startWeek: 3, dateCreated: '', teaseLocked: false, weeklyCostLocked: false,
+    }]);
+    renderWithClient(<ScoresPage adapter={createNflAdapter()} />);
+    await screen.findByText(/Week Not Scored/i);
+    expect(screen.getByText(/starts scoring at Week 3/i)).toBeInTheDocument();
+    expect(screen.queryByText('24')).toBeNull();
+  });
+
+  it('shows the ordinary score grid, not the excluded-week notice, for a week at or after the league StartWeek', async () => {
+    await setupDefaults({ week: 2, gameStarted: true });
+    mockedGetLeagueJuice.mockResolvedValue([{
+      id: 1, leagueId: 1, leagueName: 'Test League', season: 2024,
+      juice: 13, juiceDivisional: 10, juiceConference: 6, weeklyCost: 5,
+      startWeek: 2, dateCreated: '', teaseLocked: false, weeklyCostLocked: false,
+    }]);
+    await renderPage();
+    expect(screen.queryByText(/Week Not Scored/i)).toBeNull();
+    expect(screen.getByText('24')).toBeInTheDocument();
+  });
+
   it('shows week title when scores available', async () => {
     await setupDefaults({ week: 5 });
     await renderPage();

--- a/Client.React/src/components/ExcludedWeekBanner.tsx
+++ b/Client.React/src/components/ExcludedWeekBanner.tsx
@@ -1,0 +1,24 @@
+import { Box, Typography } from '@mui/material';
+
+interface ExcludedWeekBannerProps {
+  startWeek: number;
+}
+
+/**
+ * Shown on Picks/Scores for a week before the league's configured StartWeek (frizat-o3x) —
+ * LeaderboardService.CalculatePicks / CfbLeaderboardService.BuildLeaderboard both short-circuit
+ * these weeks to WeekResult.Excluded before ever reading picks, so this is purely informational:
+ * nothing submitted here affects standings (frizat-u66).
+ */
+export default function ExcludedWeekBanner({ startWeek }: ExcludedWeekBannerProps) {
+  return (
+    <Box sx={{ textAlign: 'center', py: 4 }}>
+      <Typography variant="h5" sx={{ fontWeight: 600 }}>
+        Week Not Scored
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        This league starts scoring at Week {startWeek} — picks aren&apos;t collected for this week.
+      </Typography>
+    </Box>
+  );
+}

--- a/Client.React/src/pages/PicksPage.tsx
+++ b/Client.React/src/pages/PicksPage.tsx
@@ -12,6 +12,7 @@ import WeekYearSelector from '../components/WeekYearSelector';
 import NoLeague from '../components/NoLeague';
 import QueryErrorAlert from '../components/QueryErrorAlert';
 import SpreadRelease from '../components/SpreadRelease';
+import ExcludedWeekBanner from '../components/ExcludedWeekBanner';
 import GameCard, { type PickState } from '../components/sports/GameCard';
 import GameCardGridSkeleton from '../components/GameCardSkeleton';
 import { useSession } from '../services/session';
@@ -19,8 +20,9 @@ import { useAuth } from '../services/auth';
 import type { SportAdapter, GameView, PickType, WeekState } from '../services/sportAdapter';
 import { sortGamesByTimeThenRank } from '../services/sportAdapter';
 import { useToast } from '../services/toast';
-import { isGameDecided } from '../utils/gameHelpers';
+import { isGameDecided, isWeekExcludedFromSeason } from '../utils/gameHelpers';
 import { useLeagueMinSeason } from '../utils/useLeagueMinSeason';
+import { useLeagueStartWeek } from '../utils/useLeagueStartWeek';
 import { useCurrentWeekNav } from '../utils/useCurrentWeekNav';
 
 // Pick key: "gameId|team|pickType" — stable across NFL and CFB
@@ -74,6 +76,7 @@ export default function PicksPage({ adapter }: PicksPageProps) {
   const maxWeek = currentMaxWeek ?? adapter.weekSelectorConfig.maxRegularSeasonWeek;
   const maxSeason = currentMaxSeason ?? new Date().getFullYear();
   const minSeason = useLeagueMinSeason(currentLeague, adapter.weekSelectorConfig.minSeason);
+  const startWeek = useLeagueStartWeek(currentLeague, season);
 
   const existingPicks = useMemo(
     () => new Set((data?.userPicks ?? []).map(p => pickKey(p.gameId, p.team, p.pickType))),
@@ -178,6 +181,7 @@ export default function PicksPage({ adapter }: PicksPageProps) {
   // also had to be true for the *current* week specifically, or a stale isCurrentWeek flag
   // left a spread-less future week's pick buttons fully clickable (frizat-8y4).
   const oddsNotReady = !hasOdds;
+  const isWeekExcluded = isWeekExcludedFromSeason(week, startWeek);
 
   const hasUnlockedGames = games.some(g => !gameIsLocked(g));
   const isPostSeasonSlate = isPostSeason;
@@ -211,6 +215,8 @@ export default function PicksPage({ adapter }: PicksPageProps) {
 
       {oddsNotReady ? (
         <SpreadRelease sport={adapter.sport} />
+      ) : isWeekExcluded ? (
+        <ExcludedWeekBanner startWeek={startWeek} />
       ) : (
         <Grid container spacing={2}>
           {hasUnlockedGames && (remainingPicks > 0 || userPicks.size > 0) && (

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -12,6 +12,7 @@ import WeekYearSelector from '../components/WeekYearSelector';
 import NoLeague from '../components/NoLeague';
 import QueryErrorAlert from '../components/QueryErrorAlert';
 import SpreadRelease from '../components/SpreadRelease';
+import ExcludedWeekBanner from '../components/ExcludedWeekBanner';
 import GameCardGridSkeleton from '../components/GameCardSkeleton';
 import TeamArt from '../components/sports/TeamArt';
 import RankBadge from '../components/sports/RankBadge';
@@ -20,10 +21,11 @@ import PickDialog from '../components/PickDialog';
 import FieldPosition from '../components/FieldPosition';
 import { useSession } from '../services/session';
 import { useAuth } from '../services/auth';
-import { isGameDecided, isGameFinal, isGameLive, isConsistentRedZone, spreadLabel } from '../utils/gameHelpers';
+import { isGameDecided, isGameFinal, isGameLive, isConsistentRedZone, spreadLabel, isWeekExcludedFromSeason } from '../utils/gameHelpers';
 import type { SportAdapter, GameView, WeekState, PickType } from '../services/sportAdapter';
 import { sortGamesByTimeThenRank } from '../services/sportAdapter';
 import { useLeagueMinSeason } from '../utils/useLeagueMinSeason';
+import { useLeagueStartWeek } from '../utils/useLeagueStartWeek';
 import { useCurrentWeekNav } from '../utils/useCurrentWeekNav';
 
 // ─── Icon + color helpers (use pre-computed adapter fields) ──────────────────
@@ -110,6 +112,7 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
   const maxWeek = currentMaxWeek ?? adapter.weekSelectorConfig.maxRegularSeasonWeek;
   const maxSeason = currentMaxSeason ?? new Date().getFullYear();
   const minSeason = useLeagueMinSeason(currentLeague, adapter.weekSelectorConfig.minSeason);
+  const startWeek = useLeagueStartWeek(currentLeague, data?.season ?? new Date().getFullYear());
 
   const handleWeekChange = useCallback((week: number, meta?: { isPostSeason?: boolean }) => {
     const season = data?.season ?? new Date().getFullYear();
@@ -192,6 +195,7 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
   // "no odds for the week I'm looking at" is the correct condition on its own (mirrors the
   // identical PicksPage.tsx fix, frizat-8y4).
   const oddsNotReady = !data.hasOdds;
+  const isWeekExcluded = isWeekExcludedFromSeason(data.week, startWeek);
 
   const games = showOnlyMyPicks
     ? sortedGames.filter(g =>
@@ -230,6 +234,8 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
 
       {oddsNotReady ? (
         <SpreadRelease sport={adapter.sport} />
+      ) : isWeekExcluded ? (
+        <ExcludedWeekBanner startWeek={startWeek} />
       ) : (
         <Grid container spacing={2}>
           {/* Controls row */}

--- a/Client.React/src/test/fixtures.ts
+++ b/Client.React/src/test/fixtures.ts
@@ -9,6 +9,15 @@ import type { NflPickDto, PickType, SpreadCalculationResponse, SpreadResponse } 
  * hook existed. Call from a `beforeEach` alongside the file's own mock resets; override with a
  * real resolved value only in a test that specifically exercises the per-league floor.
  */
+/**
+ * Resets a mocked `getLeagueJuice` and resolves it to no juice-mapping history, so both
+ * `useLeagueMinSeason` and `useLeagueStartWeek` (frizat-u66 — reuses the same
+ * `['leagueJuice', leagueId]` query rather than a second per-season fetch) fall back to their
+ * defaults (sport-wide minSeason; StartWeek 1, nothing excluded) — the default every
+ * pre-existing Picks/Scores/Leaderboard test was written against before either hook existed.
+ * Call from a `beforeEach` alongside the file's own mock resets; override with a real resolved
+ * value only in a test that specifically exercises the per-league floor or StartWeek gating.
+ */
 export function mockLeagueJuiceEmpty(mockedGetLeagueJuice: Mock) {
   mockedGetLeagueJuice.mockReset();
   mockedGetLeagueJuice.mockResolvedValue([]);

--- a/Client.React/src/utils/gameHelpers.ts
+++ b/Client.React/src/utils/gameHelpers.ts
@@ -19,6 +19,16 @@ export function isGameDecided(status: GameStatusValue): boolean {
   return isGameFinal(status) || isGameLive(status);
 }
 
+/**
+ * Mirrors Shared/Helpers/GameHelpers.cs's IsWeekExcludedFromSeason exactly — a league's
+ * configured StartWeek (frizat-o3x) excludes any earlier week/slate from scoring. `week` is
+ * whichever week/slate number the currently-viewed page is on (NFL week or CFB slate number,
+ * both already unified under GameView/WeekState — no sport branching needed here).
+ */
+export function isWeekExcludedFromSeason(week: number, startWeek: number): boolean {
+  return week < startWeek;
+}
+
 // Through the 2025 season, ESPN skipped postseason week 4 for the Pro Bowl (Super Bowl was raw
 // ESPN week 5). Must match the backend's GameHelpers.LastSeasonEspnSkippedProBowlWeek exactly —
 // see docs/ESPNProBowl.md and Shared/Helpers/GameHelpers.cs's identical constant (frizat-4k9).

--- a/Client.React/src/utils/useLeagueStartWeek.ts
+++ b/Client.React/src/utils/useLeagueStartWeek.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { getLeagueJuice } from '../api/league';
+
+/**
+ * The currently-selected league's configured StartWeek for `season` (frizat-o3x) — the week
+ * scoring actually begins at. Defaults to 1 (no exclusion) while loading or when the league has
+ * no juice mapping for that season yet, matching the backend's fail-open behavior in
+ * LeagueController.AddPicks / CfbPicksController.AddPicks. Shared by PicksPage and ScoresPage
+ * (frizat-u66) rather than each page independently fetching the same rarely-changing setting.
+ *
+ * Reuses useLeagueMinSeason's exact query (`getLeagueJuice`, key ['leagueJuice', leagueId]) —
+ * that response already carries every season's `startWeek`, so a second per-season endpoint call
+ * (`getLeagueJuiceForSeason`) would just be a redundant round trip for data already in flight on
+ * the same page render (/simplify efficiency finding, frizat-u66).
+ */
+export function useLeagueStartWeek(leagueId: number | null, season: number): number {
+  const { data } = useQuery({
+    queryKey: ['leagueJuice', leagueId],
+    queryFn: () => getLeagueJuice(leagueId!),
+    enabled: leagueId != null,
+  });
+
+  return data?.find(m => m.season === season)?.startWeek ?? 1;
+}

--- a/Server.UnitTests/CfbPicksControllerTests.cs
+++ b/Server.UnitTests/CfbPicksControllerTests.cs
@@ -241,6 +241,52 @@ public class CfbPicksControllerTests
         Assert.IsType<OkObjectResult>(result);
     }
 
+    // ── AddPicks — league StartWeek guard (frizat-u66) ───────────────────────
+
+    [Fact]
+    public async Task AddPicks_WhenSlateIsBeforeLeagueStartWeek_ReturnsBadRequest()
+    {
+        // MakeSlate defaults to slateNumber=1 — a league with StartWeek=2 must reject it, even
+        // though the kickoff guard and current-slate guard above would otherwise allow it.
+        _cfbRepo.GetSlateByIdAsync(1).Returns(MakeSlate());
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(2))]);
+        _repo.GetUserPicksAsync(1, 1, UserId).Returns([]);
+        _leagueRepo.GetLeagueJuiceMappingAsync(1, 2025).Returns(
+            new LeagueJuiceMapping { LeagueId = 1, Season = 2025, StartWeek = 2 });
+        var request = new AddCfbPicksRequest
+        {
+            LeagueId = 1, CfbSlateId = 1, Season = 2025,
+            Picks = [new CfbPickItem { Team = "ORE", PickType = PickType.Spread }]
+        };
+
+        var result = await BuildController().AddPicks(request, BuildCurrentSlateService());
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains("start", badRequest.Value?.ToString(), StringComparison.OrdinalIgnoreCase);
+        await _repo.DidNotReceive().AddPicksAsync(Arg.Any<IEnumerable<CfbPicks>>());
+    }
+
+    [Fact]
+    public async Task AddPicks_WhenNoLeagueJuiceMappingExists_AllowsPicks()
+    {
+        // Fail-open: no mapping means no configured restriction, matching StartWeek's own
+        // property default (1) — must not newly break every league that predates this feature.
+        _cfbRepo.GetSlateByIdAsync(1).Returns(MakeSlate());
+        _cfbRepo.GetSpreadsForSlateAsync(1).Returns([MakeSpread(DateTimeOffset.UtcNow.AddHours(2))]);
+        _repo.GetUserPicksAsync(1, 1, UserId).Returns([]);
+        _repo.AddPicksAsync(Arg.Any<IEnumerable<CfbPicks>>()).Returns(Task.CompletedTask);
+        _leagueRepo.GetLeagueJuiceMappingAsync(1, 2025).Returns((LeagueJuiceMapping?)null);
+        var request = new AddCfbPicksRequest
+        {
+            LeagueId = 1, CfbSlateId = 1, Season = 2025,
+            Picks = [new CfbPickItem { Team = "ORE", PickType = PickType.Spread }]
+        };
+
+        var result = await BuildController().AddPicks(request, BuildCurrentSlateService());
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
     // ── AddPicks — required-pick-count cap ──────────────────────────────────
 
     [Fact]

--- a/Server.UnitTests/PicksTests.cs
+++ b/Server.UnitTests/PicksTests.cs
@@ -245,6 +245,55 @@ public class PicksTests
         Assert.IsType<OkObjectResult>(result.Result);
     }
 
+    // frizat-u66: defense in depth backing the frontend gate — a league that has excluded this
+    // week via StartWeek must reject a pick submission for it even if attempted directly,
+    // regardless of whether the per-game kickoff guard above would otherwise have allowed it.
+    [Fact]
+    public async Task AddPicks_WhenWeekIsBeforeLeagueStartWeek_ReturnsBadRequest()
+    {
+        var futureKickoff = DateTimeOffset.UtcNow.AddHours(2);
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetNflWeeksAsync(Season).Returns([MakeNflWeek()]);
+        repo.UserExistsInLeagueAsync(UserId, LeagueId).Returns(true);
+        repo.GetUserNflPicksAsync(UserId, LeagueId, Season, Week).Returns([]);
+        repo.GetNflSpreadsAsync(Season, Week).Returns(MakeSpreads(futureKickoff));
+        repo.GetLeagueJuiceMappingAsync(LeagueId, Season).Returns(
+            new LeagueJuiceMapping { LeagueId = LeagueId, Season = Season, StartWeek = Week + 1 });
+
+        var controller = BuildController(repo, Substitute.For<IEspnCacheService>(), BuildPrincipal(UserId));
+        var picks = new[] { MakePick("BUF") };
+
+        // BuildCurrentWeekService defaults to this file's Week/Season, so this pick is otherwise
+        // "for the current week" — StartWeek must reject it independently of that guard.
+        var result = await controller.AddPicks(picks, BuildCurrentWeekService());
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Contains("start", badRequest.Value?.ToString(), StringComparison.OrdinalIgnoreCase);
+        await repo.DidNotReceive().AddNflPicksAsync(Arg.Any<IEnumerable<NflPicks>>());
+    }
+
+    [Fact]
+    public async Task AddPicks_WhenNoLeagueJuiceMappingExists_AllowsPicks()
+    {
+        // Fail-open: no mapping means no configured restriction, matching StartWeek's own
+        // property default (1) — must not newly break every league that predates this feature.
+        var futureKickoff = DateTimeOffset.UtcNow.AddHours(2);
+        var repo = Substitute.For<ILeagueRepository>();
+        repo.GetNflWeeksAsync(Season).Returns([MakeNflWeek()]);
+        repo.UserExistsInLeagueAsync(UserId, LeagueId).Returns(true);
+        repo.GetUserNflPicksAsync(UserId, LeagueId, Season, Week).Returns([]);
+        repo.AddNflPicksAsync(Arg.Any<IEnumerable<NflPicks>>()).Returns(Task.CompletedTask);
+        repo.GetNflSpreadsAsync(Season, Week).Returns(MakeSpreads(futureKickoff));
+        repo.GetLeagueJuiceMappingAsync(LeagueId, Season).Returns((LeagueJuiceMapping?)null);
+
+        var controller = BuildController(repo, Substitute.For<IEspnCacheService>(), BuildPrincipal(UserId));
+        var picks = new[] { MakePick("BUF") };
+
+        var result = await controller.AddPicks(picks, BuildCurrentWeekService());
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
     /// <summary>
     /// frizat-8n3: AddPicks must use the authenticated user's ID from the JWT claim,
     /// not the UserId in the request DTO. Without the fix, a user can submit picks on

--- a/Server/Controllers/CfbPicksController.cs
+++ b/Server/Controllers/CfbPicksController.cs
@@ -199,16 +199,23 @@ public class CfbPicksController(ICfbPicksRepository repo, ICfbRepository cfbRepo
         if (!await leagueRepo.UserExistsInLeagueAsync(userId, request.LeagueId))
             return Forbid();
 
-        // None of these four depend on each other's results, so fetch them concurrently.
+        // None of these five depend on each other's results, so fetch them concurrently.
         var spreadsTask = cfbRepo.GetSpreadsForSlateAsync(request.CfbSlateId);
         var existingPicksTask = repo.GetUserPicksAsync(request.LeagueId, request.CfbSlateId, userId);
         var slateTask = cfbRepo.GetSlateByIdAsync(request.CfbSlateId);
         var currentSlateTask = currentSlateService.GetCurrentSlateAsync();
-        await Task.WhenAll(spreadsTask, existingPicksTask, slateTask, currentSlateTask);
+        var juiceMappingTask = leagueRepo.GetLeagueJuiceMappingAsync(request.LeagueId, request.Season);
+        await Task.WhenAll(spreadsTask, existingPicksTask, slateTask, currentSlateTask, juiceMappingTask);
 
         var slate = slateTask.Result;
         if (slate is null)
             return BadRequest("Cfb Slate Does Not Exist");
+
+        // frizat-u66: defense in depth backing the frontend gate — a league that has excluded
+        // this slate via StartWeek must reject a submission for it even if attempted directly.
+        var startWeekError = GameHelpers.ValidateWeekNotExcluded(slate.SlateNumber, juiceMappingTask.Result?.StartWeek);
+        if (startWeekError is not null)
+            return BadRequest(startWeekError);
 
         // Guard: picks are only accepted for the currently open slate per the control table —
         // worse than NFL's equivalent gap, a spread-less future slate has empty

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -444,17 +444,25 @@ public class LeagueController(
         if (!isMember)
             return Forbid();
 
-        // Fetch weeks, this week's spreads, existing picks, and the current-week guard
-        // concurrently — none of these depend on each other's results.
+        // Fetch weeks, this week's spreads, existing picks, the current-week guard, and this
+        // league's juice mapping (for the StartWeek guard below) concurrently — none of these
+        // depend on each other's results.
         var weekTask          = repo.GetNflWeeksAsync(first.Season);
         var spreadsTask       = repo.GetNflSpreadsAsync(first.Season, first.NflWeek);
         var existingPicksTask = repo.GetUserNflPicksAsync(authenticatedUserId, first.LeagueId, first.Season, first.NflWeek);
         var currentWeekTask   = currentWeekService.GetCurrentWeekAsync();
-        await Task.WhenAll(weekTask, spreadsTask, existingPicksTask, currentWeekTask);
+        var juiceMappingTask  = repo.GetLeagueJuiceMappingAsync(first.LeagueId, first.Season);
+        await Task.WhenAll(weekTask, spreadsTask, existingPicksTask, currentWeekTask, juiceMappingTask);
 
         var weekId        = weekTask.Result;
         var spreads       = spreadsTask.Result ?? [];
         var existingPicks = existingPicksTask.Result;
+
+        // frizat-u66: defense in depth backing the frontend gate — a league that has excluded
+        // this week via StartWeek must reject a submission for it even if attempted directly.
+        var startWeekError = GameHelpers.ValidateWeekNotExcluded(first.NflWeek, juiceMappingTask.Result?.StartWeek);
+        if (startWeekError is not null)
+            return BadRequest(startWeekError);
 
         // Guard: picks are only accepted for the currently open week per the control table —
         // the per-game kickoff guard below never fires for a future week (its games haven't

--- a/Shared/Helpers/GameHelpers.cs
+++ b/Shared/Helpers/GameHelpers.cs
@@ -203,6 +203,19 @@ public static class GameHelpers {
     // sides can never drift on the boundary (e.g. off-by-one between "< " and "<=").
     public static bool IsWeekExcludedFromSeason(int week, int startWeek) => week < startWeek;
 
+    // Shared by LeagueController.AddPicks and CfbPicksController.AddPicks (frizat-u66) — was two
+    // byte-identical guard blocks, one per controller, differing only in which week/slate number
+    // got passed in. Takes `startWeek` as a nullable int (not the LeagueJuiceMapping entity
+    // itself) since that entity lives in Server.Models.Data, which Shared can't reference — a
+    // missing mapping fails open via the `?? 1` default (StartWeek's own EF default), matching
+    // every league that predates this feature.
+    public static string? ValidateWeekNotExcluded(int week, int? startWeek) {
+        var effectiveStartWeek = startWeek ?? 1;
+        return IsWeekExcludedFromSeason(week, effectiveStartWeek)
+            ? $"Picks aren't accepted before this league's configured Start Week ({effectiveStartWeek})."
+            : null;
+    }
+
     // Shared by LeagueController.AddPicks (NflSpreads) and CfbPicksController.AddPicks
     // (CfbSpreads) — was two byte-identical private methods, one per controller, differing only
     // in the spread row's concrete type. Pure control-table timestamp check, no ESPN dependency.


### PR DESCRIPTION
## Summary
- Picks/Scores pages now show a "Week Not Scored" notice instead of the normal grid for any week before a league's configured Start Week (frizat-o3x), instead of a fully-pickable grid whose submissions were silently discarded.
- `AddPicks` (both NFL `LeagueController` and CFB `CfbPicksController`) now rejects a direct pick submission for an excluded week/slate, backed by one shared `GameHelpers.ValidateWeekNotExcluded` helper rather than a duplicated guard per sport.
- `WeekYearSelector`'s navigable range is intentionally left untouched — excluded weeks stay selectable (spreads are still real for them), the empty-state message is what communicates exclusion.

## Test plan
- [x] `dotnet test` — 930/930 passing (one unrelated pre-existing live-ESPN-API test excluded; fails identically on an unrelated dev-tip worktree)
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm run test -- --run` — 666/666 passing
- [x] `npm run test:e2e -- --project=chromium` — all Picks/Scores specs pass; two unrelated pre-existing flaky specs (leaderboard, inviteFlow) confirmed flaky in isolation and untouched by this diff
- [x] `/simplify` (4 parallel agents) — applied: shared `GameHelpers.ValidateWeekNotExcluded` helper (was duplicated per sport), `useLeagueStartWeek` now reuses `useLeagueMinSeason`'s existing `getLeagueJuice` query instead of a second network round trip
- [x] CHANGELOG entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs