### PR TITLE
dev → main: stale scores on tab refocus, stray "0", auth error toasts (PR #367)

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -7,6 +7,9 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 ## 2026-09-11
 
 - Fixed: the Scores and Picks pages could sit on stale data after switching away from the tab and back — the polling pause for a hidden tab resumed correctly, but nothing forced an immediate refresh, so it just waited out the usual 5-20 minute interval instead of updating right away
+- Fixed: a stray "0" could appear next to the Scores page's "Show Only My Picks" button on a week with no picks yet
+- Fixed: Forgot Password and Reset Password showed the same generic error for any failure, including being rate-limited (3 attempts/hour) — a rate-limited user now sees a clear "too many attempts, wait a few minutes" message instead
+- Fixed: the Email field's floating label could look broken on Login/Forgot Password when the browser autofilled it — the browser's own autofill highlight color now matches the app's theme instead of clashing with it
 
 ## 2026-09-10
 

--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to IV League, most recent first. For admins — see the version 
 
 Format: `## ` release headings and single-line `- ` bullets only — no bold, links, or multi-line/nested bullets. The admin Changelog page renders this with a small hand-rolled parser (`parseChangelog.ts`), not a full Markdown engine; anything outside this subset renders as literal syntax instead of being formatted. A test guards this file against drifting outside the subset.
 
+## 2026-09-11
+
+- Fixed: the Scores page could sit on stale scores after switching away from the tab and back — the polling pause for a hidden tab resumed correctly, but nothing forced an immediate refresh, so it just waited out the usual 5-20 minute interval instead of updating right away
+
 ## 2026-09-10
 
 - Added: leagues can now set a Start Week (1-5, default 1) on the Juice tab so a league's season can skip early weeks — mainly for CFB leagues that want to skip week 1's often lopsided matchups. Weeks before it require no picks, don't appear on the leaderboard, and aren't billed the weekly cost; the following week settles normally, not as a doubled pot

--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -6,7 +6,7 @@ Format: `## ` release headings and single-line `- ` bullets only — no bold, li
 
 ## 2026-09-11
 
-- Fixed: the Scores page could sit on stale scores after switching away from the tab and back — the polling pause for a hidden tab resumed correctly, but nothing forced an immediate refresh, so it just waited out the usual 5-20 minute interval instead of updating right away
+- Fixed: the Scores and Picks pages could sit on stale data after switching away from the tab and back — the polling pause for a hidden tab resumed correctly, but nothing forced an immediate refresh, so it just waited out the usual 5-20 minute interval instead of updating right away
 
 ## 2026-09-10
 

--- a/Client.React/src/__tests__/ForgotPasswordPage.test.tsx
+++ b/Client.React/src/__tests__/ForgotPasswordPage.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
+import { buildAxiosError } from './testUtils/axiosError';
 
 const navigateMock = vi.fn();
 vi.mock('react-router-dom', async (importOriginal) => {
@@ -10,13 +11,18 @@ vi.mock('react-router-dom', async (importOriginal) => {
 });
 
 vi.mock('../api/auth', () => ({ forgotPassword: vi.fn() }));
-vi.mock('../services/toast', () => ({ useToast: () => ({ push: vi.fn() }) }));
+const pushMock = vi.fn();
+vi.mock('../services/toast', () => ({ useToast: () => ({ push: pushMock }) }));
 
 import ForgotPasswordPage from '../pages/account/ForgotPasswordPage';
 import { forgotPassword } from '../api/auth';
 
 // frizat: previously had no way to cancel/return to login before submitting.
 describe('ForgotPasswordPage', () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+  });
+
   it('has a way back to login without submitting anything', async () => {
     navigateMock.mockReset();
     render(
@@ -29,5 +35,25 @@ describe('ForgotPasswordPage', () => {
 
     expect(navigateMock).toHaveBeenCalledWith('/account/login');
     expect(forgotPassword).not.toHaveBeenCalled();
+  });
+
+  // frizat: "forgot" rate limiter (Program.cs: 3 attempts/hour per IP, shared with reset-password)
+  // returns a bare 429 — the page previously swallowed every failure into the same generic
+  // "Error requesting password reset" toast, giving a genuinely rate-limited user (who retried
+  // after not seeing the email land) no indication to stop retrying and just wait.
+  it('shows a friendly rate-limit toast on a 429 — not the generic fallback message', async () => {
+    vi.mocked(forgotPassword).mockRejectedValue(buildAxiosError(429, ''));
+    render(
+      <MemoryRouter>
+        <ForgotPasswordPage />
+      </MemoryRouter>,
+    );
+
+    await userEvent.type(screen.getByLabelText(/email/i), 'ryan3000@gmail.com');
+    await userEvent.click(screen.getByRole('button', { name: /reset password/i }));
+
+    await waitFor(() =>
+      expect(pushMock).toHaveBeenCalledWith('Too many attempts. Please wait a few minutes and try again.', 'error'),
+    );
   });
 });

--- a/Client.React/src/__tests__/ResetPasswordPage.test.tsx
+++ b/Client.React/src/__tests__/ResetPasswordPage.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
+import { buildAxiosError } from './testUtils/axiosError';
 
 const navigateMock = vi.fn();
 vi.mock('react-router-dom', async (importOriginal) => {
@@ -10,15 +11,22 @@ vi.mock('react-router-dom', async (importOriginal) => {
 });
 
 vi.mock('../api/auth', () => ({ resetPassword: vi.fn() }));
-vi.mock('../services/toast', () => ({ useToast: () => ({ push: vi.fn() }) }));
+const pushMock = vi.fn();
+vi.mock('../services/toast', () => ({ useToast: () => ({ push: pushMock }) }));
 // Bypass real base64 validation — this test only cares about the cancel link, not the code param.
 vi.mock('../utils/base64', () => ({ isValidBase64Url: () => true, decodeBase64Url: () => 'token' }));
 
 import ResetPasswordPage from '../pages/account/ResetPasswordPage';
 import { resetPassword } from '../api/auth';
 
+const VALID_PASSWORD = 'Abcdef1!';
+
 // frizat: previously had no way to cancel/return to login before submitting.
 describe('ResetPasswordPage', () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+  });
+
   it('has a way back to login without submitting anything', async () => {
     navigateMock.mockReset();
     render(
@@ -31,5 +39,26 @@ describe('ResetPasswordPage', () => {
 
     expect(navigateMock).toHaveBeenCalledWith('/account/login');
     expect(resetPassword).not.toHaveBeenCalled();
+  });
+
+  // frizat: same "forgot" rate limiter as ForgotPasswordPage (Program.cs: 3 attempts/hour per IP,
+  // shared between forgot-password and reset-password) — this page had the identical generic
+  // "Error resetting password" catch-all with no rate-limit-specific message.
+  it('shows a friendly rate-limit toast on a 429 — not the generic fallback message', async () => {
+    vi.mocked(resetPassword).mockRejectedValue(buildAxiosError(429, ''));
+    render(
+      <MemoryRouter initialEntries={['/account/resetpassword?code=abc']}>
+        <ResetPasswordPage />
+      </MemoryRouter>,
+    );
+
+    await userEvent.type(screen.getByLabelText(/email/i), 'ryan3000@gmail.com');
+    await userEvent.type(screen.getByLabelText(/new password/i), VALID_PASSWORD);
+    await userEvent.type(screen.getByLabelText(/confirm password/i), VALID_PASSWORD);
+    await userEvent.click(screen.getByRole('button', { name: /reset password/i }));
+
+    await waitFor(() =>
+      expect(pushMock).toHaveBeenCalledWith('Too many attempts. Please wait a few minutes and try again.', 'error'),
+    );
   });
 });

--- a/Client.React/src/__tests__/picks.test.tsx
+++ b/Client.React/src/__tests__/picks.test.tsx
@@ -664,4 +664,51 @@ describe('PicksPage', () => {
       );
     });
   });
+
+  // Same underlying bug/fix as ScoresPage.tsx's "tab visibility refresh" tests: refetchInterval
+  // alone doesn't trigger an immediate fetch on regaining focus, and refetchOnWindowFocus is
+  // disabled globally (main.tsx), so this page's live-week query needs its own override.
+  describe('tab visibility refresh', () => {
+    const setHidden = (hidden: boolean) => {
+      Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
+      Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => (hidden ? 'hidden' : 'visible') });
+      document.dispatchEvent(new Event('visibilitychange'));
+      window.dispatchEvent(new Event('visibilitychange'));
+    };
+
+    afterEach(() => {
+      Object.defineProperty(document, 'hidden', { configurable: true, get: () => false });
+      Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => 'visible' });
+    });
+
+    it('refetches immediately when the tab regains visibility, without waiting for the poll interval', async () => {
+      await setupDefaults();
+      await renderPage();
+
+      mockedGetWeekScores.mockClear();
+
+      await act(async () => { setHidden(true); });
+      expect(mockedGetWeekScores).not.toHaveBeenCalled();
+
+      await act(async () => { setHidden(false); });
+      await waitFor(() => expect(mockedGetWeekScores).toHaveBeenCalled());
+    });
+
+    it('does not refetch on regained visibility when viewing a historical week', async () => {
+      await setupDefaults({ week: 2 });
+      await renderPage();
+
+      const user = userEvent.setup();
+      await user.click(screen.getAllByRole('combobox')[1]);
+      await user.click(screen.getByRole('option', { name: /week 1/i }));
+      await waitFor(() => expect(mockedGetWeekScores).toHaveBeenCalledWith(expect.anything(), 1));
+
+      mockedGetWeekScores.mockClear();
+
+      await act(async () => { setHidden(true); });
+      await act(async () => { setHidden(false); });
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(mockedGetWeekScores).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -496,6 +496,69 @@ describe('ScoresPage', () => {
     });
   });
 
+  // frizat: "score not updating — if I change focus and come back it doesn't auto update".
+  // The visibilitychange handler only paused/resumed the refetchInterval gate — resuming a
+  // gate doesn't itself trigger a fetch, so React Query just waited for the next 5-20min tick.
+  // refetchOnWindowFocus is globally disabled (main.tsx) for other pages' sake, so this page
+  // must explicitly refetch on becoming visible again instead of relying on that default.
+  describe('tab visibility refresh', () => {
+    const setHidden = (hidden: boolean) => {
+      Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
+      document.dispatchEvent(new Event('visibilitychange'));
+    };
+
+    afterEach(() => {
+      Object.defineProperty(document, 'hidden', { configurable: true, get: () => false });
+    });
+
+    it('refetches immediately when the tab regains visibility, without waiting for the poll interval', async () => {
+      const liveComp = createCompetition({
+        homeTeam: 'BUF', awayTeam: 'MIA', homeScore: 24, awayScore: 10,
+        liveStatus: { name: 'status_in_progress', period: 2, displayClock: '5:00' },
+      });
+      mockedGetNflCurrentWeek.mockResolvedValue(createCurrentWeek(2));
+      mockedGetWeekScores.mockResolvedValue(createScores({
+        week: 2, postSeason: false,
+        events: [{ id: '1', season: { year: 2024, type: 2 }, week: { number: 2 }, date: new Date().toISOString(), competitions: [liveComp] }],
+      }));
+      mockedGetLiveGames.mockResolvedValue([]);
+      mockedDoOddsExist.mockResolvedValue(true);
+      mockedGetLeaguePicks.mockResolvedValue([]);
+      mockedSpreadBatch.mockResolvedValue({ responses: SPREAD_RESPONSES });
+      await renderPage();
+      expect(screen.getAllByText(/BUF/i).length).toBeGreaterThan(0);
+
+      mockedGetWeekScores.mockClear();
+
+      // Tab goes to background — no fetch just from hiding.
+      await act(async () => { setHidden(true); });
+      expect(mockedGetWeekScores).not.toHaveBeenCalled();
+
+      // Tab regains focus — must refetch right away, not wait for the poll interval.
+      await act(async () => { setHidden(false); });
+      await waitFor(() => expect(mockedGetWeekScores).toHaveBeenCalled());
+    });
+
+    it('does not refetch on regained visibility when viewing a historical week', async () => {
+      await setupDefaults({ week: 2 });
+      await renderPage();
+
+      const user = userEvent.setup();
+      await user.click(screen.getAllByRole('combobox')[1]);
+      await user.click(screen.getByRole('option', { name: /week 1/i }));
+      await waitFor(() => expect(screen.getAllByText(/DAL/i).length).toBeGreaterThan(0));
+
+      mockedGetWeekScores.mockClear();
+
+      await act(async () => { setHidden(true); });
+      await act(async () => { setHidden(false); });
+      // Give any stray async work a tick, then assert no extra fetch was made for static
+      // historical data (a real regression here would call getWeekScores again).
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(mockedGetWeekScores).not.toHaveBeenCalled();
+    });
+  });
+
   it('season selector keeps the current season navigable after viewing a historical season', async () => {
     // Regression (mirrors the equivalent PicksPage test): navigating into a past season used to
     // permanently shrink the selector's range to "minSeason..whatever season you're viewing" —

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -497,18 +497,23 @@ describe('ScoresPage', () => {
   });
 
   // frizat: "score not updating — if I change focus and come back it doesn't auto update".
-  // The visibilitychange handler only paused/resumed the refetchInterval gate — resuming a
-  // gate doesn't itself trigger a fetch, so React Query just waited for the next 5-20min tick.
-  // refetchOnWindowFocus is globally disabled (main.tsx) for other pages' sake, so this page
-  // must explicitly refetch on becoming visible again instead of relying on that default.
+  // The page's own visibilitychange handler only paused/resumed the refetchInterval gate —
+  // resuming a gate doesn't itself trigger a fetch, so React Query just waited for the next
+  // 5-20min tick. refetchOnWindowFocus is globally disabled (main.tsx) for other pages' sake, so
+  // this query overrides it back on for itself, scoped to the live current week — React Query's
+  // own focusManager (which listens on `window`, separately from the page's own `document`
+  // listener above) then handles the immediate refetch on regaining visibility.
   describe('tab visibility refresh', () => {
     const setHidden = (hidden: boolean) => {
       Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
+      Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => (hidden ? 'hidden' : 'visible') });
       document.dispatchEvent(new Event('visibilitychange'));
+      window.dispatchEvent(new Event('visibilitychange'));
     };
 
     afterEach(() => {
       Object.defineProperty(document, 'hidden', { configurable: true, get: () => false });
+      Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => 'visible' });
     });
 
     it('refetches immediately when the tab regains visibility, without waiting for the poll interval', async () => {

--- a/Client.React/src/__tests__/scores.test.tsx
+++ b/Client.React/src/__tests__/scores.test.tsx
@@ -301,6 +301,20 @@ describe('ScoresPage', () => {
     expect(myPicksButton.className).not.toMatch(/Secondary/);
   });
 
+  // frizat: `data?.allPicks.length && data.allPicks.length > 0 && (<Button/>)` — when nobody has
+  // picked yet, allPicks.length is 0 (falsy but not boolean), so `&&` short-circuits to the
+  // literal number 0 and React renders it as stray text next to the controls row (reported live:
+  // a bare "0" floating next to "Show Only My Picks" on a week with no picks yet).
+  it('does not render a stray "0" in the controls row when nobody has picked yet', async () => {
+    await setupDefaults({ picks: [], gameStarted: true });
+    const { container } = await renderPage();
+
+    expect(screen.queryByRole('button', { name: /show as matrix/i })).toBeNull();
+    const controlsRow = screen.getByRole('button', { name: /show only my picks/i }).closest('.MuiGrid-root');
+    expect(controlsRow?.textContent).not.toMatch(/^0/);
+    expect(container.textContent).not.toContain('0Show Only My Picks');
+  });
+
   // /code-review caught that the removed shield icon was the ONLY win/loss signal for a team
   // nobody in the league picked — the badge/icon-button pair used pickCount === 0 to both hide
   // the count bubble AND disable the button, and MUI's disabled state flattens `color` to gray

--- a/Client.React/src/app/global.css
+++ b/Client.React/src/app/global.css
@@ -8,6 +8,9 @@
   --ink-2: #334155;
   --accent: #ff6b35;
   --primary: #1a2847;
+  /* Mirrors theme.ts's palette.background.paper (light) — the Card/Paper surface color, distinct
+     from the body's own --bg-1/--bg-2/--bg-3. Keep these two in sync if either changes. */
+  --paper: #ffffff;
   --safe-inset-top: env(safe-area-inset-top);
   --safe-inset-bottom: env(safe-area-inset-bottom);
   --safe-inset-left: env(safe-area-inset-left);
@@ -15,6 +18,8 @@
 }
 
 [data-theme='dark'] {
+  /* Mirrors theme.ts's palette.background.paper (dark). */
+  --paper: #1a2440;
   --bg-1: #0f1729;
   /* Was #1a2440 — byte-for-byte identical to theme.ts's dark-mode background.paper. On a page
      long enough to scroll well past the first viewport (e.g. the ever-growing Changelog), the
@@ -109,6 +114,24 @@ input[type="checkbox"],
 input[type="radio"] {
   -webkit-appearance: checkbox;
   appearance: checkbox;
+}
+
+/* Safari/Chrome ignore an input's own `background` for an autofilled field and paint their own
+   solid highlight straight onto it (blue on iOS Safari, yellow on Chrome) — the input's own
+   `background-color` CSS can't override this, only `box-shadow` can. On a dark-themed MUI
+   outlined TextField this clashes with the Card/Paper the field sits in, right where the
+   floating label crosses the border — reported as the Email field's label looking broken/
+   misaligned on Login/Forgot Password. `transition` with an absurd delay prevents a flash of the
+   browser's native color before ours applies. */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  -webkit-text-fill-color: var(--ink-1);
+  caret-color: var(--ink-1);
+  -webkit-box-shadow: 0 0 0 100px var(--paper) inset;
+  box-shadow: 0 0 0 100px var(--paper) inset;
+  transition: background-color 600000s 0s, color 600000s 0s;
 }
 
 button {

--- a/Client.React/src/pages/PicksPage.tsx
+++ b/Client.React/src/pages/PicksPage.tsx
@@ -61,6 +61,12 @@ export default function PicksPage({ adapter }: PicksPageProps) {
       : adapter.loadCurrentGames(currentLeague!, user!.userId),
     enabled,
     refetchInterval: isCurrentWeek && adapter.pollIntervalMs > 0 ? adapter.pollIntervalMs : false,
+    // refetchOnWindowFocus is disabled globally (main.tsx) for other pages' sake, but the live
+    // current-week query needs it: refetchInterval alone doesn't trigger an immediate fetch on
+    // regaining focus, so without this override the page would wait out the next 5-20min poll
+    // tick after a tab switch away and back (same fix as ScoresPage.tsx). Scoped to the live
+    // week only — a historical week's data can't have changed.
+    refetchOnWindowFocus: () => isCurrentWeek,
     placeholderData: keepPreviousData,
   });
 

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -93,12 +93,21 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
   const { maxWeek: currentMaxWeek, maxSeason: currentMaxSeason, routeToCurrentIfMatches } =
     useCurrentWeekNav(isCurrentWeek, data, setWeekState);
 
-  // Page visibility — pause polling for a hidden tab rather than burn cycles/battery on it.
+  // Page visibility — pause polling for a hidden tab rather than burn cycles/battery on it, and
+  // refetch immediately on regaining visibility. refetchOnWindowFocus is disabled globally
+  // (main.tsx) for other pages' sake, so resuming the refetchInterval gate alone isn't enough —
+  // React Query would just wait for the next 5-20min tick, which is exactly what "switched tabs
+  // away and back, score didn't update" looks like. Only worth it for the live current-week
+  // query; a historical week's data won't have changed while the tab was hidden.
   useEffect(() => {
-    const h = () => setIsPageVisible(!document.hidden);
+    const h = () => {
+      const visible = !document.hidden;
+      setIsPageVisible(visible);
+      if (visible && isCurrentWeek && enabled) void refetch();
+    };
     document.addEventListener('visibilitychange', h);
     return () => document.removeEventListener('visibilitychange', h);
-  }, []);
+  }, [isCurrentWeek, enabled, refetch]);
 
   // SSE — primary update mechanism when on current NFL/CFB week with active games; polling
   // above is the fallback. Reconnects with backoff on drop and immediately on the browser's

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -250,7 +250,7 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
                 one defaulted to unstyled contained (reads as inert navy) and the other used
                 contained secondary (the brand orange reserved for real CTAs like Share). Same
                 matching, neutral treatment for both now. */}
-            {data?.allPicks.length && data.allPicks.length > 0 && (
+            {(data?.allPicks.length ?? 0) > 0 && (
               <Button variant="outlined" color="info" onClick={() => setShowMatrixView(p => !p)}>
                 {showMatrixView ? 'Show Standard View' : 'Show As Matrix'}
               </Button>

--- a/Client.React/src/pages/ScoresPage.tsx
+++ b/Client.React/src/pages/ScoresPage.tsx
@@ -87,27 +87,26 @@ export default function ScoresPage({ adapter }: ScoresPageProps) {
     refetchInterval: query => isCurrentWeek && isPageVisible && adapter.pollIntervalMs > 0
       ? (query.state.data?.hasActiveGames ? adapter.pollIntervalMs : adapter.pollIntervalMs * 4)
       : false,
+    // refetchOnWindowFocus is disabled globally (main.tsx) for other pages' sake, but the live
+    // current-week query needs it: refetchInterval only pauses/resumes background polling — that
+    // alone doesn't trigger an immediate fetch on regaining focus, so without this override the
+    // page just waits out the next 5-20min poll tick after a tab switch away and back. React
+    // Query's own focusManager already listens for `visibilitychange` under the hood, so this
+    // reuses that built-in mechanism (scoped to just this query) instead of hand-rolling a second
+    // listener. Scoped to the live week only — a historical week's data can't have changed.
+    refetchOnWindowFocus: () => isCurrentWeek,
     placeholderData: keepPreviousData,
   });
 
   const { maxWeek: currentMaxWeek, maxSeason: currentMaxSeason, routeToCurrentIfMatches } =
     useCurrentWeekNav(isCurrentWeek, data, setWeekState);
 
-  // Page visibility — pause polling for a hidden tab rather than burn cycles/battery on it, and
-  // refetch immediately on regaining visibility. refetchOnWindowFocus is disabled globally
-  // (main.tsx) for other pages' sake, so resuming the refetchInterval gate alone isn't enough —
-  // React Query would just wait for the next 5-20min tick, which is exactly what "switched tabs
-  // away and back, score didn't update" looks like. Only worth it for the live current-week
-  // query; a historical week's data won't have changed while the tab was hidden.
+  // Page visibility — pause polling for a hidden tab rather than burn cycles/battery on it.
   useEffect(() => {
-    const h = () => {
-      const visible = !document.hidden;
-      setIsPageVisible(visible);
-      if (visible && isCurrentWeek && enabled) void refetch();
-    };
+    const h = () => setIsPageVisible(!document.hidden);
     document.addEventListener('visibilitychange', h);
     return () => document.removeEventListener('visibilitychange', h);
-  }, [isCurrentWeek, enabled, refetch]);
+  }, []);
 
   // SSE — primary update mechanism when on current NFL/CFB week with active games; polling
   // above is the fallback. Reconnects with backoff on drop and immediately on the browser's

--- a/Client.React/src/pages/account/ForgotPasswordPage.tsx
+++ b/Client.React/src/pages/account/ForgotPasswordPage.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { forgotPassword } from '../../api/auth';
 import { useToast } from '../../services/toast';
 import { buildAbsoluteUrl } from '../../utils/url';
+import { extractApiErrorMessage } from '../../utils/apiError';
 
 const schema = z.object({
   email: z.string().email('Invalid email'),
@@ -31,8 +32,11 @@ export default function ForgotPasswordPage() {
         resetUrl: buildAbsoluteUrl('/account/resetpassword'),
       });
       navigate('/account/forgotpasswordconfirmation', { replace: true });
-    } catch {
-      toast.push('Error requesting password reset', 'error');
+    } catch (error) {
+      // The "forgot" rate limiter (Program.cs: 3 attempts/hour per IP, shared with reset-password)
+      // returns a bare 429 — surface that distinctly rather than a generic message that gives a
+      // rate-limited user no indication that retrying immediately won't help.
+      toast.push(extractApiErrorMessage(error, 'Error requesting password reset'), 'error');
     }
   };
 

--- a/Client.React/src/pages/account/ResetPasswordPage.tsx
+++ b/Client.React/src/pages/account/ResetPasswordPage.tsx
@@ -7,6 +7,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { resetPassword } from '../../api/auth';
 import { decodeBase64Url, isValidBase64Url } from '../../utils/base64';
 import { useToast } from '../../services/toast';
+import { extractApiErrorMessage } from '../../utils/apiError';
 
 const schema = z
   .object({
@@ -57,8 +58,11 @@ export default function ResetPasswordPage() {
         token,
       });
       navigate('/account/resetpasswordconfirmation', { replace: true });
-    } catch {
-      toast.push('Error resetting password', 'error');
+    } catch (error) {
+      // Same "forgot" rate limiter as ForgotPasswordPage (Program.cs: 3 attempts/hour per IP,
+      // shared between the two endpoints) — surface a 429 distinctly rather than the generic
+      // message that gives no indication retrying immediately won't help.
+      toast.push(extractApiErrorMessage(error, 'Error resetting password'), 'error');
     }
   };
 


### PR DESCRIPTION
## Summary

Ships #367 (already merged to `dev`, dev deploy verified healthy) to production. Four independent frontend bug fixes:

**1. Scores/Picks not auto-updating after switching tabs away and back**
Both pages pause their background poll while the tab is hidden and resume it when it comes back — but resuming a paused `refetchInterval` doesn't itself trigger a fetch, so the page just waited out the next 5–20 minute poll tick. Re-enabled React Query's built-in `refetchOnWindowFocus` scoped to just each page's own live current-week query.

**2. Stray "0" on the Scores page**
`{data?.allPicks.length && data.allPicks.length > 0 && (<Button/>)}` rendered the literal number `0` next to "Show Only My Picks" when nobody had picked yet (0 is falsy but not boolean, so JSX renders it). Made the check an explicit boolean.

**3. Unhelpful "Error requesting password reset" / "Error resetting password" toasts**
Both pages swallowed every failure into the same generic message, including a 429 from the shared "forgot" rate limiter (3 attempts/hour per IP). Verified against production (Railway logs + Neon) that a real user's forgot-password requests included 4xx responses consistent with this limiter. Wired in the existing `extractApiErrorMessage` helper (already used elsewhere) so a rate-limited user sees "Too many attempts..." instead.

**4. Email field label looking broken/misaligned on Login/Forgot Password**
Safari/Chrome paint their own solid autofill highlight directly onto an `<input>`, which can't be overridden via `background` CSS, only `box-shadow`. Added the standard override in `global.css`, keyed to a new `--paper` var matching the theme.

## Test plan
- [x] TDD: failing test written first for each fix, confirmed red, then fixed
- [x] Full frontend suite: 683 tests passing
- [x] `npm run typecheck` / `npm run lint` clean
- [x] `/simplify` run on fix #1
- [x] Railway dev deploy verified SUCCESS on this exact commit before opening this PR
- [ ] `dotnet test` — not run in this session's container (no .NET SDK available); no backend code changed
- [x] `CHANGELOG.md` entries added under 2026-09-11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzyijJxJE7NEqHxxuD1FX

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmzyijJxJE7NEqHxxuD1FX)_