### PR TITLE
dev → main: SSE reconnect-with-backoff on Scores page (frizat-a2u)

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -8,6 +8,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 
 - Added: leagues can now set a Start Week (1-5, default 1) on the Juice tab so a league's season can skip early weeks — mainly for CFB leagues that want to skip week 1's often lopsided matchups. Weeks before it require no picks, don't appear on the leaderboard, and aren't billed the weekly cost; the following week settles normally, not as a doubled pot
 - Added: Picks and Scores now show a clear "Week Not Scored" notice instead of an ordinary pick grid for any week before a league's configured Start Week, so members don't submit picks that silently don't count; the server also rejects a direct pick submission for those weeks
+- Fixed: the Scores page's live-update connection could silently go dead for the rest of a game — a dropped network blip, laptop sleep, or wifi/mobile handoff now triggers an automatic reconnect instead of leaving live scores stuck until you reload the page
 
 ## 2026-09-09
 

--- a/Client.React/src/__tests__/useReconnectingEventSource.test.ts
+++ b/Client.React/src/__tests__/useReconnectingEventSource.test.ts
@@ -1,0 +1,129 @@
+import { renderHook } from '@testing-library/react';
+import { vi } from 'vitest';
+import { useReconnectingEventSource } from '../utils/useReconnectingEventSource';
+
+// frizat-a2u: native EventSource's own auto-reconnect doesn't apply once .close() is called
+// explicitly (ScoresPage.tsx's old `es.onerror = () => es.close()` abandoned the connection for
+// the rest of the page session). This mock tracks every constructed instance so tests can assert
+// a NEW EventSource gets created after a drop, not just that the old one silently stays dead.
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  url: string;
+  withCredentials: boolean;
+  onopen: (() => void) | null = null;
+  onmessage: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+
+  constructor(url: string, init?: EventSourceInit) {
+    this.url = url;
+    this.withCredentials = init?.withCredentials ?? false;
+    MockEventSource.instances.push(this);
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
+describe('useReconnectingEventSource', () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('does nothing when url is null', () => {
+    renderHook(() => useReconnectingEventSource(null, vi.fn()));
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it('opens a connection to the given url', () => {
+    renderHook(() => useReconnectingEventSource('/api/live-stream', vi.fn()));
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toBe('/api/live-stream');
+    expect(MockEventSource.instances[0].withCredentials).toBe(true);
+  });
+
+  it('calls onMessage when the connection receives a message', () => {
+    const onMessage = vi.fn();
+    renderHook(() => useReconnectingEventSource('/api/live-stream', onMessage));
+    MockEventSource.instances[0].onmessage?.();
+    expect(onMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('reconnects with a bounded backoff after the connection errors, instead of abandoning it', () => {
+    renderHook(() => useReconnectingEventSource('/api/live-stream', vi.fn()));
+    const first = MockEventSource.instances[0];
+
+    first.onerror?.();
+    expect(first.closed).toBe(true);
+    expect(MockEventSource.instances).toHaveLength(1); // not yet — backoff hasn't elapsed
+
+    vi.advanceTimersByTime(5000);
+
+    expect(MockEventSource.instances).toHaveLength(2);
+    expect(MockEventSource.instances[1].url).toBe('/api/live-stream');
+  });
+
+  it('resets the backoff after a successful message, so a later drop retries quickly again', () => {
+    renderHook(() => useReconnectingEventSource('/api/live-stream', vi.fn()));
+
+    // First drop — let it back off and reconnect once.
+    MockEventSource.instances[0].onerror?.();
+    vi.advanceTimersByTime(5000);
+    expect(MockEventSource.instances).toHaveLength(2);
+
+    // A real message on the new connection should reset backoff to its initial value.
+    MockEventSource.instances[1].onmessage?.();
+
+    // Second drop — if backoff had kept growing, this wouldn't reconnect within the same window.
+    MockEventSource.instances[1].onerror?.();
+    vi.advanceTimersByTime(1000);
+    expect(MockEventSource.instances).toHaveLength(3);
+  });
+
+  it('reconnects immediately when the browser comes back online, without waiting for backoff', () => {
+    renderHook(() => useReconnectingEventSource('/api/live-stream', vi.fn()));
+    expect(MockEventSource.instances).toHaveLength(1);
+
+    window.dispatchEvent(new Event('online'));
+
+    expect(MockEventSource.instances).toHaveLength(2);
+    expect(MockEventSource.instances[0].closed).toBe(true);
+  });
+
+  it('closes the connection, clears any pending retry, and stops listening for online on unmount', () => {
+    const { unmount } = renderHook(() => useReconnectingEventSource('/api/live-stream', vi.fn()));
+    const first = MockEventSource.instances[0];
+    first.onerror?.(); // schedule a retry that should never fire once unmounted
+
+    unmount();
+
+    expect(first.closed).toBe(true);
+    vi.advanceTimersByTime(30_000);
+    expect(MockEventSource.instances).toHaveLength(1); // the scheduled retry never ran
+
+    window.dispatchEvent(new Event('online'));
+    expect(MockEventSource.instances).toHaveLength(1); // online listener was removed too
+  });
+
+  it('tears down the old connection and opens a new one when the url changes', () => {
+    const { rerender } = renderHook(
+      ({ url }: { url: string | null }) => useReconnectingEventSource(url, vi.fn()),
+      { initialProps: { url: '/api/live-stream' } },
+    );
+    expect(MockEventSource.instances).toHaveLength(1);
+
+    rerender({ url: '/api/cfb/live-stream' });
+
+    expect(MockEventSource.instances[0].closed).toBe(true);
+    expect(MockEventSource.instances).toHaveLength(2);
+    expect(MockEventSource.instances[1].url).toBe('/api/cfb/live-stream');
+  });
+});

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -27,6 +27,7 @@ import { sortGamesByTimeThenRank } from '../services/sportAdapter';
 import { useLeagueMinSeason } from '../utils/useLeagueMinSeason';
 import { useLeagueStartWeek } from '../utils/useLeagueStartWeek';
 import { useCurrentWeekNav } from '../utils/useCurrentWeekNav';
+import { useReconnectingEventSource } from '../utils/useReconnectingEventSource';
 
 // ─── Icon + color helpers (use pre-computed adapter fields) ──────────────────
 
@@ -99,15 +100,12 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
     return () => document.removeEventListener('visibilitychange', h);
   }, []);
 
-  // SSE — primary update mechanism when on current NFL week with active games; polling above
-  // is the fallback (and the only mechanism at all for adapters with no sseUrl, e.g. CFB).
-  useEffect(() => {
-    if (!isCurrentWeek || !isPageVisible || !leaguesLoaded || !data?.hasActiveGames || !adapter.sseUrl) return;
-    const es = new EventSource(adapter.sseUrl, { withCredentials: true });
-    es.onmessage = () => void refetch();
-    es.onerror = () => es.close(); // fallback polling takes over
-    return () => es.close();
-  }, [isCurrentWeek, isPageVisible, leaguesLoaded, data?.hasActiveGames, adapter.sseUrl, refetch]);
+  // SSE — primary update mechanism when on current NFL/CFB week with active games; polling
+  // above is the fallback. Reconnects with backoff on drop and immediately on the browser's
+  // `online` event (frizat-a2u) — a dropped connection alone doesn't change any of these gating
+  // conditions, so without this the stream stayed dead for the rest of the page session.
+  const sseEnabled = isCurrentWeek && isPageVisible && leaguesLoaded && !!data?.hasActiveGames && !!adapter.sseUrl;
+  useReconnectingEventSource(sseEnabled ? adapter.sseUrl : null, () => void refetch());
 
   const maxWeek = currentMaxWeek ?? adapter.weekSelectorConfig.maxRegularSeasonWeek;
   const maxSeason = currentMaxSeason ?? new Date().getFullYear();

--- a/Client.React/src/services/sportAdapter.ts
+++ b/Client.React/src/services/sportAdapter.ts
@@ -159,7 +159,8 @@ export interface SportAdapter {
   /** Stable sport identifier — used as the React Query cache key prefix */
   sport: 'nfl' | 'cfb';
   pollIntervalMs: number;
-  /** SSE endpoint URL for live score push. Undefined on adapters that don't support it (e.g. CFB). */
+  /** SSE endpoint URL for live score push. Both nflAdapter and cfbAdapter set a real one today
+   * (CFB's is /api/cfb/live-stream); undefined only for an adapter with no SSE support at all. */
   sseUrl?: string;
   // loadJerseys is optional — if defined, PicksPage shows jerseys when data is non-empty
   weekSelectorConfig: {

--- a/Client.React/src/utils/useReconnectingEventSource.ts
+++ b/Client.React/src/utils/useReconnectingEventSource.ts
@@ -1,0 +1,79 @@
+import { useEffect, useRef } from 'react';
+
+const INITIAL_BACKOFF_MS = 1000;
+const MAX_BACKOFF_MS = 30_000;
+
+/**
+ * Wraps EventSource with reconnect-with-backoff (frizat-a2u). Native EventSource's own
+ * auto-reconnect doesn't apply once `.close()` is called explicitly — the old ScoresPage.tsx
+ * code (`es.onerror = () => es.close()`) abandoned the connection for the rest of the page
+ * session on any drop (network blip, laptop sleep, wifi/mobile handoff, backend restart), with
+ * no visible signal to the user, silently falling back to the 5-20min poll interval — exactly
+ * what "had to reload to get an update" looks like.
+ *
+ * Also reconnects immediately on the browser's `online` event, since a network blip alone
+ * doesn't change any of the caller's gating conditions (isCurrentWeek/isPageVisible/etc.) that
+ * would otherwise be needed to re-run the effect and open a fresh connection.
+ *
+ * `url` is expected to already reflect the caller's own gating (pass null/undefined to disable —
+ * e.g. when the page is hidden, not on the current week, or the adapter has no SSE endpoint).
+ */
+export function useReconnectingEventSource(url: string | null | undefined, onMessage: () => void) {
+  const onMessageRef = useRef(onMessage);
+  useEffect(() => {
+    onMessageRef.current = onMessage;
+  }, [onMessage]);
+
+  useEffect(() => {
+    if (!url) return;
+
+    let es: EventSource | null = null;
+    let retryTimeout: ReturnType<typeof setTimeout> | null = null;
+    let backoffMs = INITIAL_BACKOFF_MS;
+    let stopped = false;
+
+    const clearRetry = () => {
+      if (retryTimeout) {
+        clearTimeout(retryTimeout);
+        retryTimeout = null;
+      }
+    };
+
+    const connect = () => {
+      es = new EventSource(url, { withCredentials: true });
+      es.onopen = () => {
+        backoffMs = INITIAL_BACKOFF_MS;
+      };
+      es.onmessage = () => {
+        backoffMs = INITIAL_BACKOFF_MS;
+        onMessageRef.current();
+      };
+      es.onerror = () => {
+        es?.close();
+        if (stopped) return;
+        clearRetry();
+        retryTimeout = setTimeout(() => {
+          backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
+          connect();
+        }, backoffMs);
+      };
+    };
+
+    const reconnectNow = () => {
+      clearRetry();
+      es?.close();
+      backoffMs = INITIAL_BACKOFF_MS;
+      connect();
+    };
+
+    connect();
+    window.addEventListener('online', reconnectNow);
+
+    return () => {
+      stopped = true;
+      clearRetry();
+      es?.close();
+      window.removeEventListener('online', reconnectNow);
+    };
+  }, [url]);
+}


### PR DESCRIPTION
## Summary
- `ScoresPage.tsx`'s live-update SSE connection had no retry — a dropped connection stayed dead for the rest of the page session, falling back to a 5-20 minute poll interval.
- New `useReconnectingEventSource` hook: exponential backoff (1s doubling to a 30s cap, reset on success), plus immediate reconnect on the browser's `online` event.
- Fixed a stale `sseUrl` type comment in `sportAdapter.ts`.
- Verified live on dev.ivleague.xyz / cfb.dev.ivleague.xyz (SHA 1effcc6).

## Test plan
- [x] `dotnet test` — 930/930 (no backend changes)
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm run test -- --run` — 674/674 (8 new dedicated hook tests)
- [x] `npm run test:e2e -- --project=chromium` — 94/95 (one unrelated pre-existing flaky spec)
- [x] `/simplify` — reviewed, no findings
- [x] CI green on PR #359, DB Migrate ran, dev deploy verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs