### PR TITLE
Fix SSE change-detection fingerprint to include live-game situation fields (frizat-a2u)

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 - Added: leagues can now set a Start Week (1-5, default 1) on the Juice tab so a league's season can skip early weeks — mainly for CFB leagues that want to skip week 1's often lopsided matchups. Weeks before it require no picks, don't appear on the leaderboard, and aren't billed the weekly cost; the following week settles normally, not as a doubled pot
 - Added: Picks and Scores now show a clear "Week Not Scored" notice instead of an ordinary pick grid for any week before a league's configured Start Week, so members don't submit picks that silently don't count; the server also rejects a direct pick submission for those weeks
 - Fixed: the Scores page's live-update connection could silently go dead for the rest of a game — a dropped network blip, laptop sleep, or wifi/mobile handoff now triggers an automatic reconnect instead of leaving live scores stuck until you reload the page
+- Fixed: live scores could stay visibly stale even with a healthy connection — the server only pushed an update when the score itself changed, so a game sitting through any stretch of play with no score change (most plays) never pushed the clock, down/distance, or ball position even though they kept changing
 
 ## 2026-09-09
 

--- a/Server.UnitTests/EspnScoresFingerprintTests.cs
+++ b/Server.UnitTests/EspnScoresFingerprintTests.cs
@@ -1,0 +1,150 @@
+using FourPlayWebApp.Server.Services;
+using FourPlayWebApp.Shared.Models;
+using FourPlayWebApp.Shared.Models.Enum;
+
+namespace FourPlayWebApp.Server.UnitTests;
+
+// frizat-a2u (fast-follow, 2026-09-10): PeriodicRefreshCache only raises Changed — the event that
+// drives the SSE push to the browser — when this fingerprint differs from the prior poll. The
+// original fingerprint hashed only event id + score + status, so a live game sitting through any
+// stretch of play where the score itself didn't change (most plays) never fired a push at all,
+// even though the clock, down/distance, and ball position kept changing in reality — "staring at
+// the page and it never updated" with no dropped connection involved. These tests assert the
+// fingerprint reacts to every field a viewer can actually see on screen.
+public class EspnScoresFingerprintTests {
+    private static EspnScores MakeScores(EspnSitutation? situation = null, string displayClock = "8:42", long period = 3) =>
+        new() {
+            Events = [
+                new Event {
+                    Id = "1",
+                    Competitions = [
+                        new Competition {
+                            Status = new EspnStatus {
+                                Type = new StatusType { Name = TypeName.StatusInProgress, Description = Description.InProgress },
+                                DisplayClock = displayClock,
+                                Period = period,
+                            },
+                            Competitors = [
+                                new Competitor { HomeAway = HomeAway.Home, Score = 14 },
+                                new Competitor { HomeAway = HomeAway.Away, Score = 10 },
+                            ],
+                            Situation = situation!,
+                            Odds = [],
+                        },
+                    ],
+                },
+            ],
+        };
+
+    private static EspnSitutation MakeSituation(int down = 1, int yardLine = 50, int distance = 10, string possession = "home-team-id", bool? isRedZone = false) =>
+        new() {
+            Down = down,
+            YardLine = yardLine,
+            Distance = distance,
+            DownDistanceText = $"{down} & {distance}",
+            ShortDownDistanceText = $"{down} & {distance}",
+            PossessionText = possession,
+            Possession = possession,
+            IsRedZone = isRedZone,
+        };
+
+    [Fact]
+    public void Compute_ReturnsSameFingerprint_WhenNothingChanged() {
+        var scores = MakeScores(MakeSituation());
+
+        Assert.Equal(EspnScoresFingerprint.Compute(scores), EspnScoresFingerprint.Compute(scores));
+    }
+
+    [Fact]
+    public void Compute_ChangesFingerprint_WhenScoreChanges() {
+        var before = EspnScoresFingerprint.Compute(MakeScores(MakeSituation()));
+        var after = MakeScores(MakeSituation());
+        after.Events![0].Competitions[0].Competitors[0].Score = 21;
+
+        Assert.NotEqual(before, EspnScoresFingerprint.Compute(after));
+    }
+
+    // The actual bug: same score, same status, but down/distance/yard line changed (a normal
+    // non-scoring play) — the OLD fingerprint would report no change here, silently swallowing the
+    // SSE push for every non-scoring play in the game. Down and Distance isolated separately so a
+    // future edit dropping just one of the two from Compute() still fails a test.
+    [Fact]
+    public void Compute_ChangesFingerprint_WhenDownChanges() {
+        var before = EspnScoresFingerprint.Compute(MakeScores(MakeSituation(down: 1)));
+        var after = EspnScoresFingerprint.Compute(MakeScores(MakeSituation(down: 2)));
+
+        Assert.NotEqual(before, after);
+    }
+
+    [Fact]
+    public void Compute_ChangesFingerprint_WhenDistanceChanges() {
+        var before = EspnScoresFingerprint.Compute(MakeScores(MakeSituation(distance: 10)));
+        var after = EspnScoresFingerprint.Compute(MakeScores(MakeSituation(distance: 7)));
+
+        Assert.NotEqual(before, after);
+    }
+
+    [Fact]
+    public void Compute_ChangesFingerprint_WhenYardLineChanges() {
+        var before = EspnScoresFingerprint.Compute(MakeScores(MakeSituation(yardLine: 50)));
+        var after = EspnScoresFingerprint.Compute(MakeScores(MakeSituation(yardLine: 45)));
+
+        Assert.NotEqual(before, after);
+    }
+
+    // Hashes Situation.Possession (the team-id field GameSituationDto.FromSituation treats as
+    // authoritative for "who has the ball"), not the derived PossessionText display string.
+    [Fact]
+    public void Compute_ChangesFingerprint_WhenPossessionChanges() {
+        var before = EspnScoresFingerprint.Compute(MakeScores(MakeSituation(possession: "home-team-id")));
+        var after = EspnScoresFingerprint.Compute(MakeScores(MakeSituation(possession: "away-team-id")));
+
+        Assert.NotEqual(before, after);
+    }
+
+    [Fact]
+    public void Compute_ChangesFingerprint_WhenRedZoneChanges() {
+        var before = EspnScoresFingerprint.Compute(MakeScores(MakeSituation(isRedZone: false)));
+        var after = EspnScoresFingerprint.Compute(MakeScores(MakeSituation(isRedZone: true)));
+
+        Assert.NotEqual(before, after);
+    }
+
+    // The clock ticking down between snaps, with no score/down/distance change yet, is itself a
+    // real on-screen change (the "Q3 8:42" status line) that a viewer would notice go stale.
+    [Fact]
+    public void Compute_ChangesFingerprint_WhenClockChanges() {
+        var before = EspnScoresFingerprint.Compute(MakeScores(MakeSituation(), displayClock: "8:42"));
+        var after = EspnScoresFingerprint.Compute(MakeScores(MakeSituation(), displayClock: "8:15"));
+
+        Assert.NotEqual(before, after);
+    }
+
+    [Fact]
+    public void Compute_ChangesFingerprint_WhenPeriodChanges() {
+        var before = EspnScoresFingerprint.Compute(MakeScores(MakeSituation(), period: 2));
+        var after = EspnScoresFingerprint.Compute(MakeScores(MakeSituation(), period: 3));
+
+        Assert.NotEqual(before, after);
+    }
+
+    // ESPN's live feed genuinely omits the full situation sub-object sometimes (see frizat-66c) —
+    // the fingerprint must not throw when Situation is null, and a null-to-present (or vice versa)
+    // transition should itself count as a change.
+    [Fact]
+    public void Compute_DoesNotThrow_WhenSituationIsNull() {
+        var scores = MakeScores(situation: null);
+
+        var ex = Record.Exception(() => EspnScoresFingerprint.Compute(scores));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Compute_ChangesFingerprint_WhenSituationGoesFromNullToPresent() {
+        var before = EspnScoresFingerprint.Compute(MakeScores(situation: null));
+        var after = EspnScoresFingerprint.Compute(MakeScores(MakeSituation()));
+
+        Assert.NotEqual(before, after);
+    }
+}

--- a/Server/Services/EspnScoresFingerprint.cs
+++ b/Server/Services/EspnScoresFingerprint.cs
@@ -10,11 +10,21 @@ namespace FourPlayWebApp.Server.Services;
 /// </summary>
 public static class EspnScoresFingerprint
 {
+    // frizat-a2u (fast-follow, 2026-09-10): PeriodicRefreshCache only raises Changed — which
+    // drives the SSE push to the browser — when this fingerprint differs from the last poll.
+    // Score+status alone missed every non-scoring play in a live game (down/distance, yard line,
+    // possession, clock all keep changing while the score doesn't), so the push silently never
+    // fired for most of a game's actual live-game changes. Include everything a viewer can see
+    // on screen (Scores page status line + FieldPosition), not just the scoreboard.
     public static string Compute(EspnScores scores) =>
         string.Join("|", scores.Events?.Select(e => {
             var c = e.Competitions.FirstOrDefault();
             var home = c?.Competitors.FirstOrDefault(x => x.HomeAway == HomeAway.Home);
             var away = c?.Competitors.FirstOrDefault(x => x.HomeAway == HomeAway.Away);
-            return $"{e.Id}:{home?.Score}:{away?.Score}:{c?.Status.Type.Name}";
+            var sit = c?.Situation;
+            // sit?.Possession (team id) is the authoritative field — GameSituationDto.FromSituation
+            // and GameHelpers.GetPossessionTeamAbbr both key off it, not the derived display string
+            // possessionText — hash the same field the rest of the app treats as source-of-truth.
+            return $"{e.Id}:{home?.Score}:{away?.Score}:{c?.Status.Type.Name}:{c?.Status.DisplayClock}:{c?.Status.Period}:{sit?.Down}:{sit?.YardLine}:{sit?.Distance}:{sit?.Possession}:{sit?.IsRedZone}";
         }) ?? []);
 }


### PR DESCRIPTION
## Summary
- `PeriodicRefreshCache` only fires the `Changed` event (which drives the SSE push) when `EspnScoresFingerprint.Compute()` differs from the prior poll — but the fingerprint only hashed event id + score + status, so a live game sitting through any stretch of play with no score change (most plays) never pushed at all, even though the clock, down/distance, and ball position kept changing. This is the fast-follow for the actual symptom reported: "staring at the page, connection fine, it just never updates" — distinct from the dropped-connection gap fixed in #359/#360.
- Fingerprint now also hashes status clock/period and situation down/distance/yard line/possession/red-zone. Shared by NFL and CFB (both use this same function), so one fix covers both sports.
- `/simplify` review caught one real bug in my own fix before merge: hashed `Situation.PossessionText` (a display string) instead of `Situation.Possession` (the team-id field the rest of the app treats as authoritative) — fixed.
- Filed frizat-6u6 (P4) as a follow-up for the underlying structural fragility (hand-maintained field list) the review also flagged — not blocking this fix.

## Test plan
- [x] `dotnet test` — 941/941 (11 new tests for the fingerprint, one unrelated pre-existing live-ESPN-API flake excluded)
- [x] `/simplify` — reviewed, applied 2 real fixes (PossessionText→Possession, split combined Down+Distance test into two isolated tests)
- [x] CHANGELOG entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs