### PR TITLE
dev → main: league Juice/Start Week lock keyed to league, not season (PR #369)

### DIFF
--- a/Client.React/CHANGELOG.md
+++ b/Client.React/CHANGELOG.md
@@ -4,6 +4,11 @@ Notable changes to IV League, most recent first. For admins — see the version 
 
 Format: `## ` release headings and single-line `- ` bullets only — no bold, links, or multi-line/nested bullets. The admin Changelog page renders this with a small hand-rolled parser (`parseChangelog.ts`), not a full Markdown engine; anything outside this subset renders as literal syntax instead of being formatted. A test guards this file against drifting outside the subset.
 
+## 2026-09-12
+
+- Fixed: a league created after its season had already started got Tease Pts and Start Week permanently locked at whatever the creation form submitted, with no way to ever configure them — the lock now protects a league's own configured Start Week, not always the season's literal week 1, and a new league defaults Start Week to whichever week is currently underway instead of always 1
+- Fixed: changing a league's Start Week on the Juice tab could silently fail to save even when the change was allowed
+
 ## 2026-09-11
 
 - Fixed: the Scores and Picks pages could sit on stale data after switching away from the tab and back — the polling pause for a hidden tab resumed correctly, but nothing forced an immediate refresh, so it just waited out the usual 5-20 minute interval instead of updating right away

--- a/Server.UnitTests/LeagueJuiceScheduleSourceTests.cs
+++ b/Server.UnitTests/LeagueJuiceScheduleSourceTests.cs
@@ -302,6 +302,24 @@ public class LeagueJuiceScheduleSourceTests
         Assert.Equal(new DateTime(2026, 2, 8, 20, 0, 0, DateTimeKind.Utc), lockTime); // 2pm CST = 20:00 UTC
     }
 
+    // frizat: a league created after the season's literal week 1 already locked previously had
+    // Tease Pts/Start Week frozen forever, because this always checked week 1's lock time
+    // regardless of the league's own configured StartWeek. The optional startWeek param lets
+    // callers (LeagueController) check the league's OWN boundary instead — defaults to 1 so
+    // GetCandidatesAsync's scheduler above (which genuinely always means the literal week 1) is
+    // unaffected.
+    [Fact]
+    public void GetSeasonStartLockTimeUtc_UsesGivenStartWeek_NotAlwaysWeek1() {
+        var nflConfigs = new[] {
+            MakeNflWeek(2025, 1, new DateTime(2025, 9, 4, 20, 20, 0, DateTimeKind.Utc)),
+            MakeNflWeek(2025, 3, new DateTime(2025, 9, 18, 20, 20, 0, DateTimeKind.Utc)),
+        };
+
+        var lockTime = LeagueJuiceScheduleSource.GetSeasonStartLockTimeUtc(LeagueType.Nfl, 2025, nflConfigs, [], startWeek: 3);
+
+        Assert.Equal(new DateTime(2025, 9, 18, 19, 0, 0, DateTimeKind.Utc), lockTime); // week 3's lock, not week 1's
+    }
+
     [Fact]
     public void GetSeasonStartLockTimeUtc_Cfb_ResolvesSlate1LockTime() {
         var cfbConfigs = new[] { MakeCfbSlate(2025, 1, new DateOnly(2025, 8, 23)) };

--- a/Server.UnitTests/LeagueOwnershipTests.cs
+++ b/Server.UnitTests/LeagueOwnershipTests.cs
@@ -200,6 +200,14 @@ public class LeagueOwnershipTests
     private static LeagueJuiceScheduleSource BuildScheduleSource(ILeagueRepository repo, ICfbRepository? cfbRepo = null) =>
         new(repo, cfbRepo ?? EmptyCfbRepo(), TimeProvider.System);
 
+    // CreateLeague's Start Week default needs both current-week services — unconfigured
+    // substitutes default IsSeasonActiveAsync() to false (NSubstitute's bool default), so
+    // ResolveInitialStartWeekAsync short-circuits to 1 without ever calling
+    // GetCurrentWeekAsync/GetCurrentSlateAsync, matching every existing CreateLeague test's
+    // implicit expectation (StartWeek = 1) unless a test configures these explicitly.
+    private static (INflCurrentWeekService NflWeek, ICfbCurrentSlateService CfbSlate) StubCurrentWeekServices() =>
+        (Substitute.For<INflCurrentWeekService>(), Substitute.For<ICfbCurrentSlateService>());
+
     [Fact]
     public async Task UpdateJuice_ReturnsForbid_WhenCallerIsNotOwnerOrAdmin()
     {
@@ -292,6 +300,50 @@ public class LeagueOwnershipTests
 
         Assert.IsType<NoContentResult>(result);
         await repo.Received(1).UpdateLeagueJuiceMappingAsync(Arg.Is<LeagueJuiceMapping>(m => m.StartWeek == 3));
+    }
+
+    // A league created after the season's literal week 1 already locked previously had Tease
+    // Pts/Start Week frozen forever — the lock check always compared against week 1, regardless of
+    // what the league's own StartWeek was. Week 3 is in the past (locked) but week 1 for THIS
+    // league is irrelevant: its own configured StartWeek is 3, so the lock boundary must be week
+    // 3's kickoff too, and that's what CreateLeague's new default lets a late-created league use.
+    [Fact]
+    public async Task UpdateJuice_AllowsTeaseAndStartWeekChange_WhenLeagueOwnStartWeekHasNotLockedYet_EvenThoughSeasonWeek1Has()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L", LeagueType = LeagueType.Nfl });
+        // This league's own StartWeek is already 3 (e.g. auto-defaulted at creation, mid-season).
+        repo.GetLeagueJuiceMappingAsync(1, 2025).Returns(new LeagueJuiceMapping { Id = 5, LeagueId = 1, Season = 2025, Juice = 13, JuiceDivisional = 10, JuiceConference = 6, WeeklyCost = 5, StartWeek = 3 });
+        repo.GetNflSeasonWeekConfigsAsync(2025).Returns(new List<NflSeasonWeekConfig> {
+            new() { Season = 2025, WeekId = 1, WeekLabel = "Week 1", WeekType = "Regular Season", ScoringFormat = "Standard",
+                FirstGameOfWeekStartDatetime = new DateTime(2025, 9, 4, 20, 20, 0, DateTimeKind.Utc) }, // in the past
+            new() { Season = 2025, WeekId = 3, WeekLabel = "Week 3", WeekType = "Regular Season", ScoringFormat = "Standard",
+                FirstGameOfWeekStartDatetime = new DateTime(2099, 9, 18, 20, 20, 0, DateTimeKind.Utc) }, // far future
+        });
+
+        var result = await ctrl.UpdateLeagueJuice(1, 2025, new LeagueJuiceUpdateDto(20, 15, 9, 5, StartWeek: 4), BuildScheduleSource(repo));
+
+        Assert.IsType<NoContentResult>(result);
+        await repo.Received(1).UpdateLeagueJuiceMappingAsync(Arg.Is<LeagueJuiceMapping>(m => m.Juice == 20 && m.StartWeek == 4));
+    }
+
+    // Mirror of the test above, at the opposite boundary: once the league's OWN StartWeek (3, not
+    // week 1) has itself started, tease points/Start Week lock exactly like they always have.
+    [Fact]
+    public async Task UpdateJuice_RejectsTeaseChange_OnceLeagueOwnStartWeekHasStarted()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.GetLeagueInfoAsync(1).Returns(new LeagueInfo { Id = 1, OwnerUserId = OwnerId, LeagueName = "L", LeagueType = LeagueType.Nfl });
+        repo.GetLeagueJuiceMappingAsync(1, 2025).Returns(new LeagueJuiceMapping { Id = 5, LeagueId = 1, Season = 2025, Juice = 13, JuiceDivisional = 10, JuiceConference = 6, WeeklyCost = 5, StartWeek = 3 });
+        repo.GetNflSeasonWeekConfigsAsync(2025).Returns(new List<NflSeasonWeekConfig> {
+            new() { Season = 2025, WeekId = 3, WeekLabel = "Week 3", WeekType = "Regular Season", ScoringFormat = "Standard",
+                FirstGameOfWeekStartDatetime = new DateTime(2025, 9, 18, 20, 20, 0, DateTimeKind.Utc) }, // in the past
+        });
+
+        var result = await ctrl.UpdateLeagueJuice(1, 2025, new LeagueJuiceUpdateDto(14, 10, 6, 5, StartWeek: 3), BuildScheduleSource(repo));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        await repo.DidNotReceive().UpdateLeagueJuiceMappingAsync(Arg.Any<LeagueJuiceMapping>());
     }
 
     [Theory]
@@ -714,12 +766,105 @@ public class LeagueOwnershipTests
         repo.AddLeagueInfoAsync(Arg.Any<LeagueInfo>()).Returns(Task.FromResult(createdLeague));
 
         var dto = new LeagueCreateDto("My League", LeagueType.Nfl, OwnerId, 2025, 13, 10, 6, 5);
-        var result = await ctrl.CreateLeague(dto) as OkObjectResult;
+        var (nflWeekSvc, cfbSlateSvc) = StubCurrentWeekServices();
+        var result = await ctrl.CreateLeague(dto, nflWeekSvc, cfbSlateSvc) as OkObjectResult;
 
         Assert.NotNull(result);
         await repo.Received(1).AddLeagueInfoAsync(Arg.Is<LeagueInfo>(l => l.LeagueName == "My League" && l.OwnerUserId == OwnerId));
         await repo.Received(1).AddLeagueJuiceMappingAsync(Arg.Is<LeagueJuiceMapping>(m => m.Season == 2025 && m.Juice == 13));
         await repo.Received(1).AddLeagueUserMappingAsync(Arg.Is<LeagueUserMapping>(m => m.UserId == OwnerId));
+    }
+
+    // ── CreateLeague's Start Week default (fix for a league created mid-season getting Tease
+    // Pts/Start Week frozen forever at the wrong value — see LeagueController.ResolveInitialStartWeekAsync) ──
+
+    [Fact]
+    public async Task CreateLeague_DefaultsStartWeekToCurrentNflWeek_WhenSeasonAlreadyActive()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.LeagueExistsAsync(Arg.Any<string>()).Returns(false);
+        repo.AddLeagueInfoAsync(Arg.Any<LeagueInfo>()).Returns(Task.FromResult(new LeagueInfo { Id = 42, LeagueName = "L", OwnerUserId = OwnerId, LeagueType = LeagueType.Nfl }));
+        var nflWeekSvc = Substitute.For<INflCurrentWeekService>();
+        nflWeekSvc.IsSeasonActiveAsync().Returns(true);
+        nflWeekSvc.GetCurrentWeekAsync().Returns(new NflWeekInfo(3, 2025, false, "Week 3", "Standard", DateTime.UtcNow));
+
+        var dto = new LeagueCreateDto("L", LeagueType.Nfl, OwnerId, 2025, 13, 10, 6, 5);
+        var result = await ctrl.CreateLeague(dto, nflWeekSvc, Substitute.For<ICfbCurrentSlateService>());
+
+        Assert.IsType<OkObjectResult>(result);
+        await repo.Received(1).AddLeagueJuiceMappingAsync(Arg.Is<LeagueJuiceMapping>(m => m.StartWeek == 3));
+    }
+
+    [Fact]
+    public async Task CreateLeague_DefaultsStartWeekToCurrentCfbSlate_WhenSeasonAlreadyActive()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        ctrl.ControllerContext.HttpContext.Request.Headers.Origin = "https://cfb.ivleague.xyz";
+        repo.LeagueExistsAsync(Arg.Any<string>()).Returns(false);
+        repo.AddLeagueInfoAsync(Arg.Any<LeagueInfo>()).Returns(Task.FromResult(new LeagueInfo { Id = 42, LeagueName = "L", OwnerUserId = OwnerId, LeagueType = LeagueType.Cfb }));
+        var cfbSlateSvc = Substitute.For<ICfbCurrentSlateService>();
+        cfbSlateSvc.IsSeasonActiveAsync().Returns(true);
+        cfbSlateSvc.GetCurrentSlateAsync().Returns(new CfbSlateInfo(1, 2025, 4, "Slate 4", "Regular Season",
+            new DateOnly(2025, 9, 20), new DateOnly(2025, 9, 26), null, new DateTime(2025, 9, 20, 12, 0, 0, DateTimeKind.Utc)));
+
+        var dto = new LeagueCreateDto("L", LeagueType.Cfb, OwnerId, 2025, 13, 10, 6, 5);
+        var result = await ctrl.CreateLeague(dto, Substitute.For<INflCurrentWeekService>(), cfbSlateSvc);
+
+        Assert.IsType<OkObjectResult>(result);
+        await repo.Received(1).AddLeagueJuiceMappingAsync(Arg.Is<LeagueJuiceMapping>(m => m.StartWeek == 4));
+    }
+
+    [Fact]
+    public async Task CreateLeague_DefaultsStartWeekToOne_WhenSeasonNotActive()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.LeagueExistsAsync(Arg.Any<string>()).Returns(false);
+        repo.AddLeagueInfoAsync(Arg.Any<LeagueInfo>()).Returns(Task.FromResult(new LeagueInfo { Id = 42, LeagueName = "L", OwnerUserId = OwnerId, LeagueType = LeagueType.Nfl }));
+        var nflWeekSvc = Substitute.For<INflCurrentWeekService>();
+        nflWeekSvc.IsSeasonActiveAsync().Returns(false); // off-season — created ahead of the season
+
+        var dto = new LeagueCreateDto("L", LeagueType.Nfl, OwnerId, 2025, 13, 10, 6, 5);
+        var result = await ctrl.CreateLeague(dto, nflWeekSvc, Substitute.For<ICfbCurrentSlateService>());
+
+        Assert.IsType<OkObjectResult>(result);
+        await repo.Received(1).AddLeagueJuiceMappingAsync(Arg.Is<LeagueJuiceMapping>(m => m.StartWeek == 1));
+        // Never even asked for the current week — IsSeasonActiveAsync's false already settled it.
+        await nflWeekSvc.DidNotReceive().GetCurrentWeekAsync();
+    }
+
+    [Fact]
+    public async Task CreateLeague_DefaultsStartWeekToOne_WhenCurrentWeekBelongsToADifferentSeason()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.LeagueExistsAsync(Arg.Any<string>()).Returns(false);
+        repo.AddLeagueInfoAsync(Arg.Any<LeagueInfo>()).Returns(Task.FromResult(new LeagueInfo { Id = 42, LeagueName = "L", OwnerUserId = OwnerId, LeagueType = LeagueType.Nfl }));
+        var nflWeekSvc = Substitute.For<INflCurrentWeekService>();
+        nflWeekSvc.IsSeasonActiveAsync().Returns(true);
+        // "Now" resolves to 2024's season, but this league is explicitly being created for 2025.
+        nflWeekSvc.GetCurrentWeekAsync().Returns(new NflWeekInfo(18, 2024, false, "Week 18", "Standard", DateTime.UtcNow));
+
+        var dto = new LeagueCreateDto("L", LeagueType.Nfl, OwnerId, 2025, 13, 10, 6, 5);
+        var result = await ctrl.CreateLeague(dto, nflWeekSvc, Substitute.For<ICfbCurrentSlateService>());
+
+        Assert.IsType<OkObjectResult>(result);
+        await repo.Received(1).AddLeagueJuiceMappingAsync(Arg.Is<LeagueJuiceMapping>(m => m.StartWeek == 1));
+    }
+
+    [Fact]
+    public async Task CreateLeague_ClampsStartWeekDefaultToFive_WhenCreatedDeepIntoTheSeason()
+    {
+        var (ctrl, repo) = BuildControllerWithRepo(BuildPrincipal(OwnerId));
+        repo.LeagueExistsAsync(Arg.Any<string>()).Returns(false);
+        repo.AddLeagueInfoAsync(Arg.Any<LeagueInfo>()).Returns(Task.FromResult(new LeagueInfo { Id = 42, LeagueName = "L", OwnerUserId = OwnerId, LeagueType = LeagueType.Nfl }));
+        var nflWeekSvc = Substitute.For<INflCurrentWeekService>();
+        nflWeekSvc.IsSeasonActiveAsync().Returns(true);
+        nflWeekSvc.GetCurrentWeekAsync().Returns(new NflWeekInfo(9, 2025, false, "Week 9", "Standard", DateTime.UtcNow));
+
+        var dto = new LeagueCreateDto("L", LeagueType.Nfl, OwnerId, 2025, 13, 10, 6, 5);
+        var result = await ctrl.CreateLeague(dto, nflWeekSvc, Substitute.For<ICfbCurrentSlateService>());
+
+        Assert.IsType<OkObjectResult>(result);
+        await repo.Received(1).AddLeagueJuiceMappingAsync(Arg.Is<LeagueJuiceMapping>(m => m.StartWeek == 5));
     }
 
     // frizat-d6l: self-serve league creation — any authenticated user may create a league now,
@@ -736,7 +881,8 @@ public class LeagueOwnershipTests
 
         // AttackerId is spoofed as the owner in the request body — caller is OwnerId, not admin.
         var dto = new LeagueCreateDto("My League", LeagueType.Nfl, AttackerId, 2025, 0, 0, 0, 0);
-        var result = await ctrl.CreateLeague(dto) as OkObjectResult;
+        var (nflWeekSvc, cfbSlateSvc) = StubCurrentWeekServices();
+        var result = await ctrl.CreateLeague(dto, nflWeekSvc, cfbSlateSvc) as OkObjectResult;
 
         Assert.NotNull(result);
         await repo.Received(1).AddLeagueInfoAsync(Arg.Is<LeagueInfo>(l => l.OwnerUserId == OwnerId));
@@ -772,7 +918,8 @@ public class LeagueOwnershipTests
         repo.LeagueExistsAsync(Arg.Any<string>()).Returns(false);
 
         var dto = new LeagueCreateDto("My League", LeagueType.Nfl, OwnerId, 2025, 0, 0, 0, 0);
-        var result = await ctrl.CreateLeague(dto);
+        var (nflWeekSvc, cfbSlateSvc) = StubCurrentWeekServices();
+        var result = await ctrl.CreateLeague(dto, nflWeekSvc, cfbSlateSvc);
 
         Assert.IsType<BadRequestObjectResult>(result);
         await repo.DidNotReceive().AddLeagueInfoAsync(Arg.Any<LeagueInfo>());
@@ -788,7 +935,8 @@ public class LeagueOwnershipTests
         repo.AddLeagueInfoAsync(Arg.Any<LeagueInfo>()).Returns(Task.FromResult(createdLeague));
 
         var dto = new LeagueCreateDto("My League", LeagueType.Cfb, OwnerId, 2025, 0, 0, 0, 0);
-        var result = await ctrl.CreateLeague(dto);
+        var (nflWeekSvc, cfbSlateSvc) = StubCurrentWeekServices();
+        var result = await ctrl.CreateLeague(dto, nflWeekSvc, cfbSlateSvc);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -803,7 +951,8 @@ public class LeagueOwnershipTests
         repo.LeagueExistsAsync(Arg.Any<string>()).Returns(false);
 
         var dto = new LeagueCreateDto("My League", LeagueType.Nfl, OwnerId, 2025, 0, 0, 0, 0);
-        var result = await ctrl.CreateLeague(dto);
+        var (nflWeekSvc, cfbSlateSvc) = StubCurrentWeekServices();
+        var result = await ctrl.CreateLeague(dto, nflWeekSvc, cfbSlateSvc);
 
         Assert.IsType<BadRequestObjectResult>(result);
     }
@@ -818,7 +967,8 @@ public class LeagueOwnershipTests
         repo.LeagueExistsAsync(Arg.Any<string>()).Returns(false);
 
         var dto = new LeagueCreateDto("My League", LeagueType.Nfl, OwnerId, 2025, 0, 0, 0, 0);
-        var result = await ctrl.CreateLeague(dto);
+        var (nflWeekSvc, cfbSlateSvc) = StubCurrentWeekServices();
+        var result = await ctrl.CreateLeague(dto, nflWeekSvc, cfbSlateSvc);
 
         Assert.IsType<BadRequestObjectResult>(result);
     }
@@ -1248,7 +1398,8 @@ public class LeagueOwnershipTests
         repo.LeagueExistsAsync(Arg.Any<string>()).Returns(true);
 
         var dto = new LeagueCreateDto("Existing League", LeagueType.Nfl, OwnerId, 2025, 13, 10, 6, 5);
-        var result = await ctrl.CreateLeague(dto);
+        var (nflWeekSvc, cfbSlateSvc) = StubCurrentWeekServices();
+        var result = await ctrl.CreateLeague(dto, nflWeekSvc, cfbSlateSvc);
 
         Assert.IsType<ConflictObjectResult>(result);
     }

--- a/Server.UnitTests/LeagueRepositoryTests.cs
+++ b/Server.UnitTests/LeagueRepositoryTests.cs
@@ -449,6 +449,27 @@ public class LeagueRepositoryTests
         Assert.NotNull(mapping.UpdatedAt);
     }
 
+    // StartWeek shipped (frizat-o3x) alongside Juice/JuiceDivisional/JuiceConference/WeeklyCost,
+    // but this method never copied it onto the entity it actually saves — LeagueController.
+    // UpdateLeagueJuice would return 204 (success) while the Start Week change silently reverted,
+    // since this method re-fetches its own tracked entity from a fresh DbContext and only copies
+    // specific properties across.
+    [Fact]
+    public async Task UpdateLeagueJuiceMappingAsync_PersistsStartWeek()
+    {
+        var factory = new DbContextFactoryStub(nameof(UpdateLeagueJuiceMappingAsync_PersistsStartWeek));
+        var seedDb = factory.CreateDbContext();
+        seedDb.LeagueJuiceMapping.Add(new LeagueJuiceMapping { Id = 1, LeagueId = 1, Season = 2025, Juice = 13, StartWeek = 1 });
+        await seedDb.SaveChangesAsync();
+
+        var repo = new LeagueRepository(factory);
+        await repo.UpdateLeagueJuiceMappingAsync(new LeagueJuiceMapping { Id = 1, LeagueId = 1, Season = 2025, Juice = 13, StartWeek = 3 });
+
+        var db = factory.CreateDbContext();
+        var mapping = await db.LeagueJuiceMapping.SingleAsync(m => m.Id == 1);
+        Assert.Equal(3, mapping.StartWeek);
+    }
+
     // /code-review: the controller's real call shape (LeagueController.UpdateLeagueJuice) always
     // passes a mapping fetched via GetLeagueJuiceMappingAsync, which .Include()s the League
     // navigation — so `mapping.League` is a populated, detached LeagueInfo snapshot from whenever

--- a/Server/Controllers/LeagueController.cs
+++ b/Server/Controllers/LeagueController.cs
@@ -118,10 +118,10 @@ public class LeagueController(
     // GetJuiceLockStateAsync instance method GetLeagueJuiceForSeason/UpdateLeagueJuice use —
     // those look up exactly one season, so a per-season DB round trip there is the cheaper
     // fetch; here, fetching per-row instead of once would be N round trips for N seasons).
-    private static (bool TeaseLocked, bool WeeklyCostLocked) GetJuiceLockState(LeagueType leagueType, int season,
+    private static (bool TeaseLocked, bool WeeklyCostLocked) GetJuiceLockState(LeagueType leagueType, int season, int startWeek,
         IEnumerable<NflSeasonWeekConfig> nflConfigs, IEnumerable<CfbSeasonWeekConfig> cfbConfigs) {
         var now = DateTimeOffset.UtcNow.UtcDateTime;
-        var teaseLockTime = LeagueJuiceScheduleSource.GetSeasonStartLockTimeUtc(leagueType, season, nflConfigs, cfbConfigs);
+        var teaseLockTime = LeagueJuiceScheduleSource.GetSeasonStartLockTimeUtc(leagueType, season, nflConfigs, cfbConfigs, startWeek);
         var weeklyCostLockTime = LeagueJuiceScheduleSource.GetSeasonEndLockTimeUtc(leagueType, season, nflConfigs, cfbConfigs);
         return (teaseLockTime is not null && now >= teaseLockTime, weeklyCostLockTime is not null && now >= weeklyCostLockTime);
     }
@@ -143,7 +143,7 @@ public class LeagueController(
         var cfbConfigs = leagueType == LeagueType.Cfb ? await cfbRepo.GetAllWeekConfigsAsync() : [];
 
         var dtoMappings = mappings.Select(m => {
-            var (teaseLocked, weeklyCostLocked) = GetJuiceLockState(leagueType, m.Season, nflConfigs, cfbConfigs);
+            var (teaseLocked, weeklyCostLocked) = GetJuiceLockState(leagueType, m.Season, m.StartWeek, nflConfigs, cfbConfigs);
             return new LeagueJuiceMappingDto {
                 LeagueId = m.LeagueId,
                 LeagueName = m.League.LeagueName,
@@ -171,7 +171,7 @@ public class LeagueController(
         var mapping = await repo.GetLeagueJuiceMappingAsync(leagueId, season);
         if (mapping == null) return Ok(null);
 
-        var (teaseLocked, weeklyCostLocked) = await scheduleSource.GetJuiceLockStateAsync(mapping.League.LeagueType, season);
+        var (teaseLocked, weeklyCostLocked) = await scheduleSource.GetJuiceLockStateAsync(mapping.League.LeagueType, season, mapping.StartWeek);
 
         var dtoMapping = new LeagueJuiceMappingDto {
             LeagueId = mapping.LeagueId,
@@ -694,7 +694,8 @@ public class LeagueController(
     [HttpPost("create")]
     [ProducesResponseType(typeof(LeagueInfoDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
-    public async Task<IActionResult> CreateLeague([FromBody] LeagueCreateDto dto) {
+    public async Task<IActionResult> CreateLeague([FromBody] LeagueCreateDto dto,
+            [FromServices] INflCurrentWeekService nflWeekService, [FromServices] ICfbCurrentSlateService cfbSlateService) {
         // Mirrors useSportContext's own host-prefix check (Client.React/src/services/sport.tsx) —
         // the frontend locks the Sport field to the current subdomain, but a crafted/replayed
         // request could still send a mismatched LeagueType directly without this backstop.
@@ -725,6 +726,7 @@ public class LeagueController(
             JuiceDivisional = dto.JuiceDivisional,
             JuiceConference = dto.JuiceConference,
             WeeklyCost = dto.WeeklyCost,
+            StartWeek = await ResolveInitialStartWeekAsync(dto.LeagueType, dto.Season, nflWeekService, cfbSlateService),
             DateCreated = DateTimeOffset.UtcNow,
         });
         await repo.AddLeagueUserMappingAsync(new LeagueUserMapping {
@@ -733,6 +735,27 @@ public class LeagueController(
             DateCreated = DateTimeOffset.UtcNow,
         });
         return Ok(new LeagueInfoDto { Id = league.Id, LeagueName = league.LeagueName, LeagueType = league.LeagueType, OwnerUserId = league.OwnerUserId, DateCreated = league.DateCreated });
+    }
+
+    // A league created after its own sport's season has already started defaults its Start Week
+    // to whatever week/slate is happening right now, instead of always defaulting to 1 (full
+    // season) — a commissioner setting up a pool mid-season shouldn't be stuck requiring picks for
+    // weeks that were already played before their league existed. Falls back to 1 when the season
+    // isn't active (preseason or off-season) or the currently-active week belongs to a different
+    // season than the one being created for — both cases where 1 is already correct and nothing
+    // needs excluding. Clamped to 5 (Juice's own StartWeek range) rather than rejecting creation
+    // outright for a league started deep into the season — best effort, matching the existing
+    // 1-5 validation in UpdateLeagueJuice.
+    private static async Task<int> ResolveInitialStartWeekAsync(LeagueType leagueType, int season,
+            INflCurrentWeekService nflWeekService, ICfbCurrentSlateService cfbSlateService) {
+        if (leagueType == LeagueType.Cfb) {
+            if (!await cfbSlateService.IsSeasonActiveAsync()) return 1;
+            var slate = await cfbSlateService.GetCurrentSlateAsync();
+            return slate is not null && slate.Season == season ? Math.Clamp(slate.SlateNumber, 1, 5) : 1;
+        }
+        if (!await nflWeekService.IsSeasonActiveAsync()) return 1;
+        var week = await nflWeekService.GetCurrentWeekAsync();
+        return week.Season == season ? Math.Clamp(week.WeekId, 1, 5) : 1;
     }
 
     // Prefers Origin (sent on every state-changing fetch, including same-origin ones — see
@@ -836,14 +859,17 @@ public class LeagueController(
         var (league, error) = await LoadOwnedLeagueAsync(leagueId);
         if (error is not null) return error;
 
-        // Independent of each other — kick both off before awaiting instead of paying for two
-        // sequential round trips.
-        var existingTask = repo.GetLeagueJuiceMappingAsync(leagueId, season);
-        var lockStateTask = scheduleSource.GetJuiceLockStateAsync(league!.LeagueType, season);
-        await Task.WhenAll(existingTask, lockStateTask);
-        var existing = existingTask.Result;
+        var existing = await repo.GetLeagueJuiceMappingAsync(leagueId, season);
         if (existing is null) return NotFound($"No juice mapping for league {leagueId} season {season}.");
-        var (teaseLocked, weeklyCostLocked) = lockStateTask.Result;
+        // Lock boundary is the mapping's OWN currently-configured StartWeek, not always week/slate
+        // 1 — see LeagueJuiceScheduleSource.GetSeasonStartLockTimeUtc's comment. A league created
+        // after the season's literal week 1 already locked previously had Tease Pts/Start Week
+        // frozen forever at whatever the create-league form happened to submit; this lets
+        // CreateLeague's own Start Week default (computed from the current week/slate at creation
+        // time) actually stay editable until ITS OWN kickoff, not the season's. Needs `existing`
+        // first, so this can no longer run in parallel with the fetch above — an acceptable cost
+        // for a settings-save endpoint, not a hot path.
+        var (teaseLocked, weeklyCostLocked) = await scheduleSource.GetJuiceLockStateAsync(league!.LeagueType, season, existing.StartWeek);
 
         if (dto.StartWeek is < 1 or > 5)
             return BadRequest("Start Week must be between 1 and 5.");

--- a/Server/Jobs/LeagueJuiceScheduleSource.cs
+++ b/Server/Jobs/LeagueJuiceScheduleSource.cs
@@ -95,13 +95,14 @@ public class LeagueJuiceScheduleSource(ILeagueRepository leagueRepo, ICfbReposit
     // frizat: LeagueController.UpdateLeagueJuice/GetLeagueJuiceForSeason's single-season lock
     // check — season-scoped repo calls (not GetCandidatesAsync's own full-table fetch above,
     // which genuinely needs every season at once for the batch scheduler) so a single request
-    // only pulls the 1-2 config rows it actually needs.
-    public async Task<(bool TeaseLocked, bool WeeklyCostLocked)> GetJuiceLockStateAsync(LeagueType leagueType, int season) {
+    // only pulls the 1-2 config rows it actually needs. `startWeek` must be the mapping's own
+    // current StartWeek (not always 1) — see GetSeasonStartLockTimeUtc's comment.
+    public async Task<(bool TeaseLocked, bool WeeklyCostLocked)> GetJuiceLockStateAsync(LeagueType leagueType, int season, int startWeek) {
         var now = timeProvider.GetUtcNow().UtcDateTime;
         IEnumerable<NflSeasonWeekConfig> nflConfigs = leagueType == LeagueType.Cfb ? [] : await leagueRepo.GetNflSeasonWeekConfigsAsync(season);
         IEnumerable<CfbSeasonWeekConfig> cfbConfigs = leagueType == LeagueType.Cfb ? await cfbRepo.GetWeekConfigsForSeasonAsync(season) : [];
 
-        var teaseLockTime = GetSeasonStartLockTimeUtc(leagueType, season, nflConfigs, cfbConfigs);
+        var teaseLockTime = GetSeasonStartLockTimeUtc(leagueType, season, nflConfigs, cfbConfigs, startWeek);
         var weeklyCostLockTime = GetSeasonEndLockTimeUtc(leagueType, season, nflConfigs, cfbConfigs);
         return (teaseLockTime is not null && now >= teaseLockTime, weeklyCostLockTime is not null && now >= weeklyCostLockTime);
     }
@@ -125,10 +126,19 @@ public class LeagueJuiceScheduleSource(ILeagueRepository leagueRepo, ICfbReposit
         return week is null ? null : LockTimeUtc(DateOnly.FromDateTime(week.FirstGameOfWeekStartDatetime!.Value));
     }
 
-    // Tease points (Juice/JuiceDivisional/JuiceConference) lock here — week/slate 1's own start.
+    // Tease points (Juice/JuiceDivisional/JuiceConference) AND Start Week lock together, here —
+    // at the league's OWN currently-configured Start Week's own kickoff, not always week/slate 1.
+    // `startWeek` defaults to 1 for GetCandidatesAsync above (the Juice Reminder/Lock scheduler
+    // genuinely always means the season's literal week 1 — it exists to auto-fill a league that
+    // never configured Juice at all before the season proper begins). LeagueController's editable-
+    // or-not checks pass the mapping's actual StartWeek instead: a league created after the
+    // season's week 1 already locked previously had Tease Pts/Start Week frozen at whatever the
+    // create-league form happened to submit, forever, with no way to ever configure them — this
+    // parameterization is what lets CreateLeague's own Start Week default (see LeagueController)
+    // — and any further edits before that week's own kickoff — actually take effect.
     public static DateTime? GetSeasonStartLockTimeUtc(LeagueType leagueType, int season,
-        IEnumerable<NflSeasonWeekConfig> nflConfigs, IEnumerable<CfbSeasonWeekConfig> cfbConfigs) =>
-        GetWeekLockTimeUtc(leagueType, season, 1, nflConfigs, cfbConfigs);
+        IEnumerable<NflSeasonWeekConfig> nflConfigs, IEnumerable<CfbSeasonWeekConfig> cfbConfigs, int startWeek = 1) =>
+        GetWeekLockTimeUtc(leagueType, season, startWeek, nflConfigs, cfbConfigs);
 
     // WeeklyCost locks here — the season's final week (NFL WeekId 22 Super Bowl) or slate (CFB
     // slate 18 Championship), per CLAUDE.md's pick-count tables (/pick-rules).

--- a/Server/Services/Repositories/LeagueRepository.cs
+++ b/Server/Services/Repositories/LeagueRepository.cs
@@ -285,6 +285,7 @@ public class LeagueRepository(IDbContextFactory<ApplicationDbContext> dbContextF
         existing.JuiceDivisional = mapping.JuiceDivisional;
         existing.JuiceConference = mapping.JuiceConference;
         existing.WeeklyCost = mapping.WeeklyCost;
+        existing.StartWeek = mapping.StartWeek;
         existing.UpdatedAt = DateTimeOffset.UtcNow;
         await db.SaveChangesAsync();
     }


### PR DESCRIPTION
## Summary

Ships #369 (already merged to `dev`, dev deploy verified healthy) to production. Fixes a real production issue: a CFB commissioner's new league had Tease Pts and Start Week permanently locked because they created it after the season had already started.

**Bug #1 (the reported issue):** Tease Pts (Juice/JuiceDivisional/JuiceConference) and Start Week locked based on whether the *season's* literal week/slate 1 had started — never whether *this league* had ever had a chance to configure them. Any league created after the season begins got these fields frozen forever at whatever the create-league form happened to submit.
- `LeagueJuiceScheduleSource.GetSeasonStartLockTimeUtc`/`GetJuiceLockStateAsync` now take the mapping's own `StartWeek` instead of hardcoding week 1. The lock now follows wherever a league's own Start Week currently points.
- `CreateLeague` now defaults Start Week to whatever week/slate is currently underway (clamped to 1-5) when created after the season has started, instead of always defaulting to 1.

**Bug #2 (found while tracing #1):** `LeagueRepository.UpdateLeagueJuiceMappingAsync` never copied `StartWeek` onto the entity it actually persists — an allowed Start Week change could return `204 No Content` while silently not saving.

## Test plan
- [x] TDD: failing tests written first, confirmed red, then fixed
- [x] Backend suite: 950/950 passing (verified in CI — this session had no local .NET SDK access)
- [x] CI green on PR #369
- [x] Railway dev deploy verified SUCCESS on this exact commit before opening this PR
- [x] `CHANGELOG.md` entry added under 2026-09-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzyijJxJE7NEqHxxuD1FX

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmzyijJxJE7NEqHxxuD1FX)_