### PR TITLE
dev → main: CFB DidPickWin/SpreadCalculator dedup (frizat-8sk)

### DIFF
--- a/Server/Services/CfbLeaderboardService.cs
+++ b/Server/Services/CfbLeaderboardService.cs
@@ -122,9 +122,14 @@ public class CfbLeaderboardService(
             return result;
         }
 
+        // One calculator per slate (mirrors LeaderboardService.IsPickAWinner's per-week pattern)
+        // rather than rebuilding it per pick — the full spreads list is the odds source every
+        // pick's team lookup resolves against, same shape CfbPicksController.GetSpreads already
+        // constructs from.
+        var spreadCalculator = new SpreadCalculator(spreads, juice);
         var allWon = picks.All(pick => {
             try {
-                return DidPickWin(pick, spreads, scores, juice);
+                return DidPickWin(pick, spreads, scores, spreadCalculator);
             } catch (Exception ex) {
                 logger.LogError(ex, "Error evaluating CFB pick {@Pick}", pick);
                 return false;
@@ -144,7 +149,7 @@ public class CfbLeaderboardService(
         return result;
     }
 
-    private static bool DidPickWin(CfbPicks pick, List<CfbSpreads> spreads, List<CfbScores> scores, double juice) {
+    private static bool DidPickWin(CfbPicks pick, List<CfbSpreads> spreads, List<CfbScores> scores, ISpreadCalculator spreadCalculator) {
         var spread = spreads.FirstOrDefault(s => s.HomeTeam == pick.Team || s.AwayTeam == pick.Team);
         if (spread is null) return true;
 
@@ -154,14 +159,8 @@ public class CfbLeaderboardService(
         var isHome = spread.HomeTeam == pick.Team;
         var teamScore = isHome ? score.HomeTeamScore : score.AwayTeamScore;
         var otherScore = isHome ? score.AwayTeamScore : score.HomeTeamScore;
-        var rawSpread = isHome ? spread.HomeTeamSpread : spread.AwayTeamSpread;
 
-        return pick.PickType switch {
-            PickType.Spread => teamScore + rawSpread + juice - otherScore > 0,
-            PickType.Over => teamScore + otherScore > spread.OverUnder - juice,
-            PickType.Under => teamScore + otherScore < spread.OverUnder + juice,
-            _ => false,
-        };
+        return spreadCalculator.DidUserWinPick(pick.Team, teamScore, otherScore, pick.PickType);
     }
 
     private static List<LeaderboardModel> CalculateTotals(List<LeaderboardModel> leaderboard,


### PR DESCRIPTION
## Summary
- Pure DRY cleanup: `CfbLeaderboardService.DidPickWin` now delegates its Over/Under/Spread win-determination arithmetic to the shared `SpreadCalculator.DidUserWinPick`, matching NFL's existing path, instead of hand-rolling the juice comparison inline.
- Zero behavior change — all 941 existing tests pass unchanged.
- Filed frizat-xtn (P4) as a follow-up for a pre-existing NFL/CFB asymmetry `/simplify` surfaced (missing-spread-row fails open on CFB, fails closed on NFL) — explicitly out of scope for this no-behavior-change chore.
- Verified live on dev.ivleague.xyz / cfb.dev.ivleague.xyz (SHA a8a07a2).

## Test plan
- [x] `dotnet test` — 941/941, unchanged
- [x] `/simplify` — reviewed, no findings requiring changes
- [x] CI green on PR #365, DB Migrate ran, dev deploy verified
- [x] No CHANGELOG entry — internal refactor only, no user-facing change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAWjtJgXaMYbzZXYJjTEYs