### PR TITLE
CFB DidPickWin: delegate to shared SpreadCalculator (frizat-8sk)

### DIFF
--- a/Server/Services/CfbLeaderboardService.cs
+++ b/Server/Services/CfbLeaderboardService.cs
@@ -122,9 +122,14 @@ public class CfbLeaderboardService(
             return result;
         }
 
+        // One calculator per slate (mirrors LeaderboardService.IsPickAWinner's per-week pattern)
+        // rather than rebuilding it per pick — the full spreads list is the odds source every
+        // pick's team lookup resolves against, same shape CfbPicksController.GetSpreads already
+        // constructs from.
+        var spreadCalculator = new SpreadCalculator(spreads, juice);
         var allWon = picks.All(pick => {
             try {
-                return DidPickWin(pick, spreads, scores, juice);
+                return DidPickWin(pick, spreads, scores, spreadCalculator);
             } catch (Exception ex) {
                 logger.LogError(ex, "Error evaluating CFB pick {@Pick}", pick);
                 return false;
@@ -144,7 +149,7 @@ public class CfbLeaderboardService(
         return result;
     }
 
-    private static bool DidPickWin(CfbPicks pick, List<CfbSpreads> spreads, List<CfbScores> scores, double juice) {
+    private static bool DidPickWin(CfbPicks pick, List<CfbSpreads> spreads, List<CfbScores> scores, ISpreadCalculator spreadCalculator) {
         var spread = spreads.FirstOrDefault(s => s.HomeTeam == pick.Team || s.AwayTeam == pick.Team);
         if (spread is null) return true;
 
@@ -154,14 +159,8 @@ public class CfbLeaderboardService(
         var isHome = spread.HomeTeam == pick.Team;
         var teamScore = isHome ? score.HomeTeamScore : score.AwayTeamScore;
         var otherScore = isHome ? score.AwayTeamScore : score.HomeTeamScore;
-        var rawSpread = isHome ? spread.HomeTeamSpread : spread.AwayTeamSpread;
 
-        return pick.PickType switch {
-            PickType.Spread => teamScore + rawSpread + juice - otherScore > 0,
-            PickType.Over => teamScore + otherScore > spread.OverUnder - juice,
-            PickType.Under => teamScore + otherScore < spread.OverUnder + juice,
-            _ => false,
-        };
+        return spreadCalculator.DidUserWinPick(pick.Team, teamScore, otherScore, pick.PickType);
     }
 
     private static List<LeaderboardModel> CalculateTotals(List<LeaderboardModel> leaderboard,


### PR DESCRIPTION
## Summary
- Pure DRY cleanup: `CfbLeaderboardService.DidPickWin` hand-rolled the Over/Under juice comparison inline instead of calling `SpreadCalculator.DidUserWinPick`, which NFL's `LeaderboardService` already uses for the identical calculation.
- Now constructs one `SpreadCalculator` per slate (mirroring NFL's per-week pattern) and delegates the win/lose arithmetic entirely. `DidPickWin` keeps only its own missing-spread/missing-score guards.
- Zero behavior change — no test values updated; all 941 existing tests pass unchanged.
- `/simplify` surfaced a pre-existing NFL/CFB asymmetry (missing-spread-row fails open on CFB, fails closed on NFL) — out of scope for this "no behavior change" chore, filed as frizat-xtn (P4) instead.

## Test plan
- [x] `dotnet test` — 941/941, unchanged (one unrelated pre-existing live-ESPN-API flake excluded)
- [x] `/simplify` — reviewed, no findings requiring changes
- [x] No CHANGELOG entry — purely internal refactor, no user-facing change (CLAUDE.md's internal-only exemption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs